### PR TITLE
feat(agent): upward signal channel (child->parent) — 1036 piece A

### DIFF
--- a/agent/agent_source.go
+++ b/agent/agent_source.go
@@ -164,6 +164,12 @@ func (s *AgentSource) Call(ctx context.Context, name string, args map[string]any
 		childScope = parent + "/" + s.cfg.Name
 	}
 	childCtx := withAgentScope(withAgentDepth(ctx, depth+1), childScope)
+	// Hand the child the sink of the dispatch that spawned it (issue 1165), so
+	// the child's signal_parent raises to THIS parent — the child's own dispatch
+	// would otherwise shadow it. nil at the top level (no parent to signal).
+	if ps := dispatchSinkFrom(ctx); ps != nil {
+		childCtx = withParentSink(childCtx, ps)
+	}
 
 	emit := func(Event) {}
 	if s.cfg.OnEvent != nil {

--- a/agent/events.go
+++ b/agent/events.go
@@ -43,8 +43,14 @@ const (
 	// carries the before/after message counts. Surfaces can render a
 	// "compacted context" note; evals can assert it happened.
 	EventCompaction EventKind = "compaction"
-	EventTurnEnd    EventKind = "turn-end"
-	EventError      EventKind = "error"
+	// EventSignal marks that a child agent raised an upward Signal, observed by
+	// the parent Runner at the dispatch join (issue 1165). Signal carries the
+	// raised signal. It is the observability projection of the control-axis "up"
+	// channel — a surface renders "child escalated"; the signal's effect on the
+	// turn (inject / abort) is the SignalPolicy's job, not this event's.
+	EventSignal  EventKind = "signal"
+	EventTurnEnd EventKind = "turn-end"
+	EventError   EventKind = "error"
 )
 
 // Event is one increment of a running turn, the payload surfaces consume
@@ -87,6 +93,9 @@ type Event struct {
 
 	// Compaction carries the before/after message counts on compaction.
 	Compaction *CompactionInfo `json:"compaction,omitempty"`
+
+	// Signal is the upward signal a child raised, on EventSignal.
+	Signal *Signal `json:"signal,omitempty"`
 }
 
 // CompactionInfo reports what a compaction pass did: the message count

--- a/agent/host/app.go
+++ b/agent/host/app.go
@@ -539,6 +539,10 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 		// Only the main Runner carries the tree budget; sub-agent / fan-out /
 		// team member Runners inherit the shared counter through ctx.
 		TreeBudget: agent.TreeBudget{MaxSteps: cfg.MaxTreeSteps, MaxTokens: cfg.MaxTreeTokens},
+		// The main agent is the parent that reacts to upward sub-agent signals
+		// (issue 1165); sub-agent Runners do not set a policy (they raise, they
+		// do not react). Nil for the inject-and-continue default.
+		SignalPolicy: signalPolicyFor(cfg.SignalPolicy),
 	}
 	// Only set Approval when a policy exists: a nil *TieredApproval boxed in
 	// the interface would read as non-nil and gate every call to a deny.

