### PR TITLE
feat(agent): async sub-agents — spawn-and-continue Task form (1035)

### DIFF
--- a/agent/async_agent_source.go
+++ b/agent/async_agent_source.go
@@ -1,0 +1,155 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+// AsyncAgentSourceConfig configures an AsyncAgentSource.
+type AsyncAgentSourceConfig struct {
+	// Name is the tool the parent model calls to spawn the sub-agent. Required.
+	Name string
+
+	// Description tells the parent when to spawn it (and that it returns later).
+	Description string
+
+	// Runner is the child agent. Required. Run is stateless over the history it
+	// is handed, so one Runner serves concurrent spawns.
+	Runner *Runner
+
+	// MaxDepth caps sub-agent nesting (checked at spawn time). Zero uses
+	// DefaultMaxAgentDepth.
+	MaxDepth int
+
+	// InputSchema, when set, replaces the default {task} schema so a parent
+	// spawns a TYPED subtask; the child is seeded with the raw args JSON. Nil
+	// keeps {task: string} (mirrors AgentSourceConfig.InputSchema).
+	InputSchema json.RawMessage
+
+	// OnEvent, when set, receives the child's event stream (scoped/depth in a
+	// SubAgentEvent) WHILE it runs in the background, so a surface can still
+	// render the sub-agent's activity after the spawning turn has ended. Nil
+	// drops it.
+	OnEvent func(SubAgentEvent)
+
+	// OnComplete is called on the child's goroutine when it finishes, with the
+	// sub-agent name, its result (nil on error), and any run error. Required —
+	// it is how the result rejoins the conversation: a host wires it to its
+	// injection seam (Ingest as a subagent.completed event), so the parent picks
+	// the result up on a later turn. Without it the result is dropped.
+	OnComplete func(name string, result *TurnResult, err error)
+}
+
+// AsyncAgentSource is the Task form of a sub-agent: the spawn-and-continue
+// counterpart to AgentSource's blocking Tool form. Call returns an ack
+// IMMEDIATELY ("sub-agent X started") and runs the child on a detached
+// goroutine; when the child finishes, OnComplete delivers its result, which a
+// host injects so the parent picks it up on a later turn. The spawning turn does
+// not wait for the subtree — right for long-running or fan-out-and-continue work
+// (contrast AgentSource: call-and-block, answer this turn).
+//
+// It is NOT an MCP task: there is no wire presence, no model-visible poll/cancel,
+// and the goroutine is ephemeral (it dies with the process). For controllable or
+// restart-surviving background work, use a real server-side task instead.
+//
+// Depth and the ctx-threaded aggregate call budget still apply (checked at spawn
+// time, before the goroutine starts). SubAgentEvent nesting still surfaces the
+// child's stream while it runs in the background.
+type AsyncAgentSource struct {
+	cfg      AsyncAgentSourceConfig
+	def      core.ToolDef
+	maxDepth int
+}
+
+// NewAsyncAgentSource validates cfg and builds the tool definition. Name,
+// Runner, and OnComplete are required.
+func NewAsyncAgentSource(cfg AsyncAgentSourceConfig) (*AsyncAgentSource, error) {
+	if cfg.Name == "" {
+		return nil, fmt.Errorf("agent: AsyncAgentSource requires a Name")
+	}
+	if cfg.Runner == nil {
+		return nil, fmt.Errorf("agent: AsyncAgentSource %q requires a Runner", cfg.Name)
+	}
+	if cfg.OnComplete == nil {
+		return nil, fmt.Errorf("agent: AsyncAgentSource %q requires an OnComplete (else the result is dropped)", cfg.Name)
+	}
+	schemaJSON := cfg.InputSchema
+	if schemaJSON == nil {
+		schemaJSON = core.GenerateSchema[agentTaskArgs]()
+	}
+	var schema any
+	if err := json.Unmarshal(schemaJSON, &schema); err != nil {
+		return nil, fmt.Errorf("agent: schema for AsyncAgentSource %q: %w", cfg.Name, err)
+	}
+	maxDepth := cfg.MaxDepth
+	if maxDepth <= 0 {
+		maxDepth = DefaultMaxAgentDepth
+	}
+	return &AsyncAgentSource{
+		cfg:      cfg,
+		def:      core.ToolDef{Name: cfg.Name, Description: cfg.Description, InputSchema: schema},
+		maxDepth: maxDepth,
+	}, nil
+}
+
+// Tools returns the single spawn tool.
+func (s *AsyncAgentSource) Tools(ctx context.Context) ([]core.ToolDef, error) {
+	return []core.ToolDef{s.def}, nil
+}
+
+// Call spawns the child on a detached goroutine and returns an ack immediately.
+// Guards (depth, budget) are checked before the spawn and refuse as an IsError
+// result; only an unknown name is a dispatch error.
+func (s *AsyncAgentSource) Call(ctx context.Context, name string, args map[string]any) (*core.ToolResult, error) {
+	if name != s.cfg.Name {
+		return nil, fmt.Errorf("%w: %q", ErrUnknownTool, name)
+	}
+	depth := agentDepth(ctx)
+	if depth >= s.maxDepth {
+		return errorToolResult(fmt.Sprintf("sub-agent %q refused: max depth %d reached", s.cfg.Name, s.maxDepth)), nil
+	}
+	if b := agentCallBudget(ctx); b != nil && b.Add(-1) < 0 {
+		return errorToolResult(fmt.Sprintf("sub-agent %q refused: call budget exhausted", s.cfg.Name)), nil
+	}
+
+	raw, err := json.Marshal(args)
+	if err != nil {
+		return nil, fmt.Errorf("agent: encode args for sub-agent %q: %w", s.cfg.Name, err)
+	}
+	seed := string(raw)
+	if s.cfg.InputSchema == nil {
+		var in agentTaskArgs
+		if err := json.Unmarshal(raw, &in); err != nil || strings.TrimSpace(in.Task) == "" {
+			return errorToolResult(fmt.Sprintf("sub-agent %q requires a non-empty 'task'", s.cfg.Name)), nil
+		}
+		seed = in.Task
+	}
+
+	childScope := s.cfg.Name
+	if parent := agentScope(ctx); parent != "" {
+		childScope = parent + "/" + s.cfg.Name
+	}
+	// Detach for background: the child outlives the spawning turn AND calls MCP
+	// server tools, so it needs the session-level push (DetachForBackground),
+	// not a plain context.WithoutCancel. Depth/scope are threaded onto the
+	// detached ctx so nested spawns and event tagging still compose.
+	childCtx := withAgentScope(withAgentDepth(core.DetachForBackground(ctx), depth+1), childScope)
+
+	emit := func(Event) {}
+	if s.cfg.OnEvent != nil {
+		childDepth := depth + 1
+		emit = func(e Event) { s.cfg.OnEvent(SubAgentEvent{Scope: childScope, Depth: childDepth, Event: e}) }
+	}
+
+	go func() {
+		result, err := s.cfg.Runner.Run(childCtx, []Message{{Role: RoleUser, Text: seed}}, emit)
+		s.cfg.OnComplete(s.cfg.Name, result, err)
+	}()
+
+	return &core.ToolResult{Content: []core.Content{{Type: "text", Text: fmt.Sprintf(
+		"sub-agent %q started in the background; its result will arrive as context when it finishes.", s.cfg.Name)}}}, nil
+}

