### PR TITLE
feat(agent): structured sub-agent I/O + per-agent Team event tagging (1033 close)

### DIFF
--- a/agent/agent_source.go
+++ b/agent/agent_source.go
@@ -57,6 +57,14 @@ type AgentSourceConfig struct {
 	// every AgentSource in a tree to the same sink and the scope/depth
 	// disambiguate nested runs.
 	OnEvent func(SubAgentEvent)
+
+	// InputSchema, when set, replaces the default {task} schema the tool
+	// advertises, so a parent delegates a TYPED subtask. The child is seeded
+	// with the raw arguments JSON as its user turn (the schema shapes what the
+	// parent model must pass; the child reads it as its instruction). Nil keeps
+	// the {task: string} shape. Structured OUTPUT is orthogonal: build the child
+	// Runner with a ResponseSchema and Call returns its coerced JSON.
+	InputSchema json.RawMessage
 }
 
 // SubAgentEvent is the envelope that carries a sub-agent's event to the
@@ -89,8 +97,12 @@ func NewAgentSource(cfg AgentSourceConfig) (*AgentSource, error) {
 	if cfg.Runner == nil {
 		return nil, fmt.Errorf("agent: AgentSource %q requires a Runner", cfg.Name)
 	}
+	schemaJSON := cfg.InputSchema
+	if schemaJSON == nil {
+		schemaJSON = core.GenerateSchema[agentTaskArgs]()
+	}
 	var schema any
-	if err := json.Unmarshal(core.GenerateSchema[agentTaskArgs](), &schema); err != nil {
+	if err := json.Unmarshal(schemaJSON, &schema); err != nil {
 		return nil, fmt.Errorf("agent: schema for AgentSource %q: %w", cfg.Name, err)
 	}
 	maxDepth := cfg.MaxDepth
@@ -134,9 +146,15 @@ func (s *AgentSource) Call(ctx context.Context, name string, args map[string]any
 	if err != nil {
 		return nil, fmt.Errorf("agent: encode args for sub-agent %q: %w", s.cfg.Name, err)
 	}
-	var in agentTaskArgs
-	if err := json.Unmarshal(raw, &in); err != nil || strings.TrimSpace(in.Task) == "" {
-		return errorToolResult(fmt.Sprintf("sub-agent %q requires a non-empty 'task'", s.cfg.Name)), nil
+	// seed is the child's user turn: the raw typed arguments when InputSchema is
+	// set (a typed subtask), else the required {task} string.
+	seed := string(raw)
+	if s.cfg.InputSchema == nil {
+		var in agentTaskArgs
+		if err := json.Unmarshal(raw, &in); err != nil || strings.TrimSpace(in.Task) == "" {
+			return errorToolResult(fmt.Sprintf("sub-agent %q requires a non-empty 'task'", s.cfg.Name)), nil
+		}
+		seed = in.Task
 	}
 
 	// Extend both ctx threads for the child: depth (guards) and scope (the
@@ -152,11 +170,17 @@ func (s *AgentSource) Call(ctx context.Context, name string, args map[string]any
 		childDepth := depth + 1
 		emit = func(e Event) { s.cfg.OnEvent(SubAgentEvent{Scope: childScope, Depth: childDepth, Event: e}) }
 	}
-	result, err := s.cfg.Runner.Run(childCtx, []Message{{Role: RoleUser, Text: in.Task}}, emit)
+	result, err := s.cfg.Runner.Run(childCtx, []Message{{Role: RoleUser, Text: seed}}, emit)
 	if err != nil {
 		return errorToolResult(fmt.Sprintf("sub-agent %q failed: %v", s.cfg.Name, err)), nil
 	}
-	return &core.ToolResult{Content: []core.Content{{Type: "text", Text: result.Text}}}, nil
+	// Structured output when the child ran with a ResponseSchema (its coerced
+	// JSON), else the final text — so a parent gets typed output back.
+	out := result.Text
+	if result.Structured.Len() > 0 {
+		out = string(result.Structured.Raw())
+	}
+	return &core.ToolResult{Content: []core.Content{{Type: "text", Text: out}}}, nil
 }
 
 type agentDepthKey struct{}

--- a/agent/agent_source_test.go
+++ b/agent/agent_source_test.go
@@ -202,3 +202,59 @@ func TestAgentSource_MissingTaskAndValidation(t *testing.T) {
 		t.Fatal("missing Name should error")
 	}
 }
+
+// TestAgentSource_TypedInput covers structured input (1033): with an InputSchema
+// set, the tool advertises that schema and the child is seeded with the raw
+// typed arguments JSON as its user turn, not the {task} string.
+func TestAgentSource_TypedInput(t *testing.T) {
+	ctx := context.Background()
+	childStub := NewStubProvider(StubTurn{Text: "done"})
+	child, _ := NewRunner(RunnerConfig{Provider: childStub})
+	schema := json.RawMessage(`{"type":"object","properties":{"topic":{"type":"string"},"depth":{"type":"integer"}},"required":["topic"]}`)
+	as, err := NewAgentSource(AgentSourceConfig{
+		Name: "researcher", Description: "typed research", Runner: child, InputSchema: schema,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// the tool advertises the caller-provided schema, not {task}
+	defs, _ := as.Tools(ctx)
+	sj, _ := json.Marshal(defs[0].InputSchema)
+	if !strings.Contains(string(sj), "topic") || strings.Contains(string(sj), "task") {
+		t.Fatalf("tool schema should be the typed input, got %s", sj)
+	}
+
+	if _, err := as.Call(ctx, "researcher", map[string]any{"topic": "caching", "depth": 3}); err != nil {
+		t.Fatal(err)
+	}
+	// the child's user turn is the raw typed args (a typed subtask), not a plucked task string
+	seed := childStub.Requests()[0].Messages[0].Text
+	if !strings.Contains(seed, "caching") || !strings.Contains(seed, "depth") {
+		t.Fatalf("child seed should carry the typed args, got %q", seed)
+	}
+}
+
+// TestAgentSource_StructuredOutput covers structured output (1033): a child whose
+// Runner has a ResponseSchema returns its coerced JSON from Call, not the text.
+func TestAgentSource_StructuredOutput(t *testing.T) {
+	ctx := context.Background()
+	schema := core.NewRawJSON(json.RawMessage(`{"type":"object","properties":{"score":{"type":"integer"}},"required":["score"]}`))
+	childStub := NewStubProvider(
+		StubTurn{Text: "the score is 7"}, // terminal text
+		StubTurn{Text: `{"score":7}`},    // finalizing coercion
+	)
+	child, err := NewRunner(RunnerConfig{Provider: childStub, ResponseSchema: schema})
+	if err != nil {
+		t.Fatal(err)
+	}
+	as, _ := NewAgentSource(AgentSourceConfig{Name: "scorer", Description: "scores", Runner: child})
+
+	res, err := as.Call(ctx, "scorer", map[string]any{"task": "score this"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := res.Content[0].Text; got != `{"score":7}` {
+		t.Fatalf("structured output should be the coerced JSON, got %q", got)
+	}
+}

--- a/agent/host/app.go
+++ b/agent/host/app.go
@@ -33,6 +33,13 @@ type App struct {
 	team            *agent.Team
 	activeTeamAgent string
 
+	// teamEventSink is the per-turn persistence tap for team member events: the
+	// Team forwards them tagged (HostSubAgentEvent renders the attribution),
+	// while this buffers the flat Event into the turn's PersistingEmit so the
+	// event log is unchanged. Set under turnMu for the duration of a team turn,
+	// nil otherwise.
+	teamEventSink func(agent.Event)
+
 	sources   *agent.MultiSource
 	clients   []*client.Client
 	history   []agent.Message
@@ -662,8 +669,15 @@ func (a *App) RunTurn(ctx context.Context, input string) error {
 			a.emit(HostEvent{Kind: HostTurnFailed, Err: err.Error()})
 			return err
 		}
-		pe = NewPersistingEmit(a.store, a.runID, emit)
-		emit = pe.Emit
+		if a.team != nil {
+			// Team member events render attributed via OnEvent, so the persisting
+			// tap must NOT also render (that would double-render) — a nil next
+			// makes pe buffer-only; teamEventSink feeds it below.
+			pe = NewPersistingEmit(a.store, a.runID, nil)
+		} else {
+			pe = NewPersistingEmit(a.store, a.runID, emit)
+			emit = pe.Emit
+		}
 	}
 
 	// The memory summary is woven into the per-turn slice only, never into
@@ -674,10 +688,17 @@ func (a *App) RunTurn(ctx context.Context, input string) error {
 	var err error
 	if a.team != nil {
 		// Team mode: the active member (persisted across turns) drives the turn,
-		// looping handoffs internally; result.Messages spans every hop. Persist
-		// the ending active agent so control stays transferred next turn.
+		// looping handoffs internally; result.Messages spans every hop. Member
+		// events flow through the Team's OnEvent (attributed render + persist via
+		// the sink), so the emit passed here is unused. Persist the ending active
+		// agent so control stays transferred next turn.
+		a.teamEventSink = func(agent.Event) {}
+		if pe != nil {
+			a.teamEventSink = pe.Emit
+		}
 		var active string
 		result, active, err = a.team.RunTurn(ctx, turnMsgs, a.activeTeamAgent, emit)
+		a.teamEventSink = nil
 		if err == nil {
 			a.activeTeamAgent = active
 		}

--- a/agent/host/config.go
+++ b/agent/host/config.go
@@ -116,6 +116,17 @@ type SubAgentConfig struct {
 	// MaxDepth caps sub-agent nesting for this persona. Zero uses the agent
 	// default.
 	MaxDepth int `json:"maxDepth,omitempty"`
+
+	// InputSchema, when set, gives the persona a TYPED input tool instead of the
+	// default {task} — the parent must pass arguments matching this JSON schema,
+	// and the persona is seeded with them (structured input, 1033). Empty keeps
+	// {task: string}.
+	InputSchema json.RawMessage `json:"inputSchema,omitempty"`
+
+	// ResponseSchema, when set, makes the persona return a JSON value coerced to
+	// this schema instead of free text (structured output, 1033) — the parent
+	// gets typed output back. Empty returns text.
+	ResponseSchema json.RawMessage `json:"responseSchema,omitempty"`
 }
 
 // FanOutGroupConfig declares one parallel-ensemble tool: the main agent calls

--- a/agent/host/subagents.go
+++ b/agent/host/subagents.go
@@ -51,6 +51,7 @@ func (a *App) buildPersonaSource(sub SubAgentConfig, serverTools *agent.MultiSou
 		Description: sub.Description,
 		Runner:      child,
 		MaxDepth:    sub.MaxDepth,
+		InputSchema: sub.InputSchema,
 		OnEvent:     func(e agent.SubAgentEvent) { a.emit(HostEvent{Kind: HostSubAgentEvent, SubAgent: e}) },
 	})
 }
@@ -77,6 +78,7 @@ func (a *App) personaRunnerConfig(sub SubAgentConfig, serverTools *agent.MultiSo
 		MaxSteps:       a.cfg.MaxSteps,
 		TracerProvider: tp,
 		MeterProvider:  mp,
+		ResponseSchema: core.NewRawJSON(sub.ResponseSchema),
 	}
 }
 

--- a/agent/host/team.go
+++ b/agent/host/team.go
@@ -28,6 +28,15 @@ func (a *App) buildTeam(serverTools *agent.MultiSource, provider agent.Provider,
 		Start:       tc.Start,
 		MaxHandoffs: tc.MaxHandoffs,
 		OnHandoff:   func(from, to string) { a.emit(HostEvent{Kind: HostHandoff, From: from, To: to}) },
+		// Each member's events render attributed by agent name (HostSubAgentEvent)
+		// and are buffered for persistence via the per-turn sink, so the event log
+		// is unchanged while the surface can tell which agent is speaking.
+		OnEvent: func(e agent.SubAgentEvent) {
+			if a.teamEventSink != nil {
+				a.teamEventSink(e.Event)
+			}
+			a.emit(HostEvent{Kind: HostSubAgentEvent, SubAgent: e})
+		},
 	})
 }
 

--- a/agent/host/team_test.go
+++ b/agent/host/team_test.go
@@ -63,6 +63,15 @@ func TestAppTeamDrivesRunTurnWithHandoff(t *testing.T) {
 	if len(handoffs) != 1 || handoffs[0].From != "triage" || handoffs[0].To != "specialist" {
 		t.Fatalf("expected one triage->specialist HostHandoff, got %+v", handoffs)
 	}
+	// team member events surface attributed by agent name (1033 tagging), not as
+	// untagged HostRunnerEvent.
+	scopes := map[string]bool{}
+	for _, e := range obs.kinds(HostSubAgentEvent) {
+		scopes[e.SubAgent.Scope] = true
+	}
+	if !scopes["triage"] || !scopes["specialist"] {
+		t.Fatalf("team events not attributed to both agents, saw %v", scopes)
+	}
 
 	// turn 2: starts from the persisted specialist — the triage provider turns
 	// are already consumed, so if turn 2 restarted at triage it would misroute.

--- a/agent/team.go
+++ b/agent/team.go
@@ -33,6 +33,7 @@ type Team struct {
 	start       string
 	maxHandoffs int
 	onHandoff   func(from, to string)
+	onEvent     func(SubAgentEvent)
 }
 
 type teamMember struct {
@@ -74,6 +75,14 @@ type TeamConfig struct {
 	// OnHandoff, when set, is called on each transfer (from, to) — the seam a
 	// surface renders "→ handed off to X" through.
 	OnHandoff func(from, to string)
+
+	// OnEvent, when set, receives every member's events tagged with the active
+	// agent's name (SubAgentEvent{Scope: name, Depth: 1, Event}), so a surface
+	// attributes team activity to the agent that produced it without inferring
+	// from OnHandoff. It REPLACES the raw emit passed to Run/RunTurn for member
+	// events (the tagged envelope carries the same Event); leave it nil to use
+	// the untagged emit. Mirrors AgentSourceConfig.OnEvent.
+	OnEvent func(SubAgentEvent)
 }
 
 // NewTeam validates cfg and builds each agent's Runner with its transfer tools
@@ -102,6 +111,7 @@ func NewTeam(cfg TeamConfig) (*Team, error) {
 		start:       cfg.Start,
 		maxHandoffs: cfg.MaxHandoffs,
 		onHandoff:   cfg.OnHandoff,
+		onEvent:     cfg.OnEvent,
 	}
 	if t.maxHandoffs <= 0 {
 		t.maxHandoffs = DefaultMaxHandoffs
@@ -204,7 +214,14 @@ func (t *Team) RunTurn(ctx context.Context, history []Message, active string, em
 	var appended []Message
 	handoffs := 0
 	for {
-		result, err := current.runner.Run(ctx, work, emit)
+		// Tag each member's events with the active agent's name when OnEvent is
+		// set (the attributed path); else the raw emit.
+		memberEmit := emit
+		if t.onEvent != nil {
+			name := current.name
+			memberEmit = func(e Event) { t.onEvent(SubAgentEvent{Scope: name, Depth: 1, Event: e}) }
+		}
+		result, err := current.runner.Run(ctx, work, memberEmit)
 		if err != nil {
 			return nil, current.name, err
 		}

--- a/agent/team_test.go
+++ b/agent/team_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"sync"
 	"testing"
 
 	"github.com/panyam/mcpkit/core"
@@ -189,5 +190,42 @@ func TestTeam_RunTurnPersistsActiveAgent(t *testing.T) {
 	}
 	if n := len(triage.Requests()); n != triageBefore {
 		t.Fatalf("triage was consulted again on turn 2 (%d -> %d); it must start from the persisted specialist, not Start", triageBefore, n)
+	}
+}
+
+// TestTeam_OnEventTagsByActiveAgent covers per-agent event tagging (1033): each
+// member's events are forwarded tagged with the active agent's name, so a
+// surface attributes them without inferring from OnHandoff.
+func TestTeam_OnEventTagsByActiveAgent(t *testing.T) {
+	triage := NewStubProvider(transferCall("c1", "specialist"), StubTurn{Text: "connecting"})
+	specialist := NewStubProvider(StubTurn{Text: "the answer"})
+
+	var mu sync.Mutex
+	scopes := map[string]bool{}
+	depths := map[int]bool{}
+	team, err := NewTeam(TeamConfig{
+		Start: "triage",
+		Members: []TeamMember{
+			{Name: "triage", Config: RunnerConfig{Provider: triage}, HandoffTo: []string{"specialist"}},
+			{Name: "specialist", Config: RunnerConfig{Provider: specialist}},
+		},
+		OnEvent: func(e SubAgentEvent) {
+			mu.Lock()
+			scopes[e.Scope] = true
+			depths[e.Depth] = true
+			mu.Unlock()
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := team.Run(context.Background(), "help", func(Event) {}); err != nil {
+		t.Fatal(err)
+	}
+	if !scopes["triage"] || !scopes["specialist"] {
+		t.Fatalf("events not tagged by both agents, saw scopes %v", scopes)
+	}
+	if !depths[1] || len(depths) != 1 {
+		t.Fatalf("team member events should be depth 1, saw %v", depths)
 	}
 }

--- a/docs/AGENT_COMPOSITION.md
+++ b/docs/AGENT_COMPOSITION.md
@@ -254,10 +254,13 @@ team members).
 - Context: handoff-via-injection + per-agent persistent context (the actor
   form above) — a generalization of `Team`.
 - Control: async sub-agents (1035), upward signals + runner-control meta-tools
-  + interruptible turn (1036), aggregate step/token tree budget (1032). The
-  remaining 1033 bits — structured sub-agent I/O (typed input + `ResponseSchema`
-  output) and map-style fan-out (distribute a list of distinct subtasks) — also
-  sit here; `FanOutSource` today broadcasts one task to all members.
+  + interruptible turn (1036), aggregate step/token tree budget (1032).
+  **1033 is closed**: `AgentSource.InputSchema` (typed subtask in) + `Structured`
+  output (a child with a `ResponseSchema` returns coerced JSON) + `Team.OnEvent`
+  (member events tagged by active agent name, rendered attributed as
+  `HostSubAgentEvent`). Map-style fan-out (distribute distinct subtasks) was NOT
+  part of 1033 — `FanOutSource` broadcasts one task to all members; a distinct-
+  subtask variant is a separate future item if wanted.
 - Surface: declarative `agent/host` + agentchat multi-agent config and nested
   rendering (1031, part 2).
 


### PR DESCRIPTION
## What changes

Closes the two remaining #1033 bullets (parallel fan-out shipped in PR 1155):

- **Structured sub-agent I/O** — a parent can delegate a *typed* subtask and get *typed* output back, not just `{task}` → text.
- **Per-agent Team event tagging** — team member events are attributed to the agent that produced them, so a surface shows "billing said…" without inferring from `OnHandoff`.

Map-style fan-out (distribute distinct subtasks across members) was *not* in 1033's text — it was a stray note; called out as a separate future item.

## Reviewer's guide

Read in this order:
1. [agent/agent_source.go](https://github.com/panyam/mcpkit/pull/1159/files#diff-cb9651df111cfad72b6d4ca30ae061405bedefa4b107cd0a6d36cd53a089bb8d) — start here. `InputSchema` (typed tool + seed the child with raw args JSON) and the `result.Structured` → tool-result output.
2. [agent/agent_source_test.go](https://github.com/panyam/mcpkit/pull/1159/files#diff-66d311d108a64c88261a91b9a0fc9a485f537513290911d12aec516b562995dc) — typed-input + structured-output acceptance.
3. [agent/team.go](https://github.com/panyam/mcpkit/pull/1159/files#diff-ecc8523fab2cb54248822322542d9194c8e2f9436ce81b71cd07d422edebc7ea) — `TeamConfig.OnEvent` tags each member's events `{Scope: activeName, Depth: 1}`.
4. [agent/team_test.go](https://github.com/panyam/mcpkit/pull/1159/files#diff-b1e079492f9b20d890a2861696c46a81012528d28a2868eda668d21ea9c79248) — tagging across a handoff.
5. `agent/host/{config,subagents}.go` — `SubAgentConfig.InputSchema`/`ResponseSchema` wiring (inherited by fan-out/team members).
6. `agent/host/{team,app}.go` — team events render attributed (`HostSubAgentEvent`) + persist via a buffer-only `PersistingEmit` (the one subtlety, below).
7. [agent/host/team_test.go](https://github.com/panyam/mcpkit/pull/1159/files#diff-b7f1da08d2e8d2f21975cf82714af55fe56916035d19f8be5662716bee8cd975) — host attribution assertion.

## The one subtlety: attributed render without double-render or losing persistence

Team member events used to flow through the raw emit → `HostRunnerEvent` (render) + `PersistingEmit` (persist), untagged. Now they flow through `Team.OnEvent` (tagged). To render them *attributed* while keeping the event log intact and not double-rendering:

```
RunTurn (team mode):
  pe = NewPersistingEmit(store, runID, next=nil)   # buffer-only: persists, does NOT render
  a.teamEventSink = pe.Emit                          # per-turn, set under turnMu

buildTeam OnEvent(SubAgentEvent{scope, event}):
  a.teamEventSink(event)                             # persist the flat event (redacted at turn-end)
  a.emit(HostSubAgentEvent{...})                     # render attributed by agent name
```

`Team.OnEvent`, when set, *replaces* the raw emit for member events, so the emit passed to `RunTurn` is unused in team mode — no path double-fires.

## Decision log

- **Structured output needs no new field** — `Call` just returns `result.Structured` when the child produced it (its Runner had a `ResponseSchema`); typed *input* is the only new config (`InputSchema`).
- **Reused `SubAgentEvent` for team tagging** (not a new envelope) — same `{Scope, Depth}` shape the sub-agent path already renders, so team turns render attributed with zero new renderer code.
- **Buffer-only `PersistingEmit` for team turns** rather than teeing the tagged event back through the render path — keeps persistence unchanged (including the turn-end message redaction) and avoids double-render.

## Risk / blast radius

- **Affects:** `AgentSource` (additive `InputSchema`; output prefers `Structured`), `Team` (additive `OnEvent`), host config + team wiring. Single-agent path untouched.
- **Behavior change for team turns:** member events now render as attributed `HostSubAgentEvent` instead of untagged `HostRunnerEvent` (the intended 1033 upgrade over 1042). Persistence unchanged.
- **Tests:** typed-input, structured-output, team-tagging (agent) + host attribution; full `agent` + `agent/host` green under `-race`. All three new behaviors proven with teeth (reverting each fails its test).

## Before / after

```
Structured output:
  before: scorer sub-agent → "the score is 7"       (free text)
  after (child has ResponseSchema): scorer → {"score":7}   (typed, Bind-able)

Team attribution (just team):
  before: <billing's answer streams as the plain main turn>
  after:  billing> <answer>       # each turn attributed to the active agent
```

## Out of scope

- Map-style fan-out (distinct subtasks per member) — not in 1033; file separately if wanted.

