### PR TITLE
feat(agent): aggregate step/token tree budget (1032)

### DIFF
--- a/agent/host/app.go
+++ b/agent/host/app.go
@@ -536,6 +536,9 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 		MaxSteps:         cfg.MaxSteps,
 		TracerProvider:   o.tp,
 		MeterProvider:    o.mp,
+		// Only the main Runner carries the tree budget; sub-agent / fan-out /
+		// team member Runners inherit the shared counter through ctx.
+		TreeBudget: agent.TreeBudget{MaxSteps: cfg.MaxTreeSteps, MaxTokens: cfg.MaxTreeTokens},
 	}
 	// Only set Approval when a policy exists: a nil *TieredApproval boxed in
 	// the interface would read as non-nil and gate every call to a deny.

--- a/agent/host/config.go
+++ b/agent/host/config.go
@@ -25,6 +25,13 @@ type Config struct {
 	// MaxSteps caps model calls per turn. Zero uses the agent default.
 	MaxSteps int `json:"maxSteps,omitempty"`
 
+	// MaxTreeSteps and MaxTreeTokens cap the AGGREGATE model steps / tokens
+	// across a turn's whole sub-agent tree (parent + sub-agents + fan-out
+	// members + handoff rounds), not just per-Runner MaxSteps. Zero means
+	// unbounded. The safety rail for deep or chatty multi-agent trees.
+	MaxTreeSteps  int `json:"maxTreeSteps,omitempty"`
+	MaxTreeTokens int `json:"maxTreeTokens,omitempty"`
+
 	// Servers lists the MCP servers to connect.
 	Servers []ServerConfig `json:"servers"`
 

--- a/agent/host/tree_budget_test.go
+++ b/agent/host/tree_budget_test.go
@@ -1,0 +1,42 @@
+package host
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/panyam/mcpkit/agent"
+	"github.com/panyam/mcpkit/core"
+)
+
+// TestAppTreeBudgetBoundsTheTurn is the 1032 host wiring: Config.MaxTreeSteps
+// reaches the main Runner as a TreeBudget, so a chatty agent is stopped at the
+// aggregate cap (here it spins by calling an unknown tool, which continues the
+// turn) rather than running to its own MaxSteps.
+func TestAppTreeBudgetBoundsTheTurn(t *testing.T) {
+	ts := startTestServer(t)
+	turns := make([]agent.StubTurn, 10)
+	for i := range turns {
+		turns[i] = agent.StubTurn{ToolCalls: []agent.ToolCall{{
+			ID: "x", Name: "nope", Args: core.NewRawJSON(json.RawMessage(`{}`)),
+		}}}
+	}
+	stub := agent.NewStubProvider(turns...)
+
+	cfg := testConfig(ts.URL)
+	cfg.MaxSteps = 20
+	cfg.MaxTreeSteps = 3
+	app, err := NewApp(cfg, nil, strings.NewReader(""), WithProvider(stub))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Close()
+
+	if err := app.RunTurn(context.Background(), "go"); err == nil {
+		t.Fatal("a turn exceeding the tree step budget should fail")
+	}
+	if n := len(stub.Requests()); n != 3 {
+		t.Fatalf("tree budget should have capped the turn at 3 model calls, got %d", n)
+	}
+}

--- a/agent/runner.go
+++ b/agent/runner.go
@@ -63,6 +63,15 @@ type RunnerConfig struct {
 	// MaxSteps caps model calls per turn. Zero means DefaultMaxSteps.
 	MaxSteps int
 
+	// TreeBudget caps aggregate steps/tokens across the whole sub-agent tree
+	// (parent + sub-agents + fan-out members + handoff rounds), complementing
+	// the per-Runner MaxSteps. The Runner installs it on ctx at the top of a
+	// turn ONLY if the ctx does not already carry one, so a top-level Runner's
+	// budget is inherited and shared by every child run (do not set it on
+	// sub-agent Runner configs — they inherit it). Zero (both dimensions) is no
+	// budget. Equivalent to calling WithTreeBudget on the turn ctx yourself.
+	TreeBudget TreeBudget
+
 	// TracerProvider opts the Runner into SEP 414 span emission:
 	// agent.turn per Run, agent.step per model call, agent.tool per
 	// dispatch, with ctx threading so client-side dispatch spans (and
@@ -259,6 +268,14 @@ func (r *Runner) RunTurn(ctx context.Context, req TurnRequest) (*TurnResult, err
 			}
 		}()
 	}