--- a/agent/host/config.go
+++ b/agent/host/config.go
@@ -145,10 +145,11 @@ type SubAgentConfig struct {
 
 	// CanSignal, when true, gives the persona the signal_parent control tool
 	// (issue 1165), so it can raise an upward Signal to the main agent —
-	// "escalate" / "cancel_siblings" / "custom". The main agent reacts per
-	// Config.SignalPolicy (inject-and-continue by default). False (the default)
-	// keeps the persona server-tools-only. Ignored for async personas (a
-	// detached child has no live parent dispatch to signal).
+	// "escalate" or "custom" (reporting only its own state; it has no knowledge
+	// of sibling agents). The main agent reacts per Config.SignalPolicy
+	// (inject-and-continue by default). False (the default) keeps the persona
+	// server-tools-only. Ignored for async personas (a detached child has no
+	// live parent dispatch to signal).
 	CanSignal bool `json:"canSignal,omitempty"`
 
 	// Async, when true, builds the persona as the spawn-and-continue Task form

--- a/agent/host/config.go
+++ b/agent/host/config.go
@@ -32,6 +32,14 @@ type Config struct {
 	MaxTreeSteps  int `json:"maxTreeSteps,omitempty"`
 	MaxTreeTokens int `json:"maxTreeTokens,omitempty"`
 
+	// SignalPolicy selects how the main agent reacts to an upward Signal a
+	// signalling sub-agent raises (issue 1165), read at the dispatch join:
+	//   - "" / "inject" — inject the signal as context and continue (default).
+	//   - "abort_on_escalate" — end the turn when a child raises "escalate".
+	// Either way the signal is injected so the main model sees it. Only meaningful
+	// alongside a sub-agent with CanSignal.
+	SignalPolicy string `json:"signalPolicy,omitempty"`
+
 	// Servers lists the MCP servers to connect.
 	Servers []ServerConfig `json:"servers"`
 
@@ -134,6 +142,14 @@ type SubAgentConfig struct {
 	// this schema instead of free text (structured output, 1033) — the parent
 	// gets typed output back. Empty returns text.
 	ResponseSchema json.RawMessage `json:"responseSchema,omitempty"`
+
+	// CanSignal, when true, gives the persona the signal_parent control tool
+	// (issue 1165), so it can raise an upward Signal to the main agent —
+	// "escalate" / "cancel_siblings" / "custom". The main agent reacts per
+	// Config.SignalPolicy (inject-and-continue by default). False (the default)
+	// keeps the persona server-tools-only. Ignored for async personas (a
+	// detached child has no live parent dispatch to signal).
+	CanSignal bool `json:"canSignal,omitempty"`
 
 	// Async, when true, builds the persona as the spawn-and-continue Task form
 	// (agent.AsyncAgentSource, 1035): the delegate tool acks immediately and the

--- a/agent/host/render.go
+++ b/agent/host/render.go
@@ -87,6 +87,8 @@ func (r *renderer) handle(e agent.Event) {
 		fmt.Fprintf(r.out, "%s\n", r.dim("  ◼ "+e.ToolCall.Name+" cancelled: "+snippet(e.Reason, 120)))
 	case agent.EventToolUnavailable:
 		fmt.Fprintf(r.out, "%s\n", r.dim("  ⊘ "+e.ToolCall.Name+" unavailable: "+snippet(e.Reason, 120)))
+	case agent.EventSignal:
+		fmt.Fprintf(r.out, "%s\n", r.dim("  ▲ signal "+string(e.Signal.Kind)+" from "+e.Signal.Source+": "+snippet(e.Signal.Note, 120)))
 	case agent.EventError:
 		r.breakLine()
 	}

--- a/agent/host/subagents.go
+++ b/agent/host/subagents.go
@@ -10,6 +10,16 @@ import (
 	"github.com/panyam/mcpkit/core"
 )
 
+// signalPolicyFor maps a Config.SignalPolicy string to an agent.SignalPolicy:
+// "abort_on_escalate" -> agent.AbortOnEscalate; "" / "inject" / anything else
+// -> nil (inject-and-continue, the default).
+func signalPolicyFor(name string) agent.SignalPolicy {
+	if name == "abort_on_escalate" {
+		return agent.AbortOnEscalate
+	}
+	return nil
+}
+
 // registerSubAgents builds each configured persona as an agent.AgentSource and
 // adds it to the aggregate, so the main agent delegates to it as a tool. Each
 // persona runs a child Runner on the SHARED provider over a FilterSource-
@@ -129,6 +139,15 @@ func (a *App) personaRunnerConfig(sub SubAgentConfig, serverTools *agent.MultiSo
 			allow[name] = true
 		}
 		tools = agent.NewFilterSource(serverTools, func(d core.ToolDef) bool { return allow[d.Name] })
+	}
+	// A signalling persona gets the signal_parent control tool alongside its
+	// (filtered) server tools. It is a control channel, not ambient parent state,
+	// so it does not violate A7 (memory-free personas).
+	if sub.CanSignal && !sub.Async {
+		agg := agent.NewMultiSource()
+		_ = agg.Add("persona-tools", tools)
+		_ = agg.Add("signal", agent.NewSignalSource())
+		tools = agg
 	}
 	return agent.RunnerConfig{
 		Provider:       provider,

--- a/agent/host/subagents_test.go
+++ b/agent/host/subagents_test.go
@@ -115,6 +115,50 @@ func TestAppSubAgentSnakeCaseName(t *testing.T) {
 	}
 }
 
+// TestAppSubAgentSignalsSurface: a CanSignal persona raises signal_parent, and
+// the main agent surfaces it as an EventSignal (wrapped in HostRunnerEvent) and
+// continues (default inject-and-continue policy). Guards the host wiring of
+// issue 1165 — the persona gets the control tool and the main Runner reacts.
+func TestAppSubAgentSignalsSurface(t *testing.T) {
+	ts := startTestServer(t)
+	stub := agent.NewStubProvider(
+		agent.StubTurn{ToolCalls: []agent.ToolCall{{ID: "d1", Name: "worker",
+			Args: core.NewRawJSON(json.RawMessage(`{"task":"go"}`))}}},
+		agent.StubTurn{ToolCalls: []agent.ToolCall{{ID: "s1", Name: agent.SignalParentToolName,
+			Args: core.NewRawJSON(json.RawMessage(`{"kind":"escalate","note":"found it"}`))}}},
+		agent.StubTurn{Text: "child done"},
+		agent.StubTurn{Text: "synthesized"},
+	)
+
+	cfg := testConfig(ts.URL)
+	cfg.SubAgents = []SubAgentConfig{{
+		Name: "worker", Description: "does work", Instructions: "You work.", CanSignal: true,
+	}}
+	obs := &collectObserver{}
+	app, err := NewApp(cfg, nil, strings.NewReader(""), WithProvider(stub), WithObserver(obs))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Close()
+
+	if err := app.RunTurn(context.Background(), "delegate to worker"); err != nil {
+		t.Fatal(err)
+	}
+
+	var found *agent.Signal
+	for _, e := range obs.kinds(HostRunnerEvent) {
+		if e.RunnerEvent.Kind == agent.EventSignal {
+			found = e.RunnerEvent.Signal
+		}
+	}
+	if found == nil {
+		t.Fatal("no EventSignal surfaced; the persona could not signal the main agent")
+	}
+	if found.Kind != agent.SignalEscalate || found.Source != "worker" {
+		t.Fatalf("surfaced signal = %+v, want escalate from 'worker'", found)
+	}
+}
+
 func hasToolNamed(defs []core.ToolDef, name string) bool {
 	for _, d := range defs {
 		if d.Name == name {

--- a/agent/runner.go
+++ b/agent/runner.go
@@ -117,6 +117,15 @@ type RunnerConfig struct {
 	// pre-loop.
 	Compactor Compactor
 
+	// SignalPolicy, when non-nil, decides how this Runner (as a parent) reacts
+	// to the upward Signals its children raised during a dispatch, read at the
+	// join (issue 1165). It runs after the fan-out has joined, so it chooses
+	// only whether to abort the turn (SignalAction.AbortTurn -> ErrSignalAbort);
+	// the signals are injected into the next step as a RoleSystem note either
+	// way, so the parent model sees them. Nil means inject-and-continue. See
+	// AbortOnEscalate for the built-in deterministic policy.
+	SignalPolicy SignalPolicy
+
 	// ResponseSchema, when set, coerces the turn's final answer into
 	// structured output. After the tool loop reaches its terminal
 	// no-tool-call text, the Runner makes one additional Generate call with
@@ -384,13 +393,36 @@ func (r *Runner) RunTurn(ctx context.Context, req TurnRequest) (*TurnResult, err
 			return result, nil
 		}
 
-		toolMsgs := r.dispatch(stepCtx, step, resp.ToolCalls, tools, emit, reg)
+		toolMsgs, signals := r.dispatch(stepCtx, step, resp.ToolCalls, tools, emit, reg)
 		stepSpan.End()
 		if err := ctx.Err(); err != nil {
 			return nil, r.failSpan(emit, turnSpan, err)
 		}
+		// Tool results must immediately follow the assistant message that
+		// requested them (providers pair RoleTool with the assistant's tool
+		// calls), so append them first; a signal note goes after.
 		msgs = append(msgs, toolMsgs...)
 		added = append(added, toolMsgs...)
+		if len(signals) > 0 {
+			for i := range signals {
+				emit(Event{Kind: EventSignal, Step: step, Signal: &signals[i]})
+			}
+			if r.cfg.SignalPolicy != nil {
+				if act := r.cfg.SignalPolicy(signals); act.AbortTurn {
+					reason := act.Reason
+					if reason == "" {
+						reason = "child signalled abort"
+					}
+					return nil, r.failSpan(emit, turnSpan, fmt.Errorf("%w: %s", ErrSignalAbort, reason))
+				}
+			}
+			// Inject the signals as a RoleSystem note so the parent model sees
+			// them on the next step. Drained once from the sink, appended once —
+			// no transient-stacking (unlike a re-derived snapshot).
+			sigMsg := Message{Role: RoleSystem, Text: renderSignals(signals)}
+			msgs = append(msgs, sigMsg)
+			added = append(added, sigMsg)
+		}
 	}
 
 	return nil, r.failSpan(emit, turnSpan, fmt.Errorf("%w (%d steps)", ErrMaxSteps, r.cfg.MaxSteps))
@@ -516,10 +548,15 @@ func (g *callCancels) cancel(id string) {
 
 // dispatch runs the step's tool calls concurrently, serializes event
 // emission, and returns RoleTool messages in call order regardless of
-// completion order. When reg is non-nil each call runs under its own
-// child context registered by call ID, so a Control can cancel one call
-// without touching its siblings or the turn.
-func (r *Runner) dispatch(ctx context.Context, step int, calls []ToolCall, tools []core.ToolDef, emit func(Event), reg *callCancels) []Message {
+// completion order, plus any upward Signals the calls' sub-agents raised.
+// When reg is non-nil each call runs under its own child context registered by
+// call ID, so a Control can cancel one call without touching its siblings or
+// the turn. A fresh signal sink is installed per dispatch (not shared across
+// the tree): a sub-agent spawned by one of these calls raises into THIS sink,
+// its immediate parent's, and a nested dispatch shadows it for grandchildren.
+func (r *Runner) dispatch(ctx context.Context, step int, calls []ToolCall, tools []core.ToolDef, emit func(Event), reg *callCancels) ([]Message, []Signal) {
+	sink := &signalSink{}
+	ctx = withDispatchSink(ctx, sink)
 	results := make([]Message, len(calls))
 	var emitMu sync.Mutex
 	locked := func(ev Event) {
@@ -552,7 +589,7 @@ func (r *Runner) dispatch(ctx context.Context, step int, calls []ToolCall, tools
 		}(i, call)
 	}
 	wg.Wait()
-	return results
+	return results, sink.drain()
 }
 
 // toolReadOnly reports whether the named tool declares the readOnlyHint

--- a/agent/signal.go
+++ b/agent/signal.go
@@ -21,17 +21,19 @@ const (
 	// injected and the parent model decides.
 	SignalEscalate SignalKind = "escalate"
 
-	// SignalCancelSiblings asks the parent to cancel the child's in-flight
-	// siblings ("I found it; the others are wasted work"). In the
-	// non-interruptible turn (issue 1165) this intent is RECORDED and surfaced,
-	// but the siblings have already joined by the time the parent reads it at the
-	// dispatch barrier; acting on it mid-flight is the interruptible turn (issue
-	// 1167). Do not mistake it for working cancellation yet.
-	SignalCancelSiblings SignalKind = "cancel_siblings"
-
 	// SignalCustom carries an application-defined signal (named by Name, with an
 	// optional Data payload) for a SignalPolicy or the parent model to interpret.
 	SignalCustom SignalKind = "custom"
+
+	// A preemption signal ("I have a sufficient result; the parallel work is
+	// moot") is deliberately NOT defined here. It only has teeth once the parent
+	// can break the join barrier and cancel the other in-flight calls, which is
+	// the interruptible turn (issue 1167, piece C). It stays non-referential
+	// even there: the child reports its OWN sufficiency, and the parent — which
+	// alone holds the fan-out inventory — decides which siblings to cancel from
+	// its own prompt/policy. A child never names a sibling (it has no knowledge
+	// of them; A7). Defining it in piece A would ship a kind that no-ops (the
+	// siblings have already joined by the time the parent reads it).
 )
 
 // Signal is an upward message from a child agent to its parent Runner. It is
@@ -174,7 +176,7 @@ func RaiseSignal(ctx context.Context, sig Signal) bool {
 const SignalParentToolName = "signal_parent"
 
 type signalParentArgs struct {
-	// Kind is "escalate", "cancel_siblings", or "custom".
+	// Kind is "escalate" or "custom".
 	Kind string `json:"kind"`
 	// Note is a short reason surfaced to the parent.
 	Note string `json:"note,omitempty"`
@@ -189,13 +191,13 @@ type signalParentArgs struct {
 func NewSignalSource() *FuncSource {
 	fs := NewFuncSource()
 	_ = AddFunc(fs, SignalParentToolName,
-		"Raise a signal to the parent agent that spawned you. kind: 'escalate' (ask the parent to stop and handle your finding), 'cancel_siblings' (you found the answer; the parent's other in-flight sub-agents are wasted work), or 'custom' (a named signal). Use sparingly — only for a decisive result the parent must act on.",
+		"Raise a signal to the parent agent that spawned you. kind: 'escalate' (ask the parent to stop and handle your finding) or 'custom' (a named signal with your own findings). Report only your OWN state — you have no knowledge of other sub-agents; the parent decides what to do. Use sparingly, only for a decisive result the parent must act on.",
 		func(ctx context.Context, in signalParentArgs) (string, error) {
 			kind := SignalKind(in.Kind)
 			switch kind {
-			case SignalEscalate, SignalCancelSiblings, SignalCustom:
+			case SignalEscalate, SignalCustom:
 			default:
-				return "", fmt.Errorf("unknown signal kind %q (want escalate, cancel_siblings, or custom)", in.Kind)
+				return "", fmt.Errorf("unknown signal kind %q (want escalate or custom)", in.Kind)
 			}
 			if RaiseSignal(ctx, Signal{Kind: kind, Name: in.Name, Note: in.Note}) {
 				return fmt.Sprintf("signalled parent: %s", kind), nil

--- a/agent/signal.go
+++ b/agent/signal.go
@@ -1,0 +1,232 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+// SignalKind classifies an upward signal a child agent raises to its parent
+// Runner — the control-axis complement to the downward Control (issue 936).
+type SignalKind string
+
+const (
+	// SignalEscalate asks the parent to stop and handle the child's finding
+	// ("decisive result" / "an error you must deal with"). With the
+	// AbortOnEscalate policy the parent turn ends; otherwise the signal is
+	// injected and the parent model decides.
+	SignalEscalate SignalKind = "escalate"
+
+	// SignalCancelSiblings asks the parent to cancel the child's in-flight
+	// siblings ("I found it; the others are wasted work"). In the
+	// non-interruptible turn (issue 1165) this intent is RECORDED and surfaced,
+	// but the siblings have already joined by the time the parent reads it at the
+	// dispatch barrier; acting on it mid-flight is the interruptible turn (issue
+	// 1167). Do not mistake it for working cancellation yet.
+	SignalCancelSiblings SignalKind = "cancel_siblings"
+
+	// SignalCustom carries an application-defined signal (named by Name, with an
+	// optional Data payload) for a SignalPolicy or the parent model to interpret.
+	SignalCustom SignalKind = "custom"
+)
+
+// Signal is an upward message from a child agent to its parent Runner. It is
+// wire-serializable (constraint A2) so a remote child raises it identically to
+// a co-located one: RaiseSignal writes it into the ctx-threaded sink the parent
+// installs around the dispatch that spawned the child, and the parent reads the
+// drained signals at the join.
+type Signal struct {
+	// Kind classifies the signal; a SignalPolicy switches on it.
+	Kind SignalKind `json:"kind"`
+	// Name names a SignalCustom signal (ignored for the built-in kinds).
+	Name string `json:"name,omitempty"`
+	// Note is a short reason, surfaced when the signal is injected into the
+	// parent's next step.
+	Note string `json:"note,omitempty"`
+	// Data is an optional JSON payload for a SignalCustom signal (A5: RawJSON).
+	Data core.RawJSON `json:"data,omitempty"`
+	// Source is the raising child's scope path (agentScope), stamped by
+	// RaiseSignal so a policy or the model knows who signalled. Callers do not
+	// set it.
+	Source string `json:"source,omitempty"`
+}
+
+// SignalAction is a SignalPolicy's verdict over the signals drained at one
+// dispatch join. The zero value continues the turn (inject-and-proceed).
+type SignalAction struct {
+	// AbortTurn ends the parent turn immediately with ErrSignalAbort; Reason is
+	// folded into the error. Use it for an escalation that should stop the parent.
+	AbortTurn bool
+	// Reason is the abort reason (and the turn error message). Ignored unless
+	// AbortTurn is set.
+	Reason string
+}
+
+// SignalPolicy decides how a parent Runner reacts to the signals its children
+// raised during one dispatch, read at the join. It runs after the fan-out has
+// joined (issue 1165 is non-interruptible), so it chooses only whether to abort
+// the parent turn; the signals are injected into the next step regardless. Nil
+// means inject-and-continue. A policy must be a pure function of the drained
+// signals.
+type SignalPolicy func(signals []Signal) SignalAction
+
+// AbortOnEscalate is a built-in SignalPolicy that aborts the parent turn as
+// soon as a child raises SignalEscalate, folding that child's note into the
+// error. Other signal kinds inject-and-continue. It is the deterministic
+// counterpart to letting the parent model decide via injection.
+func AbortOnEscalate(signals []Signal) SignalAction {
+	for _, s := range signals {
+		if s.Kind == SignalEscalate {
+			reason := s.Note
+			if reason == "" {
+				reason = fmt.Sprintf("escalated by %s", s.Source)
+			}
+			return SignalAction{AbortTurn: true, Reason: reason}
+		}
+	}
+	return SignalAction{}
+}
+
+// ErrSignalAbort is returned (wrapped) by a turn a SignalPolicy aborted via
+// SignalAction.AbortTurn — a child escalated and the parent chose to stop.
+// Check with errors.Is; the wrapped message carries the policy's Reason.
+var ErrSignalAbort = errors.New("agent: turn aborted by child signal")
+
+// signalSink collects the signals raised by the sub-agents one dispatch
+// spawned. Two ctx keys keep the direction right (the subtle part): a dispatch
+// installs its sink under dispatchSinkKey (where it collects its OWN children's
+// signals), and when an AgentSource spawns a child it snapshots that sink under
+// parentSinkKey in the child's ctx (where the child's signal_parent writes).
+// RaiseSignal reads parentSinkKey. So a child raises to its SPAWNER's sink, not
+// to its own dispatch sink — which the child's own dispatch would otherwise
+// shadow — and a grandchild raises to the child, never skipping a level.
+type signalSink struct {
+	mu      sync.Mutex
+	signals []Signal
+}
+
+func (s *signalSink) raise(sig Signal) {
+	s.mu.Lock()
+	s.signals = append(s.signals, sig)
+	s.mu.Unlock()
+}
+
+// drain returns the collected signals and clears the sink.
+func (s *signalSink) drain() []Signal {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := s.signals
+	s.signals = nil
+	return out
+}
+
+type dispatchSinkKey struct{}
+type parentSinkKey struct{}
+
+// withDispatchSink stamps the sink a dispatch collects its children's signals
+// into. AgentSource reads it (via dispatchSinkFrom) to hand the spawned child
+// its parent sink.
+func withDispatchSink(ctx context.Context, s *signalSink) context.Context {
+	return context.WithValue(ctx, dispatchSinkKey{}, s)
+}
+
+func dispatchSinkFrom(ctx context.Context) *signalSink {
+	s, _ := ctx.Value(dispatchSinkKey{}).(*signalSink)
+	return s
+}
+
+// withParentSink stamps the sink a running child raises TO — snapshotted by the
+// spawning AgentSource from the spawner's dispatch sink, so the child's own
+// dispatch cannot shadow it.
+func withParentSink(ctx context.Context, s *signalSink) context.Context {
+	return context.WithValue(ctx, parentSinkKey{}, s)
+}
+
+func parentSinkFrom(ctx context.Context) *signalSink {
+	s, _ := ctx.Value(parentSinkKey{}).(*signalSink)
+	return s
+}
+
+// RaiseSignal delivers sig to the parent Runner's signal sink — the
+// control-axis "up" primitive a child's control tool calls. It stamps
+// sig.Source with the child's scope when unset. It returns false when ctx
+// carries no parent sink (a top-level agent has no parent to signal), so a
+// control tool can tell the model there is nothing to signal instead of
+// silently dropping it.
+func RaiseSignal(ctx context.Context, sig Signal) bool {
+	sink := parentSinkFrom(ctx)
+	if sink == nil {
+		return false
+	}
+	if sig.Source == "" {
+		sig.Source = agentScope(ctx)
+	}
+	sink.raise(sig)
+	return true
+}
+
+// SignalParentToolName is the fixed name of the control tool a child agent calls
+// to raise a Signal to its parent (kept fixed, like the memory/meta-tool names).
+const SignalParentToolName = "signal_parent"
+
+type signalParentArgs struct {
+	// Kind is "escalate", "cancel_siblings", or "custom".
+	Kind string `json:"kind"`
+	// Note is a short reason surfaced to the parent.
+	Note string `json:"note,omitempty"`
+	// Name names a custom signal (kind="custom").
+	Name string `json:"name,omitempty"`
+}
+
+// NewSignalSource returns a leaf ToolSource exposing the signal_parent control
+// tool so a child agent can raise an upward Signal (issue 1165). Add it to a
+// sub-agent's tool set; a top-level agent that has no parent gets a graceful
+// "no parent to signal" result. Model-facing, so it lives in agent/ (A6).
+func NewSignalSource() *FuncSource {
+	fs := NewFuncSource()
+	_ = AddFunc(fs, SignalParentToolName,
+		"Raise a signal to the parent agent that spawned you. kind: 'escalate' (ask the parent to stop and handle your finding), 'cancel_siblings' (you found the answer; the parent's other in-flight sub-agents are wasted work), or 'custom' (a named signal). Use sparingly — only for a decisive result the parent must act on.",
+		func(ctx context.Context, in signalParentArgs) (string, error) {
+			kind := SignalKind(in.Kind)
+			switch kind {
+			case SignalEscalate, SignalCancelSiblings, SignalCustom:
+			default:
+				return "", fmt.Errorf("unknown signal kind %q (want escalate, cancel_siblings, or custom)", in.Kind)
+			}
+			if RaiseSignal(ctx, Signal{Kind: kind, Name: in.Name, Note: in.Note}) {
+				return fmt.Sprintf("signalled parent: %s", kind), nil
+			}
+			return "no parent to signal (you are the top-level agent)", nil
+		})
+	return fs
+}
+
+// renderSignals formats the drained signals into the RoleSystem note injected
+// into the parent's next step, so the parent model sees what its children
+// raised. One line per signal.
+func renderSignals(signals []Signal) string {
+	var b strings.Builder
+	b.WriteString("Sub-agent signals received:")
+	for _, s := range signals {
+		b.WriteString("\n- ")
+		b.WriteString(string(s.Kind))
+		if s.Name != "" {
+			b.WriteString(" (")
+			b.WriteString(s.Name)
+			b.WriteString(")")
+		}
+		if s.Source != "" {
+			b.WriteString(" from ")
+			b.WriteString(s.Source)
+		}
+		if s.Note != "" {
+			b.WriteString(": ")
+			b.WriteString(s.Note)
+		}
+	}
+	return b.String()
+}

--- a/agent/signal_test.go
+++ b/agent/signal_test.go
@@ -1,0 +1,227 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+func TestSignal_JSONRoundTrip(t *testing.T) {
+	sig := Signal{
+		Kind:   SignalCustom,
+		Name:   "quorum",
+		Note:   "2 of 3 agreed",
+		Data:   core.NewRawJSON(json.RawMessage(`{"votes":2}`)),
+		Source: "review/checker",
+	}
+	data, err := json.Marshal(sig)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var back Signal
+	if err := json.Unmarshal(data, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	data2, err := json.Marshal(back)
+	if err != nil {
+		t.Fatalf("re-marshal: %v", err)
+	}
+	if string(data) != string(data2) {
+		t.Fatalf("round-trip drift:\n got %s\nwant %s", data2, data)
+	}
+}
+
+func TestRaiseSignal_NoParentReturnsFalse(t *testing.T) {
+	if RaiseSignal(context.Background(), Signal{Kind: SignalEscalate}) {
+		t.Fatal("RaiseSignal with no parent sink should return false")
+	}
+}
+
+func TestSignalSource_TopLevelGraceful(t *testing.T) {
+	fs := NewSignalSource()
+	res, err := fs.Call(context.Background(), SignalParentToolName, map[string]any{"kind": "escalate", "note": "hi"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError || !strings.Contains(res.Content[0].Text, "no parent") {
+		t.Fatalf("top-level signal_parent = %+v, want a graceful 'no parent' result", res)
+	}
+}
+
+// signalingChild builds an AgentSource whose child raises signal_parent(kind,
+// note) on its first turn, then answers. It is the reusable "a sub-agent that
+// signals up" fixture.
+func signalingChild(t *testing.T, name, kind, note string) *AgentSource {
+	t.Helper()
+	child, err := NewRunner(RunnerConfig{
+		Provider: NewStubProvider(
+			StubTurn{ToolCalls: []ToolCall{{ID: "s1", Name: SignalParentToolName,
+				Args: core.NewRawJSON(json.RawMessage(`{"kind":"` + kind + `","note":"` + note + `"}`))}}},
+			StubTurn{Text: name + " done"},
+		),
+		Tools: NewSignalSource(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	as, err := NewAgentSource(AgentSourceConfig{Name: name, Description: "d", Runner: child})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return as
+}
+
+func parentOver(t *testing.T, child *AgentSource, policy SignalPolicy) (*Runner, *StubProvider) {
+	t.Helper()
+	tools := NewMultiSource()
+	if err := tools.Add("child-src", child); err != nil {
+		t.Fatal(err)
+	}
+	stub := NewStubProvider(
+		StubTurn{ToolCalls: []ToolCall{{ID: "c1", Name: child.cfg.Name,
+			Args: core.NewRawJSON(json.RawMessage(`{"task":"go"}`))}}},
+		StubTurn{Text: "parent done"},
+	)
+	r, err := NewRunner(RunnerConfig{Provider: stub, Tools: tools, SignalPolicy: policy})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return r, stub
+}
+
+// TestUpwardSignal_ReachesParentAndInjects: with no policy, a child's escalate
+// reaches the parent, emits EventSignal, and is injected into the parent's next
+// step as a RoleSystem note the parent model sees.
+func TestUpwardSignal_ReachesParentAndInjects(t *testing.T) {
+	child := signalingChild(t, "worker", "escalate", "found it")
+	parent, stub := parentOver(t, child, nil)
+
+	var mu sync.Mutex
+	var signals []Signal
+	res, err := parent.Run(context.Background(), []Message{{Role: RoleUser, Text: "go"}}, func(e Event) {
+		if e.Kind == EventSignal {
+			mu.Lock()
+			signals = append(signals, *e.Signal)
+			mu.Unlock()
+		}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Text != "parent done" {
+		t.Fatalf("parent final = %q, want it to continue after the signal", res.Text)
+	}
+	if len(signals) != 1 || signals[0].Kind != SignalEscalate || signals[0].Source != "worker" {
+		t.Fatalf("EventSignal = %+v, want one escalate from 'worker'", signals)
+	}
+	// The parent's second model call sees the signal injected as a RoleSystem note.
+	fed := stub.Requests()[1].Messages
+	var injected bool
+	for _, m := range fed {
+		if m.Role == RoleSystem && strings.Contains(m.Text, "escalate") && strings.Contains(m.Text, "found it") {
+			injected = true
+		}
+	}
+	if !injected {
+		t.Fatalf("signal not injected into the parent's next step: %+v", fed)
+	}
+}
+
+// TestUpwardSignal_AbortOnEscalate: the built-in policy ends the parent turn
+// when a child escalates, folding the note into ErrSignalAbort.
+func TestUpwardSignal_AbortOnEscalate(t *testing.T) {
+	child := signalingChild(t, "worker", "escalate", "found it")
+	parent, stub := parentOver(t, child, AbortOnEscalate)
+
+	_, err := parent.Run(context.Background(), []Message{{Role: RoleUser, Text: "go"}}, func(Event) {})
+	if !errors.Is(err, ErrSignalAbort) {
+		t.Fatalf("err = %v, want ErrSignalAbort", err)
+	}
+	if !strings.Contains(err.Error(), "found it") {
+		t.Fatalf("abort reason = %v, want the child's note", err)
+	}
+	// The parent never reached its second turn (it aborted after the signal).
+	if n := len(stub.Requests()); n != 1 {
+		t.Fatalf("parent made %d model calls, want 1 (aborted before continuing)", n)
+	}
+}
+
+// TestUpwardSignal_NoSignalUnchanged: a sub-agent call with no signal leaves
+// the parent's next step free of any injected note and emits no EventSignal.
+func TestUpwardSignal_NoSignalUnchanged(t *testing.T) {
+	quietChild, _ := NewRunner(RunnerConfig{Provider: NewStubProvider(StubTurn{Text: "quiet"})})
+	as, _ := NewAgentSource(AgentSourceConfig{Name: "worker", Description: "d", Runner: quietChild})
+	parent, stub := parentOver(t, as, AbortOnEscalate)
+
+	var sawSignal bool
+	if _, err := parent.Run(context.Background(), []Message{{Role: RoleUser, Text: "go"}}, func(e Event) {
+		if e.Kind == EventSignal {
+			sawSignal = true
+		}
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if sawSignal {
+		t.Fatal("EventSignal emitted with no child signal")
+	}
+	for _, m := range stub.Requests()[1].Messages {
+		if m.Role == RoleSystem && strings.Contains(m.Text, "Sub-agent signals") {
+			t.Fatalf("injected a signal note with no signal: %+v", m)
+		}
+	}
+}
+
+// TestUpwardSignal_NestedReachesImmediateParent: a grandchild's signal reaches
+// its immediate parent (the middle agent), NOT the top — proving the sink is
+// scoped to the spawner, not shared across the tree.
+func TestUpwardSignal_NestedReachesImmediateParent(t *testing.T) {
+	var topRec, midRec recorder
+
+	grandchild := signalingChild(t, "grandchild", "escalate", "deep")
+	midTools := NewMultiSource()
+	if err := midTools.Add("gc-src", grandchild); err != nil {
+		t.Fatal(err)
+	}
+	middleRunner, err := NewRunner(RunnerConfig{
+		Provider: NewStubProvider(
+			StubTurn{ToolCalls: []ToolCall{{ID: "m1", Name: "grandchild",
+				Args: core.NewRawJSON(json.RawMessage(`{"task":"go"}`))}}},
+			StubTurn{Text: "middle done"},
+		),
+		Tools:        midTools,
+		SignalPolicy: midRec.policy,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	middle, _ := NewAgentSource(AgentSourceConfig{Name: "middle", Description: "d", Runner: middleRunner})
+
+	top, _ := parentOver(t, middle, topRec.policy)
+	if _, err := top.Run(context.Background(), []Message{{Role: RoleUser, Text: "go"}}, func(Event) {}); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(midRec.sigs) != 1 || midRec.sigs[0].Source != "middle/grandchild" {
+		t.Fatalf("middle recorded %+v, want one escalate from 'middle/grandchild'", midRec.sigs)
+	}
+	if len(topRec.sigs) != 0 {
+		t.Fatalf("top recorded %+v, want none (signal is scoped to the immediate parent)", topRec.sigs)
+	}
+}
+
+type recorder struct {
+	mu   sync.Mutex
+	sigs []Signal
+}
+
+func (r *recorder) policy(signals []Signal) SignalAction {
+	r.mu.Lock()
+	r.sigs = append(r.sigs, signals...)
+	r.mu.Unlock()
+	return SignalAction{}
+}

--- a/docs/AGENT_COMPOSITION.md
+++ b/docs/AGENT_COMPOSITION.md
@@ -36,13 +36,17 @@ model manages its own async through meta-tools today: `create_trigger`,
 
 - **Down** — `Control` (issue 936): an outside caller cancels an in-flight
   call, cleanly, across all outcome shapes.
-- **Up** — **signals** (issue 1036, deferred): a child raises an
+- **Up** — **signals** (issue 1165, piece A of 1036): a child raises an
   exception/signal to its parent — "stop the siblings," "escalate" — itself
-  just a tool call from the child's side.
-- **Model-driven** — **runner-control meta-tools** (deferred): `spawn_agent`,
-  `cancel_agent`, `await_agent`, `transfer_to`, `schedule` — the async-control
-  plane extended to sub-agents, so "supervision/orchestration" is *a Runner
-  whose tools control other Runners*, not a separate engine.
+  just a tool call from the child's side, writing to a ctx-threaded upward sink
+  the parent reads at the join. This is the *mechanism*; reacting mid-fan-out
+  is the interruptible turn below.
+- **Model-driven** — **runner-control meta-tools** (issue 1166, piece B of
+  1036): `spawn_agent`, `cancel_agent`, `await_agent`, `transfer_to`,
+  `schedule` — the async-control plane extended to sub-agents, so
+  "supervision/orchestration" is *a Runner whose tools control other Runners*,
+  not a separate engine. Host-layer over a running-agent registry; no Runner
+  change.
 - **Composition-via-tools** — the same principle one level up: not just steering
   *execution* but mutating the *graph*. Membership is **static today** (`Team`
   declares its members at construction; a fixed, validated handoff graph), and
@@ -52,9 +56,18 @@ model manages its own async through meta-tools today: `create_trigger`,
   composition trades the static graph's determinism, so the depth / budget /
   handoff caps matter *more* — a model that grows its own tree needs hard
   bounds.
-- **Interruptible turn** (opt-in) — reacting to a signal or a partial result
-  mid-fan-out breaks the join barrier. Gated so the default fan-out-then-join
-  stays deterministic; only a signal-wired turn becomes interruptible.
+- **Interruptible turn** (opt-in — issue 1167, piece C of 1036) — reacting to a
+  signal or a partial result mid-fan-out breaks the join barrier. Gated so the
+  default fan-out-then-join stays deterministic; only a signal-wired turn
+  becomes interruptible. The one structural Runner change of the three; requires
+  A (a signal to react to).
+
+The 1036 epic decomposes into these three separable pieces — **A** upward
+signals (1165, the mechanism, no barrier break), **B** runner-control meta-tools
+(1166, host-layer), **C** the interruptible turn (1167, the gated exception).
+Sequence is A -> C (C needs a signal to react to); B is independent. A is the
+keystone: it forces the signal-payload design B and C both consume, and it is
+what the interaction mediator (1157) needs.
 
 ### A note on the third channel — observability (not an axis)
 
@@ -275,8 +288,9 @@ Host: `SubAgentConfig.Async` builds it; demoed as `deep_researcher` in
 
 - Context: handoff-via-injection + per-agent persistent context (the actor
   form above) — a generalization of `Team`.
-- Control: upward signals + runner-control meta-tools
-  + interruptible turn (1036).
+- Control: the 1036 epic, now split into three tracked pieces — upward signals
+  (1165, A), runner-control meta-tools (1166, B), interruptible turn (1167, C);
+  sequence A -> C, B independent.
   **`TreeBudget` shipped (1032):** a ctx-threaded aggregate cap on total model
   **steps** and **tokens** across a turn's whole tree (parent + sub-agents +
   fan-out members + handoff rounds), consulted by the Runner per step. The

--- a/examples/agents/kitchen-sink/kitchen-sink.json
+++ b/examples/agents/kitchen-sink/kitchen-sink.json
@@ -1,5 +1,6 @@
 {
   "instructions": "You are a capable assistant with access to MCP tools, specialist sub-agents (researcher, analyst), a background deep_researcher, and a review_team fan-out tool. Use working memory to remember durable facts the user tells you; delegate research/analysis to the sub-agents when it helps; for a thorough report the user doesn't need immediately, call deep_researcher (it runs in the background and its report arrives on a later turn, so acknowledge and move on); and when asked for a review or multiple perspectives on a plan call review_team (three reviewers in parallel). Keep answers concise.",
+  "signalPolicy": "inject",
   "connections": {
     "active": "deepseek-r1",
     "embedder": "openai-embed",
@@ -50,8 +51,9 @@
     {
       "name": "analyst",
       "description": "Computes summary statistics for a list of numbers using the analyze tool.",
-      "instructions": "You are a data analyst. Call the analyze tool on the numbers you are given and explain the result in one sentence.",
-      "allow": ["analyze"]
+      "instructions": "You are a data analyst. Call the analyze tool on the numbers you are given and explain the result in one sentence. If the analysis reveals something the main agent must act on urgently, call signal_parent with kind='escalate' and a short note.",
+      "allow": ["analyze"],
+      "canSignal": true
     },
     {
       "name": "deep_researcher",


### PR DESCRIPTION
## What changes

Adds the **upward** control channel to the agent Runner (issue 1165, piece A of the 1036 control-axis epic) — the complement to issue 936's downward `Control`. A child agent raises a serializable `Signal` to its parent by calling the `signal_parent` control tool; the parent Runner reads the drained signals **at the existing dispatch join** and reacts, either via a `SignalPolicy` (e.g. abort the turn on escalation) or by injecting the signal into the next step so the parent model sees it. No join barrier is broken — reacting *mid*-fan-out is deliberately deferred to piece C (1167). The change is additive: with no signalling child, behavior is unchanged.

**Signals are non-referential.** A child has no knowledge of its siblings (A7 isolation — it runs over its own slice seeded with just its task) and never names one. It reports only its *own* state ("escalate" / "custom" with its own findings). The **parent** — which alone holds the fan-out inventory (its `dispatch`, the per-call cancel registry from 936) and its own prompt/policy — decides what to do about the other in-flight children. Child raises a blind scalar up; parent, holding the tree, acts. (An agent that *knows and targets* specific children is the opposite topology — it `spawn_agent`s them and holds their handles — which is piece B, 1166, not signals.)

## Reviewer's guide

Read in this order:
1. [agent/signal.go](https://github.com/panyam/mcpkit/pull/1168/files#diff-98761de362bbd0c99796bb3ab5360ee494436658720dedf38865cec20180dee4) — start here. The whole mechanism: the `Signal` type, the two-key ctx sink, `RaiseSignal`, `NewSignalSource` (the `signal_parent` tool), and `AbortOnEscalate`. The load-bearing subtlety is the **two keys** — see "How it works".
2. [agent/agent_source.go](https://github.com/panyam/mcpkit/pull/1168/files#diff-cb9651df111cfad72b6d4ca30ae061405bedefa4b107cd0a6d36cd53a089bb8d) — the 6-line snapshot that hands a spawned child its parent's sink. This is what makes signals reach the *spawner*, not the child's own dispatch.
3. [agent/runner.go](https://github.com/panyam/mcpkit/pull/1168/files#diff-6d787b427ac08cd61669af7e34ff0b747c4264d20b31b21b681a2ec2c826d9f0) — `dispatch` installs/drains the sink and returns signals; `RunTurn` emits `EventSignal`, applies the policy, and injects the note. `RunnerConfig.SignalPolicy` + `ErrSignalAbort`.
4. [agent/signal_test.go](https://github.com/panyam/mcpkit/pull/1168/files#diff-298acda4b986e3057eb5167778dc598b8003a891e0b00cc3b06d0bde6843a34a) — acceptance for all of the above, including the nested-scoping guard.
5. `agent/host/*` — wiring: `SubAgentConfig.CanSignal` adds the tool to a persona; `Config.SignalPolicy` sets the main Runner's policy; `render.go` shows the signal. [agent/host/subagents_test.go](https://github.com/panyam/mcpkit/pull/1168/files#diff-2d54a2ee7af3226fd54ff17fab9344db5dc337cf238e6e1deeecf64af88b59d3) is the host integration test.

Skim or skip: [agent/events.go](https://github.com/panyam/mcpkit/pull/1168/files#diff-decf072b43cd6fba38445f5ab18d681fd6e933ca6b9e6bdf51d6bd95ac2977b7) (one new kind + field), [examples/agents/kitchen-sink/kitchen-sink.json](https://github.com/panyam/mcpkit/pull/1168/files#diff-613a756047a90e7dceae2a92468ffd872aa635011d08e72fc3f71a791757d94c) (config-only demo).

## How it works (the two-key sink)

The single subtle decision. A signal must reach the sink of the dispatch that **spawned** the child — but a child's own dispatch would shadow a single naive per-dispatch sink. So two ctx keys:

- `dispatchSinkKey` — a dispatch installs the sink it collects **its own children's** signals into.
- `parentSinkKey` — when `AgentSource` spawns a child, it snapshots the spawner's dispatch sink here; `RaiseSignal` reads this one.

```
dispatch(ctx, calls):
    sink = new signalSink
    ctx' = withDispatchSink(ctx, sink)          # collects THIS agent's children's signals
    parallel for each call: callTool(ctx', ...)
    wg.Wait()                                    # the join barrier — UNCHANGED in piece A
    return results, sink.drain()

AgentSource.Call(ctx, task):                     # spawning a child
    parentSink = dispatchSinkFrom(ctx)           # the spawner's sink
    childCtx  = withParentSink(childCtx, parentSink)   # NOT shadowed by the child's own dispatch
    child.Run(childCtx, [task])

RaiseSignal(ctx, sig):                           # called by signal_parent, inside the child's turn
    sink = parentSinkFrom(ctx)                   # -> the SPAWNER's sink, one level up
    if sink == nil: return false                 # top-level agent: no parent to signal
    sink.raise(stamp Source = agentScope(ctx))

RunTurn step loop (after a tool step):
    toolMsgs, signals = dispatch(stepCtx, calls)
    msgs += toolMsgs                             # tool results must pair with the assistant first
    if signals:
        emit EventSignal per signal             # observability
        if SignalPolicy(signals).AbortTurn: return ErrSignalAbort(reason)
        msgs += RoleSystem note(signals)         # drained once -> appended once, no stacking
```

Because a child's own dispatch installs a fresh `dispatchSink` (for its grandchildren) but `parentSink` is a different key, a grandchild's signal reaches the child, never skipping a level.

## Sequence diagram

```mermaid
sequenceDiagram
    participant M as Parent model
    participant PR as Parent Runner (RunTurn)
    participant D as dispatch (fan-out)
    participant AS as AgentSource
    participant C as Child Runner
    participant T as signal_parent tool
    participant SK as parent sink (ctx)
    M->>PR: assistant turn: call [worker]
    PR->>D: dispatch(calls)
    Note over D,SK: dispatch installs its sink (dispatchSinkKey)
    D->>AS: callTool(worker)
    AS->>AS: parentSink = dispatchSinkFrom(ctx)
    AS->>C: child.Run(childCtx with parentSink)
    C->>T: signal_parent(escalate, "found it")
    T->>SK: RaiseSignal → parentSinkFrom(ctx)
    C-->>AS: child final text
    AS-->>D: tool result
    D-->>D: wg.Wait() — join (unchanged)
    D->>SK: drain()
    D-->>PR: (results, [sig])
    PR->>M: emit EventSignal
    alt SignalPolicy → AbortTurn
        PR-->>M: turn ends (ErrSignalAbort, reason)
    else inject (default)
        PR->>M: next step sees the RoleSystem signal note
    end
```

## Decision log

- **Two-key sink, not one (`dispatchSinkKey` + `parentSinkKey`).** A single per-dispatch sink is shadowed by the child's own dispatch, so the child would raise into its own sink instead of the parent's. Caught while writing the nested-scoping test, before running it. Guarded by `TestUpwardSignal_NestedReachesImmediateParent`.
- **Per-dispatch sink, NOT install-if-absent** (contrast `TreeBudget`). `TreeBudget` is an *aggregate* shared across the tree; signals are *directional* to the immediate parent. Opposite requirements.
- **Injected note persists** (unlike memory injection's transient rule). A signal is drained from the sink exactly once, so appending it to history doesn't stack across turns — it's a real conversation event like a tool result.
- **No `cancel_siblings` kind in A.** An earlier draft had one; it was dropped. A child can't reference a sibling (it has no knowledge of them, A7), so a "cancel_siblings" kind is misleadingly phrased as a command about siblings the child can't see — and it no-ops in A anyway (the siblings have already joined by the time the parent reads it). A ships `escalate` + `custom` only, both of which act in A. The preemption signal ("I have a sufficient result") belongs to piece C (1167), where the parent can break the join and cancel in-flight calls — and even there it stays non-referential: the child reports its own sufficiency, the parent picks which siblings to cancel.
- **`SignalPolicy` on the parent, not the child.** A child *raises*; the parent *reacts*. Sub-agent Runners set no policy; only the main Runner does (host `Config.SignalPolicy`).

## Risk / blast radius

- **Affects:** `Runner.dispatch` (now returns `([]Message, []Signal)`) and `RunTurn` (new post-join block). The signature change is internal (unexported). No public Runner API removed.
- **Default path unchanged:** no sink is populated without a signalling child, so `dispatch` returns `nil` signals and `RunTurn` skips the whole block. Guarded by `TestUpwardSignal_NoSignalUnchanged`.
- **Be paranoid about:** the two-key direction (the nested test is the guard), and message ordering — the signal `RoleSystem` note is appended *after* tool results so it never breaks the assistant/tool-result pairing providers require.
- **Tests covering this:** 6 agent-layer tests + 1 host integration test; full `just test-agent` green.

## Before / after

Behavior before: a sub-agent could only return its final answer; there was no way for it to tell the parent "stop" or "escalate" mid-work — control flowed only down (936).

After (`AbortOnEscalate` policy), captured from `TestUpwardSignal_AbortOnEscalate`:

```
child turn 1: signal_parent(kind=escalate, note="found it")
parent dispatch join: drains [escalate from "worker"]
parent: EventSignal emitted
parent: SignalPolicy → AbortTurn → RunTurn returns ErrSignalAbort: "found it"
(parent never makes its 2nd model call)
```

After (default `inject` policy), from `TestUpwardSignal_ReachesParentAndInjects`: the parent continues, and its next model call's messages include a `RoleSystem` note: `Sub-agent signals received:\n- escalate from worker: found it`.

## Out of scope (deliberately deferred)

- Mid-fan-out reaction / actual sibling cancellation → the interruptible turn, issue 1167 (piece C).
- `spawn_agent`/`cancel_agent`/`await_agent` meta-tools → issue 1166 (piece B).
- Signals from **async** sub-agents (a detached child has no live parent dispatch) → noted on `SubAgentConfig.CanSignal`; a later follow-up if wanted.
- An agentchat `--signal-policy` flag → config-driven (`signalPolicy`) is enough for now.