--- a/agent/async_agent_source_test.go
+++ b/agent/async_agent_source_test.go
@@ -1,0 +1,119 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// latchProvider blocks in Stream until released, so a test can assert the async
+// Call returned its ack BEFORE the child finished.
+type latchProvider struct {
+	release <-chan struct{}
+	text    string
+}
+
+func (p *latchProvider) Stream(ctx context.Context, req ProviderRequest) (Stream, error) {
+	<-p.release
+	return &stubStream{deltas: []Delta{{Kind: DeltaText, Text: p.text}, {Kind: DeltaFinish, FinishReason: "stop"}}}, nil
+}
+func (p *latchProvider) Generate(ctx context.Context, req ProviderRequest) (*ProviderResponse, error) {
+	<-p.release
+	var acc Accumulator
+	acc.Add(Delta{Kind: DeltaText, Text: p.text})
+	acc.Add(Delta{Kind: DeltaFinish, FinishReason: "stop"})
+	return acc.Result(), nil
+}
+
+// TestAsyncAgentSource_AcksThenDelivers is the core guarantee: Call returns an
+// ack immediately (does not block on the child), and OnComplete delivers the
+// child's result once it finishes.
+func TestAsyncAgentSource_AcksThenDelivers(t *testing.T) {
+	release := make(chan struct{})
+	child, _ := NewRunner(RunnerConfig{Provider: &latchProvider{release: release, text: "the deep answer"}})
+
+	done := make(chan *TurnResult, 1)
+	as, err := NewAsyncAgentSource(AsyncAgentSourceConfig{
+		Name: "researcher", Description: "deep research", Runner: child,
+		OnComplete: func(name string, result *TurnResult, err error) { done <- result },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Call returns the ack while the child is still latched (not blocked).
+	res, err := as.Call(context.Background(), "researcher", map[string]any{"task": "dig in"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError || !strings.Contains(res.Content[0].Text, "started") {
+		t.Fatalf("Call should ack immediately, got %+v", res)
+	}
+	select {
+	case <-done:
+		t.Fatal("OnComplete fired before the child was released — Call must not block")
+	case <-time.After(50 * time.Millisecond):
+		// expected: child still latched, no completion yet
+	}
+
+	// release the child; OnComplete delivers its result.
+	close(release)
+	select {
+	case result := <-done:
+		if result == nil || result.Text != "the deep answer" {
+			t.Fatalf("OnComplete result = %+v, want the child's answer", result)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("OnComplete never fired after the child finished")
+	}
+}
+
+// TestAsyncAgentSource_DepthGuard asserts the depth guard refuses (before spawn)
+// and does not start the child.
+func TestAsyncAgentSource_DepthGuard(t *testing.T) {
+	child, _ := NewRunner(RunnerConfig{Provider: NewStubProvider(StubTurn{Text: "x"})})
+	fired := make(chan struct{}, 1)
+	as, _ := NewAsyncAgentSource(AsyncAgentSourceConfig{
+		Name: "deep", Runner: child, MaxDepth: 1,
+		OnComplete: func(string, *TurnResult, error) { fired <- struct{}{} },
+	})
+	// ctx already at depth 1 (== MaxDepth) → refused.
+	ctx := withAgentDepth(context.Background(), 1)
+	res, _ := as.Call(ctx, "deep", map[string]any{"task": "go"})
+	if !res.IsError || !strings.Contains(res.Content[0].Text, "max depth") {
+		t.Fatalf("over-depth spawn should be refused, got %+v", res)
+	}
+	select {
+	case <-fired:
+		t.Fatal("a refused spawn must not run the child")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+// TestAsyncAgentSource_ForwardsEvents asserts the child's stream still surfaces
+// (SubAgentEvent, scoped/depth) while it runs in the background.
+func TestAsyncAgentSource_ForwardsEvents(t *testing.T) {
+	child, _ := NewRunner(RunnerConfig{Provider: NewStubProvider(StubTurn{Text: "hi"})})
+	events := make(chan SubAgentEvent, 16)
+	done := make(chan struct{}, 1)
+	as, _ := NewAsyncAgentSource(AsyncAgentSourceConfig{
+		Name: "worker", Runner: child,
+		OnEvent:    func(e SubAgentEvent) { events <- e },
+		OnComplete: func(string, *TurnResult, error) { done <- struct{}{} },
+	})
+	if _, err := as.Call(context.Background(), "worker", map[string]any{"task": "go"}); err != nil {
+		t.Fatal(err)
+	}
+	<-done
+	close(events)
+	var sawScoped bool
+	for e := range events {
+		if e.Scope == "worker" && e.Depth == 1 {
+			sawScoped = true
+		}
+	}
+	if !sawScoped {
+		t.Fatal("background child events not surfaced scoped to the sub-agent")
+	}
+}

--- a/agent/host/async_subagent_test.go
+++ b/agent/host/async_subagent_test.go
@@ -1,0 +1,84 @@
+package host
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/panyam/mcpkit/agent"
+	"github.com/panyam/mcpkit/core"
+)
+
+// waitFor polls until cond is true or the deadline passes.
+func waitForCond(t *testing.T, d time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatal("condition not met before deadline")
+}
+
+// TestAppAsyncSubAgentAcksThenInjects is the 1035 payoff: an Async persona acks
+// immediately on the spawning turn, runs in the background, and its result is
+// injected into a LATER turn's context (not this turn).
+func TestAppAsyncSubAgentAcksThenInjects(t *testing.T) {
+	ts := startTestServer(t)
+
+	// main turn 1: delegate to the async researcher, then reply (the ack is the
+	// tool result, so the main agent continues). The researcher (same stub)
+	// answers when it runs in the background. main turn 2: a plain reply that
+	// should now see the injected result.
+	stub := agent.NewStubProvider(
+		agent.StubTurn{ToolCalls: []agent.ToolCall{{
+			ID: "a1", Name: "researcher",
+			Args: core.NewRawJSON(json.RawMessage(`{"task":"deep dive on caching"}`)),
+		}}},
+		agent.StubTurn{Text: "kicked off the research"},  // main finishes turn 1
+		agent.StubTurn{Text: "the deep research result"}, // the async child's answer
+		agent.StubTurn{Text: "here is what came back"},   // main turn 2
+	)
+
+	cfg := testConfig(ts.URL)
+	cfg.SubAgents = []SubAgentConfig{{
+		Name: "researcher", Description: "long-running deep research", Instructions: "research deeply", Async: true,
+	}}
+	obs := &collectObserver{}
+	app, err := NewApp(cfg, nil, strings.NewReader(""), WithProvider(stub), WithObserver(obs))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Close()
+	ctx := context.Background()
+
+	// turn 1: the main agent delegates; the tool result is an ACK, and the turn
+	// completes without waiting for the child.
+	if err := app.RunTurn(ctx, "kick off deep research"); err != nil {
+		t.Fatal(err)
+	}
+	ackFed := toolMsgByID(t, stub.Requests()[1].Messages, "a1").Text
+	if !strings.Contains(ackFed, "started") {
+		t.Fatalf("async delegate should feed the model an ack, got %q", ackFed)
+	}
+
+	// the background child finishes and notifies (HostMessage) — wait for it.
+	waitForCond(t, 2*time.Second, func() bool { return len(obs.kinds(HostMessage)) > 0 })
+
+	// turn 2: the injected result is now in the request's system context.
+	if err := app.RunTurn(ctx, "anything back yet?"); err != nil {
+		t.Fatal(err)
+	}
+	if !hasSystemContaining(stub.Requests()[3].Messages, "subagent.completed") ||
+		!hasSystemContaining(stub.Requests()[3].Messages, "the deep research result") {
+		t.Fatalf("async result not injected into the later turn: %+v", stub.Requests()[3].Messages)
+	}
+	// and it was NOT in turn 1's own request (it hadn't finished yet)
+	if hasSystemContaining(stub.Requests()[0].Messages, "subagent.completed") {
+		t.Fatal("async result must not appear on the spawning turn")
+	}
+}

--- a/agent/host/config.go
+++ b/agent/host/config.go
@@ -127,6 +127,13 @@ type SubAgentConfig struct {
 	// this schema instead of free text (structured output, 1033) — the parent
 	// gets typed output back. Empty returns text.
 	ResponseSchema json.RawMessage `json:"responseSchema,omitempty"`
+
+	// Async, when true, builds the persona as the spawn-and-continue Task form
+	// (agent.AsyncAgentSource, 1035): the delegate tool acks immediately and the
+	// child runs in the background, its result injected as context on a later
+	// turn — for long-running subtasks the parent should not block on. False
+	// (the default) is the blocking Tool form (answer this turn).
+	Async bool `json:"async,omitempty"`
 }
 
 // FanOutGroupConfig declares one parallel-ensemble tool: the main agent calls

--- a/agent/host/subagents.go
+++ b/agent/host/subagents.go
@@ -1,7 +1,11 @@
 package host
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
 	"strings"
+	"time"
 
 	"github.com/panyam/mcpkit/agent"
 	"github.com/panyam/mcpkit/core"
@@ -24,7 +28,13 @@ import (
 // Guarded by TestSubAgentCannotReachParentMemory.
 func (a *App) registerSubAgents(multi, serverTools *agent.MultiSource, provider agent.Provider, tp core.TracerProvider, mp core.MeterProvider) error {
 	for _, sub := range a.cfg.SubAgents {
-		src, err := a.buildPersonaSource(sub, serverTools, provider, tp, mp)
+		var src agent.ToolSource
+		var err error
+		if sub.Async {
+			src, err = a.buildAsyncPersonaSource(sub, serverTools, provider, tp, mp)
+		} else {
+			src, err = a.buildPersonaSource(sub, serverTools, provider, tp, mp)
+		}
 		if err != nil {
 			return err
 		}
@@ -33,6 +43,56 @@ func (a *App) registerSubAgents(multi, serverTools *agent.MultiSource, provider 
 		}
 	}
 	return nil
+}
+
+// buildAsyncPersonaSource builds an async (Task-form) persona: an
+// agent.AsyncAgentSource whose delegate tool acks immediately and runs the child
+// in the background, its result injected on a later turn via onAsyncComplete.
+// The child is a persona like any other (serverTools-only, memory-free per A7).
+func (a *App) buildAsyncPersonaSource(sub SubAgentConfig, serverTools *agent.MultiSource, provider agent.Provider, tp core.TracerProvider, mp core.MeterProvider) (*agent.AsyncAgentSource, error) {
+	child, err := agent.NewRunner(a.personaRunnerConfig(sub, serverTools, provider, tp, mp))
+	if err != nil {
+		return nil, err
+	}
+	return agent.NewAsyncAgentSource(agent.AsyncAgentSourceConfig{
+		Name:        sub.Name,
+		Description: sub.Description,
+		Runner:      child,
+		MaxDepth:    sub.MaxDepth,
+		InputSchema: sub.InputSchema,
+		OnEvent:     func(e agent.SubAgentEvent) { a.emit(HostEvent{Kind: HostSubAgentEvent, SubAgent: e}) },
+		OnComplete:  a.onAsyncComplete,
+	})
+}
+
+// onAsyncComplete delivers a finished async sub-agent's result back into the
+// conversation, mirroring the background-task completion path (tasks_bg.go):
+// build a subagent.completed event, Ingest it so it is injected on the next turn
+// (or a trigger fires a proactive turn), and notify the surface. Runs on the
+// child's goroutine — injection.Ingest, emit, and runProactiveTurn are each
+// safe to call from there.
+func (a *App) onAsyncComplete(name string, result *agent.TurnResult, err error) {
+	payload := map[string]any{"subAgent": name, "status": "completed"}
+	switch {
+	case err != nil:
+		payload["status"] = "failed"
+		payload["error"] = err.Error()
+	case result != nil:
+		payload["result"] = result.Text
+	}
+	raw, _ := json.Marshal(payload)
+	ev := agent.IncomingEvent{
+		Server: name,
+		Name:   "subagent.completed",
+		ID:     name,
+		Time:   time.Now(),
+		Data:   core.NewRawJSON(raw),
+	}
+	a.injection.Ingest(ev)
+	a.emit(HostEvent{Kind: HostMessage, Message: fmt.Sprintf("sub-agent %q finished; its result will be in context on your next turn", name)})
+	if firing := a.triggers.OnEvent(ev); firing != nil {
+		a.runProactiveTurn(context.Background(), firing)
+	}
 }
 
 // buildPersonaSource constructs one persona as an agent.AgentSource: a child

--- a/docs/AGENT_COMPOSITION.md
+++ b/docs/AGENT_COMPOSITION.md
@@ -249,11 +249,33 @@ persists across turns; `HostHandoff` event; `just team` demo. Mutually exclusive
 with the single-agent features (deferred: integrating memory/offloading into
 team members).
 
+**`AsyncAgentSource` — the Task form (1035):** the spawn-and-continue counterpart
+to `AgentSource`'s blocking Tool form. `Call` returns an ack immediately and runs
+the child on a detached goroutine (`core.DetachForBackground` — it outlives the
+turn and makes server calls); on completion `OnComplete` delivers the result,
+which the host injects as a `subagent.completed` event (reusing the `tasks_bg.go`
+Ingest + trigger path), so the parent picks it up on a later turn. Depth/budget
+guards apply at spawn; `SubAgentEvent` still surfaces the background stream.
+Host: `SubAgentConfig.Async` builds it; demoed as `deep_researcher` in
+`examples/agents/kitchen-sink`.
+
+**Tool vs Task vs *a real Task*:**
+- **Tool** (`AgentSource`): call-and-block, answer this turn. For short subtasks
+  the parent must have now.
+- **Task form** (`AsyncAgentSource`): ack-now, result later via injection. For
+  long-running or fan-out-and-continue work. But it is **not** an MCP task — no
+  wire presence, no model-visible poll/cancel, the goroutine is ephemeral (dies
+  with the process).
+- **A real (server-side) task** (`ext/tasks`): when you need the model to *poll*
+  or *cancel* the background work, or it must survive a restart. Heavier: a task
+  runtime + wire support. The async sub-agent is the no-runtime, ephemeral end of
+  the same spawn-and-continue spectrum whose durable/controllable end is a task.
+
 **Deferred, mapped to the axes:**
 
 - Context: handoff-via-injection + per-agent persistent context (the actor
   form above) — a generalization of `Team`.
-- Control: async sub-agents (1035), upward signals + runner-control meta-tools
+- Control: upward signals + runner-control meta-tools
   + interruptible turn (1036), aggregate step/token tree budget (1032).
   **1033 is closed**: `AgentSource.InputSchema` (typed subtask in) + `Structured`
   output (a child with a `ResponseSchema` returns coerced JSON) + `Team.OnEvent`

--- a/examples/agents/kitchen-sink/README.md
+++ b/examples/agents/kitchen-sink/README.md
@@ -139,6 +139,15 @@ Gemini). You can also swap chat models mid-session with `/provider`.
    performance, cost) that run **concurrently** — in `--ui notebook` you see
    their events interleave under one fan-out call in the sub-agent tree — and
    returns their assessments combined in one result.
+   - **Async (background) sub-agent.** Ask: *"Kick off deep research on
+     event-driven architectures — I'll keep working."* The model calls
+     `deep_researcher`, which **acks immediately** ("started in the background")
+     so the turn finishes without waiting. Keep chatting; after the child
+     finishes you'll see *"sub-agent deep_researcher finished"*, and its report
+     is injected as context on your **next** turn (ask *"what did the research
+     find?"*). Contrast the synchronous `researcher` (step 2), which blocks the
+     turn until it answers — async is the spawn-and-continue Task form for work
+     you don't need this instant.
 4. **Semantic memory + durability.** Tell it: *"Remember that our prod region is
    us-east-1."* It calls `remember`, which embeds and upserts a pgvector row.
    **Quit and `just run` again** (same `$SESSION`). Ask: *"Where do we run

--- a/examples/agents/kitchen-sink/kitchen-sink.json
+++ b/examples/agents/kitchen-sink/kitchen-sink.json
@@ -1,5 +1,5 @@
 {
-  "instructions": "You are a capable assistant with access to MCP tools, two specialist sub-agents (researcher, analyst), and a review_team fan-out tool. Use working memory to remember durable facts the user tells you, delegate research/analysis to the sub-agents when it helps, and when asked for a review or multiple perspectives on a plan call review_team (it runs three reviewers in parallel and returns their combined take). Keep answers concise.",
+  "instructions": "You are a capable assistant with access to MCP tools, specialist sub-agents (researcher, analyst), a background deep_researcher, and a review_team fan-out tool. Use working memory to remember durable facts the user tells you; delegate research/analysis to the sub-agents when it helps; for a thorough report the user doesn't need immediately, call deep_researcher (it runs in the background and its report arrives on a later turn, so acknowledge and move on); and when asked for a review or multiple perspectives on a plan call review_team (three reviewers in parallel). Keep answers concise.",
   "connections": {
     "active": "deepseek-r1",
     "embedder": "openai-embed",
@@ -52,6 +52,13 @@
       "description": "Computes summary statistics for a list of numbers using the analyze tool.",
       "instructions": "You are a data analyst. Call the analyze tool on the numbers you are given and explain the result in one sentence.",
       "allow": ["analyze"]
+    },
+    {
+      "name": "deep_researcher",
+      "description": "Kicks off a long-running deep research report on a topic IN THE BACKGROUND. Returns immediately with an acknowledgement; the finished report arrives as context on a later turn. Use this (not researcher) when the user wants a thorough report but does not need it this instant.",
+      "instructions": "You are a deep researcher. Call the report tool for the requested topic and produce a thorough summary of its key findings.",
+      "allow": ["report"],
+      "async": true
     }
   ],
   "fanOut": [


### PR DESCRIPTION
## What changes

Adds the **Task form** of a sub-agent (`AsyncAgentSource`): the spawn-and-continue counterpart to `AgentSource`'s blocking Tool form. `Call` returns an ack immediately (`"sub-agent X started"`), the child runs in the **background** while the parent's turn finishes, and the child's result rejoins the conversation as **injected context on a later turn**. For long-running or fan-out-and-continue subtasks the parent shouldn't stall on. Host-wired via `SubAgentConfig.Async` and demoed as `deep_researcher` in kitchen-sink.

## Reviewer's guide

Read in this order:
1. [agent/async_agent_source.go](https://github.com/panyam/mcpkit/pull/1161/files#diff-9344253de52af3b2c74cd0b8543276c80dcdff08843a3db19a50b2df87dbbccb) — start here. `Call` guards → detach → spawn goroutine → ack; `OnComplete` on finish.
2. [agent/async_agent_source_test.go](https://github.com/panyam/mcpkit/pull/1161/files#diff-16c032ad5197b35fc1a34e764ed29ea8971c7530d3ba83841a9a926418eb8a41) — acceptance: acks-without-blocking (latch), depth guard, background event forwarding.
3. [agent/host/subagents.go](https://github.com/panyam/mcpkit/pull/1161/files#diff-21724f272556c58ee608c6c4ee3b765e2f4194f582f49c6b8af967c85369aa50) — `registerSubAgents` branches on `Async`; `onAsyncComplete` mirrors `tasks_bg.go` (Ingest a `subagent.completed` event + trigger + notice).
4. [agent/host/async_subagent_test.go](https://github.com/panyam/mcpkit/pull/1161/files#diff-9491de4a13cb003b7a876078f6f6e3efa7da4b2860015c8959a322dc31fa8667) — host acceptance: ack this turn, result injected on the *next* turn.
5. [agent/host/config.go](https://github.com/panyam/mcpkit/pull/1161/files#diff-6aff502cc5cae4b9d9769752e8638899bab121e09de870b5d1320cc892c6bf2d) — `SubAgentConfig.Async`.

Skim or skip: `examples/agents/kitchen-sink/*` (demo config + README), [docs/AGENT_COMPOSITION.md](https://github.com/panyam/mcpkit/pull/1161/files#diff-eb4e08c1812047fd2e31f27bd4879fe7c4ab94690580b2e559203992cb5fea0b) (Tool-vs-Task guidance).

## How it works

```
parent turn: model calls deep_researcher(task)
  AsyncAgentSource.Call:
    depth + budget guards (refuse before spawning)
    childCtx = DetachForBackground(ctx) + depth+1 + scope   # outlives the turn, keeps the session push
    go child.Run(childCtx, {task}) -> OnComplete(name, result, err)
    return "sub-agent started"                              # turn continues, answers user, ENDS
  ... child runs across later turns ...
  child finishes -> host.onAsyncComplete:
    injection.Ingest(IncomingEvent{subagent.completed, {name, result}})
    triggers.OnEvent(...)   # next turn picks it up (or fires a proactive turn)
next parent turn: drainInjectionLocked -> result is RoleSystem context
```

The one subtlety: the completion path is the **same seam** background tasks already use (`tasks_bg.go` ingests `task.completed`); async sub-agents ingest `subagent.completed`. No new delivery path, and the Runner doesn't change — the child is just a `ToolSource` whose `Call` happens to be non-blocking.

## Decision log

- **`core.DetachForBackground`, not `context.WithoutCancel`** — the child both outlives the turn *and* calls MCP server tools, so it needs the session-level push (the CLAUDE.md gotcha). Depth/scope are threaded onto the detached ctx so nested spawns + event tagging still compose.
- **Dedicated `AsyncAgentSource`** over an `Async bool` on `AgentSource` — the `Call` contract genuinely differs (ack vs answer). Host config still unifies them under one `subAgents` list via `SubAgentConfig.Async`.
- **Reused the `tasks_bg.go` injection path verbatim** — async sub-agent completion is the same shape as a background task completing; a surface renders it and the model reads it identically.
- **Explicitly not an MCP task** — no wire presence, no model-visible poll/cancel, ephemeral goroutine. When you need poll/cancel or restart-survival, use a real `ext/tasks` task; the docs draw this line.

## Risk / blast radius

- **Affects:** `agent/` (new leaf source, no change to existing types), `agent/host/` (async persona branch + completion handler; sync path untouched). `OnComplete` runs on the child goroutine — `injection.Ingest`, `emit`, `triggers.OnEvent`, `runProactiveTurn` are all safe from there (mirrors `tasks_bg.go`).
- **Tests:** agent (ack-non-blocking with teeth via a latch, depth guard, event forwarding) + host (ack-then-inject-on-later-turn, teeth-verified by removing the Ingest). Full `agent` + `agent/host` green under `-race`.
- **Be paranoid about:** the detached child surviving `App.Close()` — it holds a detached ctx, so a shutdown mid-flight lets it run to completion and then Ingest into a policy no turn will drain; acceptable (ephemeral, best-effort), documented as "not durable."

## Before / after

```
before: every sub-agent is call-and-block — delegating a long report stalls
        the parent (and the user) for the whole subtree.

after (kitchen-sink, deep_researcher async):
  you> kick off deep research on event-driven architectures
  asst> started deep_researcher in the background — I'll share when it's ready
  you> meanwhile, what's the capital of France?      # turn didn't stall
  asst> Paris.
  [sub-agent deep_researcher finished]
  you> what did the research find?
  asst> <uses the injected report>                    # result rejoined later
```

## Out of scope (deferred)

- Model-visible **poll/cancel** of an in-flight async sub-agent → use a real `ext/tasks` task (documented).
- **Async fan-out** (spawn N, none join, all inject) — a combination of this + `FanOutSource`, not this primitive.