+	// Install the aggregate tree budget only if one is not already threaded on
+	// ctx: the top-level Runner installs it and every sub-agent run inherits the
+	// same shared counter, so the totals are aggregate across the tree.
+	if !r.cfg.TreeBudget.zero() && treeBudgetFrom(ctx) == nil {
+		ctx = WithTreeBudget(ctx, r.cfg.TreeBudget)
+	}
+	treeBudget := treeBudgetFrom(ctx)
+
 	ctx, turnSpan := r.cfg.TracerProvider.StartSpan(ctx, "agent.turn")
 	defer turnSpan.End()
 	turnStart := time.Now()
@@ -287,6 +304,11 @@ func (r *Runner) RunTurn(ctx context.Context, req TurnRequest) (*TurnResult, err
 	var usage Usage
 
 	for step := 1; step <= r.cfg.MaxSteps; step++ {
+		// Aggregate tree budget: charge one step (and reject if prior steps
+		// already blew the token cap) before spending another model call.
+		if !treeBudget.consumeStep() {
+			return nil, r.failSpan(emit, turnSpan, fmt.Errorf("%w (aggregate across the agent tree)", ErrTreeBudget))
+		}
 		stepCtx, stepSpan := r.cfg.TracerProvider.StartSpan(ctx, "agent.step",
 			core.Attribute{Key: "agent.step", Value: fmt.Sprint(step)})
 
@@ -328,6 +350,7 @@ func (r *Runner) RunTurn(ctx context.Context, req TurnRequest) (*TurnResult, err
 		if resp.Usage != nil {
 			usage.InputTokens += resp.Usage.InputTokens
 			usage.OutputTokens += resp.Usage.OutputTokens
+			treeBudget.addTokens(resp.Usage.InputTokens + resp.Usage.OutputTokens)
 		}
 
 		assistant := Message{Role: RoleAssistant, Text: resp.Text, ToolCalls: resp.ToolCalls}
@@ -445,6 +468,7 @@ func (r *Runner) finalizeStructured(ctx context.Context, instructions string, ms
 		if resp.Usage != nil {
 			usage.InputTokens += resp.Usage.InputTokens
 			usage.OutputTokens += resp.Usage.OutputTokens
+			treeBudgetFrom(ctx).addTokens(resp.Usage.InputTokens + resp.Usage.OutputTokens)
 		}
 		last = resp.Text
 		if json.Valid([]byte(last)) {

--- a/agent/tree_budget.go
+++ b/agent/tree_budget.go
@@ -1,0 +1,88 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+)
+
+// ErrTreeBudget is returned (wrapped) by the Runner when a ctx-threaded
+// TreeBudget is exhausted mid-turn — the aggregate step or token cap across the
+// whole sub-agent tree was hit. For a sub-agent it surfaces as an IsError result
+// (AgentSource softens a child error), so the parent turn continues; for the
+// top-level Runner the turn fails, like ErrMaxSteps.
+var ErrTreeBudget = errors.New("agent: tree budget exhausted")
+
+// TreeBudget caps the TOTAL model steps and/or tokens summed over a turn's whole
+// agent tree — the parent Runner plus every sub-agent, fan-out member, and
+// handoff round beneath it. It is the aggregate cost guard complementary to the
+// per-source depth cap, the call-count budget (WithAgentCallBudget), and each
+// Runner's own MaxSteps. A zero field means that dimension is unbounded.
+type TreeBudget struct {
+	// MaxSteps caps total model calls across the tree. Zero means unbounded.
+	MaxSteps int
+	// MaxTokens caps total tokens (input + output, as reported by providers)
+	// across the tree. Zero means unbounded. Enforced post-hoc — a turn can
+	// overshoot by at most one step's output, since usage is known only after a
+	// model call.
+	MaxTokens int
+}
+
+// zero reports whether the budget constrains nothing (both dimensions off).
+func (b TreeBudget) zero() bool { return b.MaxSteps <= 0 && b.MaxTokens <= 0 }
+
+type treeBudgetKey struct{}
+
+// treeBudgetState is the live shared counter installed on ctx. One instance is
+// shared by every Runner in a tree (ctx values propagate to child runs), so the
+// step and token totals are aggregate, not per-Runner.
+type treeBudgetState struct {
+	stepsLeft  atomic.Int64 // remaining steps; unused when maxSteps == 0
+	maxSteps   int64        // 0 = unbounded
+	tokensUsed atomic.Int64
+	maxTokens  int64 // 0 = unbounded
+}
+
+// WithTreeBudget installs a shared aggregate budget on ctx, consulted by every
+// Runner that runs under it (parent + sub-agents). Call it once at the top of a
+// turn; child runs inherit the same live counter through ctx. A zero TreeBudget
+// is a no-op (returns ctx unchanged). Installing again on a ctx that already
+// carries a budget replaces it — but the Runner only installs when absent, so
+// the top-level budget is the one the whole tree shares.
+func WithTreeBudget(ctx context.Context, b TreeBudget) context.Context {
+	if b.zero() {
+		return ctx
+	}
+	st := &treeBudgetState{maxSteps: int64(b.MaxSteps), maxTokens: int64(b.MaxTokens)}
+	st.stepsLeft.Store(int64(b.MaxSteps))
+	return context.WithValue(ctx, treeBudgetKey{}, st)
+}
+
+func treeBudgetFrom(ctx context.Context) *treeBudgetState {
+	st, _ := ctx.Value(treeBudgetKey{}).(*treeBudgetState)
+	return st
+}
+
+// consumeStep charges one step and returns false when the aggregate step budget
+// is exhausted or the token budget was already exceeded by prior steps. Called
+// at the top of each Runner step; nil state (no budget) always passes.
+func (st *treeBudgetState) consumeStep() bool {
+	if st == nil {
+		return true
+	}
+	if st.maxTokens > 0 && st.tokensUsed.Load() >= st.maxTokens {
+		return false
+	}
+	if st.maxSteps > 0 && st.stepsLeft.Add(-1) < 0 {
+		return false
+	}
+	return true
+}
+
+// addTokens folds a step's usage into the shared token total. Nil state is a
+// no-op.
+func (st *treeBudgetState) addTokens(n int) {
+	if st != nil && st.maxTokens > 0 && n > 0 {
+		st.tokensUsed.Add(int64(n))
+	}
+}

--- a/agent/tree_budget_test.go
+++ b/agent/tree_budget_test.go
@@ -1,0 +1,122 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+// spinTurn is a stub turn that always calls a no-op tool, so a Runner keeps
+// looping (one step per turn) until a step cap stops it.
+func spinTurn() StubTurn {
+	return StubTurn{ToolCalls: []ToolCall{{ID: "s", Name: "noop", Args: core.NewRawJSON(json.RawMessage(`{}`))}}}
+}
+
+func noopSource(t *testing.T) *FuncSource {
+	t.Helper()
+	src := NewFuncSource()
+	AddFunc(src, "noop", "does nothing", func(ctx context.Context, in struct{}) (string, error) { return "ok", nil })
+	return src
+}
+
+// TestTreeBudget_StepCapAbortsTurn asserts the aggregate step budget stops a
+// chatty single Runner before its own MaxSteps, with ErrTreeBudget.
+func TestTreeBudget_StepCapAbortsTurn(t *testing.T) {
+	// The provider would spin forever; MaxSteps is high, but the tree budget of
+	// 3 steps must stop it first.
+	turns := make([]StubTurn, 10)
+	for i := range turns {
+		turns[i] = spinTurn()
+	}
+	stub := NewStubProvider(turns...)
+	r, err := NewRunner(RunnerConfig{Provider: stub, Tools: noopSource(t), MaxSteps: 20, TreeBudget: TreeBudget{MaxSteps: 3}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = r.Run(context.Background(), []Message{{Role: RoleUser, Text: "go"}}, nil)
+	if !errors.Is(err, ErrTreeBudget) {
+		t.Fatalf("want ErrTreeBudget, got %v", err)
+	}
+	// exactly 3 model calls happened (the budget), not 20 (MaxSteps).
+	if n := len(stub.Requests()); n != 3 {
+		t.Fatalf("tree step budget = 3, but %d model calls happened", n)
+	}
+}
+
+// usageTurn is a text turn that also reports token usage.
+func usageTurn(text string, in, out int) StubTurn {
+	return StubTurn{Deltas: []Delta{
+		{Kind: DeltaText, Text: text},
+		{Kind: DeltaUsage, Usage: &Usage{InputTokens: in, OutputTokens: out}},
+		{Kind: DeltaFinish, FinishReason: "tool_calls"},
+	}}
+}
+
+// spinUsageTurn spins (calls noop) AND reports usage, so a multi-step run
+// accumulates tokens across steps.
+func spinUsageTurn(in, out int) StubTurn {
+	return StubTurn{Deltas: []Delta{
+		{Kind: DeltaToolCallStart, Index: 0, ToolCallID: "s", ToolName: "noop", Text: "{}"},
+		{Kind: DeltaUsage, Usage: &Usage{InputTokens: in, OutputTokens: out}},
+		{Kind: DeltaFinish, FinishReason: "tool_calls"},
+	}}
+}
+
+// TestTreeBudget_TokenCapAbortsTurn asserts the token budget stops the turn once
+// cumulative usage exceeds MaxTokens (post-hoc: after the step that crosses it).
+func TestTreeBudget_TokenCapAbortsTurn(t *testing.T) {
+	// each step reports 40 tokens; a 90-token budget allows steps 1 and 2 (80),
+	// then step 3's top-of-loop check sees 80 < 90 so it runs (120), and step 4
+	// is rejected. So 3 model calls, then ErrTreeBudget.
+	turns := make([]StubTurn, 10)
+	for i := range turns {
+		turns[i] = spinUsageTurn(30, 10)
+	}
+	stub := NewStubProvider(turns...)
+	r, _ := NewRunner(RunnerConfig{Provider: stub, Tools: noopSource(t), MaxSteps: 20, TreeBudget: TreeBudget{MaxTokens: 90}})
+	_, err := r.Run(context.Background(), []Message{{Role: RoleUser, Text: "go"}}, nil)
+	if !errors.Is(err, ErrTreeBudget) {
+		t.Fatalf("want ErrTreeBudget from token cap, got %v", err)
+	}
+	if n := len(stub.Requests()); n != 3 {
+		t.Fatalf("token budget should have allowed 3 steps (30+30+30=90 crossed), got %d", n)
+	}
+}
+
+// TestTreeBudget_SharedAcrossSubAgents asserts the budget is AGGREGATE: a
+// parent's steps and a sub-agent's steps draw from ONE shared counter, so the
+// total across the tree hits the cap — not one cap per Runner. With a 3-step
+// budget, the parent's step 1 (delegate) + the child's steps 2 & 3 exhaust it;
+// then the parent cannot continue either.
+func TestTreeBudget_SharedAcrossSubAgents(t *testing.T) {
+	// child spins forever if allowed; the shared budget is what stops it.
+	childTurns := make([]StubTurn, 10)
+	for i := range childTurns {
+		childTurns[i] = spinTurn()
+	}
+	childStub := NewStubProvider(childTurns...)
+	child, _ := NewRunner(RunnerConfig{Provider: childStub, Tools: noopSource(t), MaxSteps: 20})
+	as, _ := NewAgentSource(AgentSourceConfig{Name: "worker", Description: "delegates", Runner: child})
+
+	src := NewMultiSource()
+	_ = src.Add("sub", as)
+	parent := NewStubProvider(
+		StubTurn{ToolCalls: []ToolCall{{ID: "d1", Name: "worker", Args: core.NewRawJSON(json.RawMessage(`{"task":"spin"}`))}}},
+		StubTurn{Text: "unreachable — budget is gone"},
+	)
+	parentStub := parent
+	r, _ := NewRunner(RunnerConfig{Provider: parent, Tools: src, MaxSteps: 20, TreeBudget: TreeBudget{MaxSteps: 3}})
+
+	_, err := r.Run(context.Background(), []Message{{Role: RoleUser, Text: "go"}}, nil)
+	if !errors.Is(err, ErrTreeBudget) {
+		t.Fatalf("tree budget shared across parent+child should exhaust, got %v", err)
+	}
+	// One shared counter of 3: parent made 1 model call, child made 2 (total 3).
+	// A per-Runner budget would let each run 3, and neither would exhaust.
+	if pn, cn := len(parentStub.Requests()), len(childStub.Requests()); pn != 1 || cn != 2 {
+		t.Fatalf("aggregate step count wrong: parent=%d child=%d, want 1+2=3 shared", pn, cn)
+	}
+}

--- a/cmd/agentchat/main.go
+++ b/cmd/agentchat/main.go
@@ -193,6 +193,8 @@ func newRoot() (*cobra.Command, *viper.Viper) {
 	fl.String("api-key-env", "", "env var holding the model API key")
 	fl.String("instructions", "You are a helpful assistant with access to tools.", "system prompt (when no config)")
 	fl.Int("max-steps", 0, "max model calls per turn (0 = default)")
+	fl.Int("max-tree-steps", 0, "cap total model steps across a turn's whole sub-agent tree (0 = unbounded)")
+	fl.Int("max-tree-tokens", 0, "cap total tokens across a turn's whole sub-agent tree (0 = unbounded)")
 	fl.String("active", "", "override the active chat connection at startup (a name in the config's connections; default = the config's active)")
 	fl.Bool("persist-config", false, "persist runtime picks (/provider, /approve) to a sibling <config>.local.json overlay, merged over the base config on the next start (needs --config)")
 	fl.String("session-store", "", "session persistence backend: memory | sqlite://path.db | redis://host:port | postgres://user:pass@host:port/db (empty = off)")
@@ -240,6 +242,14 @@ func runChat(v *viper.Viper) error {
 	)
 	if err != nil {
 		return err
+	}
+	// Tree-budget flags override the config (and apply to the flag-built config
+	// too), so the aggregate cost rail can be set without editing JSON.
+	if n := v.GetInt("max-tree-steps"); n > 0 {
+		cfg.MaxTreeSteps = n
+	}
+	if n := v.GetInt("max-tree-tokens"); n > 0 {
+		cfg.MaxTreeTokens = n
 	}
 	// --active overrides the config's chat connection at startup, so a real
 	// provider can be selected by env/flag without editing the config

--- a/docs/AGENT_COMPOSITION.md
+++ b/docs/AGENT_COMPOSITION.md
@@ -276,7 +276,16 @@ Host: `SubAgentConfig.Async` builds it; demoed as `deep_researcher` in
 - Context: handoff-via-injection + per-agent persistent context (the actor
   form above) — a generalization of `Team`.
 - Control: upward signals + runner-control meta-tools
-  + interruptible turn (1036), aggregate step/token tree budget (1032).
+  + interruptible turn (1036).
+  **`TreeBudget` shipped (1032):** a ctx-threaded aggregate cap on total model
+  **steps** and **tokens** across a turn's whole tree (parent + sub-agents +
+  fan-out members + handoff rounds), consulted by the Runner per step. The
+  top-level Runner installs it (`RunnerConfig.TreeBudget`, host `Config.MaxTree*`
+  / agentchat `--max-tree-*`); every child run inherits the same shared counter
+  through ctx. Exhaustion aborts with `ErrTreeBudget` (a sub-agent's becomes a
+  non-fatal `IsError` result). It completes the cost-guard set alongside the
+  per-source depth cap, the call-count budget (`WithAgentCallBudget`), and
+  per-Runner `MaxSteps`/`Team.MaxHandoffs`.
   **1033 is closed**: `AgentSource.InputSchema` (typed subtask in) + `Structured`
   output (a child with a `ResponseSchema` returns coerced JSON) + `Team.OnEvent`
   (member events tagged by active agent name, rendered attributed as

--- a/examples/agents/kitchen-sink/run.sh
+++ b/examples/agents/kitchen-sink/run.sh
@@ -75,6 +75,11 @@ args=(
 )
 [ "$MEMORY" = "1" ] && args+=(--memory --memory-inject-recall)
 [ -n "$ACTIVE" ] && args+=(--active "$ACTIVE")
+# Aggregate cost rail across the sub-agent tree (unset = unbounded). Try
+# MAX_TREE_STEPS=4 just run and ask for the review team + deep research to see a
+# chatty tree get capped.
+[ -n "$MAX_TREE_STEPS" ] && args+=(--max-tree-steps "$MAX_TREE_STEPS")
+[ -n "$MAX_TREE_TOKENS" ] && args+=(--max-tree-tokens "$MAX_TREE_TOKENS")
 # Only override the config's embedder role when EMBED_MODEL is set.
 if [ -n "$EMBED_MODEL" ]; then
 	args+=(--memory-embed-model "$EMBED_MODEL" --memory-embed-url "$EMBED_URL" --memory-embed-dim "$EMBED_DIM")


### PR DESCRIPTION
## What changes

Adds `TreeBudget`: an **aggregate** cap on total model **steps** and **tokens** summed over a turn's whole sub-agent tree (parent + sub-agents + fan-out members + handoff rounds) — the safety rail for deep or chatty multi-agent trees, complementing the per-Runner `MaxSteps` and the existing depth / call-count / handoff caps. Host-configurable (`Config.MaxTreeSteps`/`MaxTreeTokens`, agentchat `--max-tree-*`).

## Reviewer's guide

Read in this order:
1. [agent/tree_budget.go](https://github.com/panyam/mcpkit/pull/1162/files#diff-a738765fbe624c6aaea795f7d21f1d35f5fa1bda06727f978a5a20f11ada42b5) — start here. The ctx-threaded shared counter (`treeBudgetState`), `WithTreeBudget`, `consumeStep`/`addTokens`, `ErrTreeBudget`.
2. [agent/runner.go](https://github.com/panyam/mcpkit/pull/1162/files#diff-6d787b427ac08cd61669af7e34ff0b747c4264d20b31b21b681a2ec2c826d9f0) — install-if-absent at turn start, the `consumeStep` check at the top of the step loop, and `addTokens` after usage (incl. the finalizing structured `Generate`).
3. [agent/tree_budget_test.go](https://github.com/panyam/mcpkit/pull/1162/files#diff-bfc898cb00674b387d7cc1ceb34b87bf1795df69c7ddb5cea608b3b3e4b0fae5) — step cap, token cap, and the aggregate-across-a-sub-agent-tree proof.
4. `agent/host/{config,app}.go` + [agent/host/tree_budget_test.go](https://github.com/panyam/mcpkit/pull/1162/files#diff-757b91c29cd2a138253bb09c6eddb3754f3469c99489d5f0ab85cf09047c6d4f) — `Config.MaxTree*` → the **main** Runner only; children inherit via ctx.
5. [cmd/agentchat/main.go](https://github.com/panyam/mcpkit/pull/1162/files#diff-ce3956549c93b4983f18090136a2139c3c92d38408e923245f5e9ba628bcc98a), [examples/agents/kitchen-sink/run.sh](https://github.com/panyam/mcpkit/pull/1162/files#diff-2bddbe5c136c0ba080a2f14842ebbb769ebc00c0b071cd9997a338e35bb1ae04) — flags.

Skim or skip: [docs/AGENT_COMPOSITION.md](https://github.com/panyam/mcpkit/pull/1162/files#diff-eb4e08c1812047fd2e31f27bd4879fe7c4ab94690580b2e559203992cb5fea0b).

## How it works — why sharing is free

```
Runner.RunTurn(ctx):
  if cfg.TreeBudget set AND ctx has no budget yet:   # TOP installs, children inherit
      ctx = WithTreeBudget(ctx, cfg.TreeBudget)
  tb = treeBudgetFrom(ctx)                            # one shared *treeBudgetState
  for each step:
      if !tb.consumeStep(): abort ErrTreeBudget       # pre-decrement steps; reject if tokens already blown
      resp = model()
      tb.addTokens(resp.Usage.in + out)               # post-hoc token tally

AgentSource / FanOutSource / Team / async all thread the child ctx from the
parent (withAgentDepth(ctx,…) / DetachForBackground(ctx)), and ctx VALUES
propagate — so the child Runner's treeBudgetFrom(ctx) returns the SAME counter.
No plumbing; the aggregate falls out of the propagation AgentSource already does.
```

The one subtlety a reviewer would check: the **install-if-absent** guard is what makes it aggregate — only the top-level Runner installs, so every child shares one counter (a per-Runner install would give each sub-agent its own budget, defeating the point).

## Decision log

- **Error on exhaustion (`ErrTreeBudget`), not graceful-partial** — consistent with `ErrMaxSteps`; and `AgentSource` already converts a child's error into a non-fatal `IsError` result, so a sub-agent hitting the cap doesn't hard-fail the parent (though the tree is then genuinely out of budget, so the parent's own next step also stops — correct).
- **Steps pre-decremented, tokens post-hoc** — you only know a call's usage after it returns, so the token check is at the *next* step's top; a turn can overshoot `MaxTokens` by at most one step's output (documented).
- **Top-installs-only** over threading a budget object through every sub-agent config — the whole point is one shared counter; ctx propagation already gives it to us.
- **Uses provider-reported `Usage`**, not an estimator — token *estimation* is #1007's job; this budget is exact where providers report usage.

## Risk / blast radius

- **Affects:** the Runner step loop (one guard + one tally; no-op when no budget is set — `nil` state fast-paths). Every existing turn is unchanged with `TreeBudget` zero.
- **Tests:** step cap, token cap, aggregate-across-sub-agents (agent) + host wiring; step-cap teeth verified (removing the check spins to stub exhaustion). Full `agent` + `agent/host` green under `-race`.
- **Be paranoid about:** concurrent decrements — `consumeStep`/`addTokens` use `atomic.Int64`, and fan-out members hit the same counter from parallel goroutines (covered by the `-race` run).

## Before / after

```
before: a runaway multi-agent tree (deep nesting × chatty children × handoffs)
        is bounded only per-Runner (MaxSteps each) + a call-COUNT budget —
        total steps/tokens across the tree are unbounded.

after (MAX_TREE_STEPS=3):
  parent step 1 (delegate) → child steps 2,3 → budget exhausted
  → ErrTreeBudget; total model calls across the tree = 3, not 3-per-Runner.
```

## Out of scope (deferred)

- Per-role / per-subtree sub-budgets (one flat tree budget here).
- Token estimation without provider `Usage` → #1007.

