### PR TITLE
feat(agent): runner-control meta-tools (spawn/await/cancel) — 1036 piece B

### DIFF
--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -1,0 +1,318 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+// Runner-control tool names (issue 1166), kept fixed like the memory/meta-tool
+// names.
+const (
+	SpawnAgentToolName  = "spawn_agent"
+	AwaitAgentToolName  = "await_agent"
+	CancelAgentToolName = "cancel_agent"
+	ListAgentsToolName  = "list_agents"
+)
+
+type spawnArgs struct {
+	// Name is the agent to spawn (one of the pool's registered names).
+	Name string `json:"name"`
+	// Task is the instruction handed to the spawned agent as its user turn.
+	Task string `json:"task"`
+}
+
+type agentIDArgs struct {
+	// ID is the handle returned by spawn_agent.
+	ID string `json:"id"`
+}
+
+// NewSpawnSource returns a leaf ToolSource exposing the runner-control tools
+// over pool: spawn_agent / await_agent / cancel_agent / list_agents (issue
+// 1166). "Supervision = a Runner whose tools control other Runners" — this is
+// that tool surface. Model-facing, so it lives in agent/ (A6). The spawn tool's
+// description enumerates the pool's registered agents, so populate the pool
+// (Register) before calling this.
+func NewSpawnSource(pool *AgentPool) *FuncSource {
+	fs := NewFuncSource()
+
+	var menu strings.Builder
+	for _, a := range pool.Names() {
+		fmt.Fprintf(&menu, "\n- %s: %s", a.Name, a.Status)
+	}
+	_ = AddFunc(fs, SpawnAgentToolName,
+		"Start a sub-agent running in the background and get a handle id back; it keeps running while you do other work. Await its result later with await_agent, or drop it with cancel_agent. Available agents:"+menu.String(),
+		func(ctx context.Context, in spawnArgs) (string, error) {
+			if strings.TrimSpace(in.Task) == "" {
+				return "", fmt.Errorf("spawn_agent requires a non-empty 'task'")
+			}
+			id, err := pool.Spawn(ctx, in.Name, in.Task)
+			if err != nil {
+				return "", err
+			}
+			return fmt.Sprintf("spawned %q as %s (running in the background)", in.Name, id), nil
+		})
+
+	_ = AddFunc(fs, AwaitAgentToolName,
+		"Wait for a spawned sub-agent to finish and return its result. Blocks until it completes.",
+		func(ctx context.Context, in agentIDArgs) (string, error) {
+			result, err := pool.Await(ctx, in.ID)
+			if err != nil {
+				return "", err
+			}
+			if result == nil {
+				return fmt.Sprintf("spawned agent %s finished with no result", in.ID), nil
+			}
+			if result.Structured.Len() > 0 {
+				return string(result.Structured.Raw()), nil
+			}
+			return result.Text, nil
+		})
+
+	_ = AddFunc(fs, CancelAgentToolName,
+		"Cancel a spawned sub-agent you no longer need, by its handle id.",
+		func(ctx context.Context, in agentIDArgs) (string, error) {
+			if err := pool.Cancel(in.ID); err != nil {
+				return "", err
+			}
+			return "cancelled " + in.ID, nil
+		})
+
+	_ = AddFunc(fs, ListAgentsToolName,
+		"List the sub-agents you have spawned and their status (running / done / failed / cancelled).",
+		func(ctx context.Context, _ struct{}) (string, error) {
+			st := pool.Statuses()
+			if len(st) == 0 {
+				return "no spawned agents", nil
+			}
+			var b strings.Builder
+			for _, s := range st {
+				fmt.Fprintf(&b, "%s (%s): %s\n", s.ID, s.Name, s.Status)
+			}
+			return b.String(), nil
+		})
+
+	return fs
+}
+
+// AgentPool runs named child agents in the background and hands the parent
+// model a handle to each, so the model can steer sub-agents through ordinary
+// tool calls (issue 1166, piece B of the 1036 control axis): spawn one now,
+// await its result at a chosen point, or cancel it. It is the model-driven,
+// handle-based counterpart to AgentSource (blocking, no handle) and
+// AsyncAgentSource (fire-and-inject, no handle): here the model holds the
+// handle and pulls the result via await, or drops it via cancel.
+//
+// A handle outlives the spawning turn (the child runs on a DetachForBackground
+// context), so spawn-in-turn-1 / await-in-turn-3 works. Delivery is pull-only:
+// a spawned result is stored on the handle and returned by Await, never
+// auto-injected — auto-injection is AsyncAgentSource's model. The pool is
+// safe for concurrent use.
+type AgentPool struct {
+	mu      sync.Mutex
+	agents  map[string]pooledAgent
+	order   []string
+	handles map[string]*spawnHandle
+	seq     int
+	onEvent func(SubAgentEvent)
+}
+
+type pooledAgent struct {
+	runner      *Runner
+	description string
+	maxDepth    int
+}
+
+// spawnHandle tracks one background child. done closes exactly once, when the
+// child's Run returns; result/err are then readable. cancel aborts the child.
+type spawnHandle struct {
+	id     string
+	name   string
+	done   chan struct{}
+	cancel context.CancelFunc
+
+	mu     sync.Mutex
+	status string // "running" | "done" | "failed" | "cancelled"
+	result *TurnResult
+	err    error
+}
+
+// SpawnStatus is a wire-serializable snapshot of a handle for list_agents
+// (constraint A2).
+type SpawnStatus struct {
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	Status string `json:"status"`
+}
+
+// NewAgentPool returns an empty pool. onEvent, when non-nil, receives every
+// spawned child's event stream wrapped in a SubAgentEvent (scope = the agent
+// name, depth threaded), so a surface renders background activity the same way
+// it renders a blocking sub-agent's. Nil drops child events.
+func NewAgentPool(onEvent func(SubAgentEvent)) *AgentPool {
+	return &AgentPool{
+		agents:  map[string]pooledAgent{},
+		handles: map[string]*spawnHandle{},
+		onEvent: onEvent,
+	}
+}
+
+// Register adds a spawnable agent under name (its child Runner + a description
+// for the model + a depth cap; zero uses DefaultMaxAgentDepth). A duplicate
+// name is an error.
+func (p *AgentPool) Register(name, description string, runner *Runner, maxDepth int) error {
+	if name == "" || runner == nil {
+		return fmt.Errorf("agent: AgentPool.Register requires a name and runner")
+	}
+	if maxDepth <= 0 {
+		maxDepth = DefaultMaxAgentDepth
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if _, exists := p.agents[name]; exists {
+		return fmt.Errorf("agent: AgentPool already has %q", name)
+	}
+	p.agents[name] = pooledAgent{runner: runner, description: description, maxDepth: maxDepth}
+	p.order = append(p.order, name)
+	return nil
+}
+
+// Names returns the registered spawnable agent names in registration order,
+// with their descriptions — for a spawn tool's help text.
+func (p *AgentPool) Names() []SpawnStatus {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]SpawnStatus, 0, len(p.order))
+	for _, n := range p.order {
+		out = append(out, SpawnStatus{Name: n, Status: p.agents[n].description})
+	}
+	return out
+}
+
+// Spawn starts the named agent on a detached, cancellable goroutine over an
+// isolated slice seeded with task, and returns a handle id. Depth and the
+// ctx-threaded call budget are checked before the spawn (an unknown name or an
+// exhausted guard is an error, not a started agent). The child outlives ctx
+// (DetachForBackground), so it keeps running after the spawning turn ends.
+func (p *AgentPool) Spawn(ctx context.Context, name, task string) (string, error) {
+	p.mu.Lock()
+	spec, ok := p.agents[name]
+	if !ok {
+		p.mu.Unlock()
+		return "", fmt.Errorf("no spawnable agent %q", name)
+	}
+	depth := agentDepth(ctx)
+	if depth >= spec.maxDepth {
+		p.mu.Unlock()
+		return "", fmt.Errorf("spawn %q refused: max depth %d reached", name, spec.maxDepth)
+	}
+	if b := agentCallBudget(ctx); b != nil && b.Add(-1) < 0 {
+		p.mu.Unlock()
+		return "", fmt.Errorf("spawn %q refused: call budget exhausted", name)
+	}
+	p.seq++
+	id := fmt.Sprintf("agent-%d", p.seq)
+	p.mu.Unlock()
+
+	childScope := name
+	if parent := agentScope(ctx); parent != "" {
+		childScope = parent + "/" + name
+	}
+	bgCtx := withAgentScope(withAgentDepth(core.DetachForBackground(ctx), depth+1), childScope)
+	runCtx, cancel := context.WithCancel(bgCtx)
+
+	h := &spawnHandle{id: id, name: name, done: make(chan struct{}), cancel: cancel, status: "running"}
+	p.mu.Lock()
+	p.handles[id] = h
+	p.mu.Unlock()
+
+	emit := func(Event) {}
+	if p.onEvent != nil {
+		childDepth := depth + 1
+		emit = func(e Event) { p.onEvent(SubAgentEvent{Scope: childScope, Depth: childDepth, Event: e}) }
+	}
+	go func() {
+		result, err := spec.runner.Run(runCtx, []Message{{Role: RoleUser, Text: task}}, emit)
+		h.finish(result, err)
+	}()
+	return id, nil
+}
+
+// finish records the terminal outcome and closes done exactly once. A cancelled
+// handle keeps its "cancelled" status (the run error is the cancellation).
+func (h *spawnHandle) finish(result *TurnResult, err error) {
+	h.mu.Lock()
+	if h.status == "running" {
+		if err != nil {
+			h.status = "failed"
+		} else {
+			h.status = "done"
+		}
+	}
+	h.result, h.err = result, err
+	h.mu.Unlock()
+	close(h.done)
+}
+
+// Await blocks until the spawned agent id finishes and returns its result, or
+// returns when ctx is cancelled (the turn was cancelled). An unknown id is an
+// error. Await is idempotent: a second call returns the same stored result.
+func (p *AgentPool) Await(ctx context.Context, id string) (*TurnResult, error) {
+	p.mu.Lock()
+	h, ok := p.handles[id]
+	p.mu.Unlock()
+	if !ok {
+		return nil, fmt.Errorf("no spawned agent %q", id)
+	}
+	select {
+	case <-h.done:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.err != nil {
+		return nil, fmt.Errorf("spawned agent %q (%s) failed: %w", id, h.name, h.err)
+	}
+	return h.result, nil
+}
+
+// Cancel aborts the spawned agent id (its context is cancelled; the running
+// child returns and its handle moves to "cancelled"). An unknown id is an
+// error. Cancelling a finished agent is a no-op that still succeeds.
+func (p *AgentPool) Cancel(id string) error {
+	p.mu.Lock()
+	h, ok := p.handles[id]
+	p.mu.Unlock()
+	if !ok {
+		return fmt.Errorf("no spawned agent %q", id)
+	}
+	h.mu.Lock()
+	if h.status == "running" {
+		h.status = "cancelled"
+	}
+	h.mu.Unlock()
+	h.cancel()
+	return nil
+}
+
+// Statuses snapshots every handle (running and finished) for list_agents,
+// in id order of creation.
+func (p *AgentPool) Statuses() []SpawnStatus {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]SpawnStatus, 0, len(p.handles))
+	for i := 1; i <= p.seq; i++ {
+		h, ok := p.handles[fmt.Sprintf("agent-%d", i)]
+		if !ok {
+			continue
+		}
+		h.mu.Lock()
+		out = append(out, SpawnStatus{ID: h.id, Name: h.name, Status: h.status})
+		h.mu.Unlock()
+	}
+	return out
+}

--- a/agent/agent_pool_test.go
+++ b/agent/agent_pool_test.go
@@ -1,0 +1,121 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func poolRunner(t *testing.T, turns ...StubTurn) *Runner {
+	t.Helper()
+	r, err := NewRunner(RunnerConfig{Provider: NewStubProvider(turns...)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return r
+}
+
+func TestAgentPool_SpawnAwait(t *testing.T) {
+	pool := NewAgentPool(nil)
+	if err := pool.Register("worker", "does work", poolRunner(t, StubTurn{Text: "the answer"}), 0); err != nil {
+		t.Fatal(err)
+	}
+
+	id, err := pool.Spawn(context.Background(), "worker", "go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := pool.Await(context.Background(), id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Text != "the answer" {
+		t.Fatalf("await result = %q, want the child's answer", res.Text)
+	}
+	// Await is idempotent.
+	if res2, err := pool.Await(context.Background(), id); err != nil || res2.Text != "the answer" {
+		t.Fatalf("second await = (%+v, %v), want the same stored result", res2, err)
+	}
+}
+
+func TestAgentPool_UnknownName(t *testing.T) {
+	pool := NewAgentPool(nil)
+	if _, err := pool.Spawn(context.Background(), "nope", "go"); err == nil {
+		t.Fatal("spawning an unregistered agent should error")
+	}
+}
+
+func TestAgentPool_UnknownHandle(t *testing.T) {
+	pool := NewAgentPool(nil)
+	if _, err := pool.Await(context.Background(), "agent-99"); err == nil {
+		t.Fatal("await of an unknown handle should error")
+	}
+	if err := pool.Cancel("agent-99"); err == nil {
+		t.Fatal("cancel of an unknown handle should error")
+	}
+}
+
+func TestAgentPool_Cancel(t *testing.T) {
+	// blockingProvider's stream blocks until ctx is cancelled, so the spawned
+	// child cannot finish before Cancel — the status transition is deterministic.
+	r, _ := NewRunner(RunnerConfig{Provider: blockingProvider{}})
+	pool := NewAgentPool(nil)
+	if err := pool.Register("slow", "blocks", r, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	id, err := pool.Spawn(context.Background(), "slow", "go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := pool.Cancel(id); err != nil {
+		t.Fatal(err)
+	}
+	// Awaiting a cancelled agent errors (its run returned ctx.Canceled).
+	if _, err := pool.Await(context.Background(), id); err == nil {
+		t.Fatal("await of a cancelled agent should error")
+	}
+	for _, s := range pool.Statuses() {
+		if s.ID == id && s.Status != "cancelled" {
+			t.Fatalf("status = %q, want cancelled", s.Status)
+		}
+	}
+}
+
+func TestAgentPool_Statuses(t *testing.T) {
+	pool := NewAgentPool(nil)
+	_ = pool.Register("a", "a", poolRunner(t, StubTurn{Text: "x"}), 0)
+	id, _ := pool.Spawn(context.Background(), "a", "go")
+	if _, err := pool.Await(context.Background(), id); err != nil {
+		t.Fatal(err)
+	}
+	st := pool.Statuses()
+	if len(st) != 1 || st[0].ID != id || st[0].Status != "done" {
+		t.Fatalf("statuses = %+v, want one done handle", st)
+	}
+}
+
+// TestSpawnSource_Tools drives the meta-tools end to end: spawn_agent returns a
+// handle, await_agent returns the child's text.
+func TestSpawnSource_Tools(t *testing.T) {
+	pool := NewAgentPool(nil)
+	_ = pool.Register("worker", "does work", poolRunner(t, StubTurn{Text: "tool answer"}), 0)
+	src := NewSpawnSource(pool)
+
+	spawned, err := src.Call(context.Background(), SpawnAgentToolName, map[string]any{"name": "worker", "task": "go"})
+	if err != nil || spawned.IsError {
+		t.Fatalf("spawn_agent = (%+v, %v)", spawned, err)
+	}
+	// the handle id is the last token of "spawned \"worker\" as agent-1 (...)"
+	id := "agent-1"
+	if !strings.Contains(spawned.Content[0].Text, id) {
+		t.Fatalf("spawn result %q did not name the handle", spawned.Content[0].Text)
+	}
+	awaited, err := src.Call(context.Background(), AwaitAgentToolName, map[string]any{"id": id})
+	if err != nil || awaited.IsError {
+		t.Fatalf("await_agent = (%+v, %v)", awaited, err)
+	}
+	if awaited.Content[0].Text != "tool answer" {
+		t.Fatalf("await_agent result = %q, want the child's text", awaited.Content[0].Text)
+	}
+}

--- a/agent/host/app.go
+++ b/agent/host/app.go
@@ -54,6 +54,11 @@ type App struct {
 	group       *client.Group
 	serverTools *agent.MultiSource
 
+	// agentPool backs the runner-control meta-tools (Config.RunnerControl,
+	// issue 1166): the registry of spawnable personas + their live handles. Nil
+	// when runner control is off.
+	agentPool *agent.AgentPool
+
 	// oauthSources holds the interactive (oauth) token source per server id, so
 	// LoginServer can force a fresh browser login. Only oauth-typed servers have
 	// an entry; its presence is what CanLogin reports.
@@ -489,6 +494,16 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 	// sub-agents (serverTools-only), so the same memory-free rule holds.
 	if len(cfg.FanOut) > 0 {
 		if err := app.registerFanOut(multi, app.serverTools, provider, o.tp, o.mp); err != nil {
+			app.Close()
+			return nil, err
+		}
+	}
+
+	// Runner-control meta-tools: let the main model spawn/await/cancel the
+	// configured personas in the background with handles (issue 1166). Reuses
+	// the persona child Runners; only meaningful with SubAgents.
+	if cfg.RunnerControl && len(cfg.SubAgents) > 0 {
+		if err := app.registerRunnerControl(multi, app.serverTools, provider, o.tp, o.mp); err != nil {
 			app.Close()
 			return nil, err
 		}

--- a/agent/host/config.go
+++ b/agent/host/config.go
@@ -32,6 +32,14 @@ type Config struct {
 	MaxTreeSteps  int `json:"maxTreeSteps,omitempty"`
 	MaxTreeTokens int `json:"maxTreeTokens,omitempty"`
 
+	// RunnerControl, when true, gives the main agent the runner-control
+	// meta-tools (issue 1166): spawn_agent / await_agent / cancel_agent /
+	// list_agents, over the configured sub-agent personas. The model can run a
+	// persona in the background, get a handle, and await or cancel it — the
+	// model-driven, handle-based counterpart to calling a persona as a blocking
+	// tool. Only meaningful alongside SubAgents. False (the default) omits them.
+	RunnerControl bool `json:"runnerControl,omitempty"`
+
 	// SignalPolicy selects how the main agent reacts to an upward Signal a
 	// signalling sub-agent raises (issue 1165), read at the dispatch join:
 	//   - "" / "inject" — inject the signal as context and continue (default).

--- a/agent/host/runner_control.go
+++ b/agent/host/runner_control.go
@@ -1,0 +1,34 @@
+package host
+
+import (
+	"github.com/panyam/mcpkit/agent"
+	"github.com/panyam/mcpkit/core"
+)
+
+// registerRunnerControl builds an agent.AgentPool from the configured sub-agent
+// personas and adds the runner-control meta-tools (spawn_agent / await_agent /
+// cancel_agent / list_agents, issue 1166) to the main aggregate, so the main
+// model can run personas in the background with handles.
+//
+// Each pooled agent is a persona child Runner built exactly like the blocking
+// tool registerSubAgents builds (shared provider, serverTools-only, memory-free
+// per A7). The same persona is thus reachable both as a direct blocking tool and
+// as a spawnable background agent — two invocation modes over one child. The
+// pool forwards each background child's event stream as a HostSubAgentEvent, so
+// spawned activity renders the same way a blocking sub-agent's does.
+func (a *App) registerRunnerControl(multi, serverTools *agent.MultiSource, provider agent.Provider, tp core.TracerProvider, mp core.MeterProvider) error {
+	pool := agent.NewAgentPool(func(e agent.SubAgentEvent) {
+		a.emit(HostEvent{Kind: HostSubAgentEvent, SubAgent: e})
+	})
+	for _, sub := range a.cfg.SubAgents {
+		child, err := agent.NewRunner(a.personaRunnerConfig(sub, serverTools, provider, tp, mp))
+		if err != nil {
+			return err
+		}
+		if err := pool.Register(sub.Name, sub.Description, child, sub.MaxDepth); err != nil {
+			return err
+		}
+	}
+	a.agentPool = pool
+	return multi.Add("runner-control", agent.NewSpawnSource(pool))
+}

--- a/agent/host/runner_control_test.go
+++ b/agent/host/runner_control_test.go
@@ -1,0 +1,74 @@
+package host
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/panyam/mcpkit/agent"
+)
+
+// TestAppRunnerControlWiring: a RunnerControl config offers the four
+// runner-control meta-tools to the main agent and registers each persona as a
+// spawnable agent. Spawn/await/cancel behavior is covered at the agent layer
+// (agent_pool_test.go) with isolated providers; a full host turn would race on
+// the shared stub (main + the background child pull it concurrently), so this
+// guards the wiring.
+func TestAppRunnerControlWiring(t *testing.T) {
+	ts := startTestServer(t)
+	stub := agent.NewStubProvider(agent.StubTurn{Text: "ok"})
+
+	cfg := testConfig(ts.URL)
+	cfg.RunnerControl = true
+	cfg.SubAgents = []SubAgentConfig{
+		{Name: "worker", Description: "does work", Instructions: "You work."},
+	}
+	app, err := NewApp(cfg, nil, strings.NewReader(""), WithProvider(stub))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Close()
+
+	defs, _ := app.sources.Tools(context.Background())
+	for _, name := range []string{
+		agent.SpawnAgentToolName, agent.AwaitAgentToolName,
+		agent.CancelAgentToolName, agent.ListAgentsToolName,
+	} {
+		if !hasToolNamed(defs, name) {
+			t.Fatalf("runner-control tool %q not offered: %v", name, toolDefNames(defs))
+		}
+	}
+
+	if app.agentPool == nil {
+		t.Fatal("agentPool not built with RunnerControl")
+	}
+	var names []string
+	for _, n := range app.agentPool.Names() {
+		names = append(names, n.Name)
+	}
+	if len(names) != 1 || names[0] != "worker" {
+		t.Fatalf("spawnable agents = %v, want [worker]", names)
+	}
+}
+
+// TestAppRunnerControlOffByDefault: without the flag, no spawn tool appears.
+func TestAppRunnerControlOffByDefault(t *testing.T) {
+	ts := startTestServer(t)
+	stub := agent.NewStubProvider(agent.StubTurn{Text: "ok"})
+
+	cfg := testConfig(ts.URL)
+	cfg.SubAgents = []SubAgentConfig{{Name: "worker", Description: "w", Instructions: "You work."}}
+	app, err := NewApp(cfg, nil, strings.NewReader(""), WithProvider(stub))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Close()
+
+	defs, _ := app.sources.Tools(context.Background())
+	if hasToolNamed(defs, agent.SpawnAgentToolName) {
+		t.Fatal("spawn_agent offered without RunnerControl")
+	}
+	if app.agentPool != nil {
+		t.Fatal("agentPool built without RunnerControl")
+	}
+}

--- a/examples/agents/kitchen-sink/kitchen-sink.json
+++ b/examples/agents/kitchen-sink/kitchen-sink.json
@@ -1,6 +1,7 @@
 {
   "instructions": "You are a capable assistant with access to MCP tools, specialist sub-agents (researcher, analyst), a background deep_researcher, and a review_team fan-out tool. Use working memory to remember durable facts the user tells you; delegate research/analysis to the sub-agents when it helps; for a thorough report the user doesn't need immediately, call deep_researcher (it runs in the background and its report arrives on a later turn, so acknowledge and move on); and when asked for a review or multiple perspectives on a plan call review_team (three reviewers in parallel). Keep answers concise.",
   "signalPolicy": "inject",
+  "runnerControl": true,
   "connections": {
     "active": "deepseek-r1",
     "embedder": "openai-embed",


### PR DESCRIPTION
## What changes

Adds the **runner-control meta-tools** (issue 1166, piece B of the 1036 control-axis epic) — `spawn_agent` / `await_agent` / `cancel_agent` / `list_agents`. This is the axis realization of "supervision = a Runner whose tools control other Runners": the main model runs a configured persona in the background, gets a **handle**, and awaits or cancels it through ordinary tool calls.

It's the third point on the sub-agent control-timing axis, and the only one with a handle:

| primitive | timing | handle? | delivery |
|---|---|---|---|
| `AgentSource` (941) | blocking, this turn | no | return value |
| `AsyncAgentSource` (1035) | fire-and-continue | no | auto-injected later |
| **`AgentPool` (this PR)** | **spawn now, await when you choose** | **yes** | **pulled via `await_agent`** |

> **Stacked on #1168 (piece A).** Base is `feat/1165-upward-signals`, so this PR's own diff is just the B files; the A commits show until A merges, then I'll retarget to `main`.

## Reviewer's guide

Read in this order:
1. [agent/agent_pool.go](https://github.com/panyam/mcpkit/pull/1169/files#diff-bb46e1fff5d5d2ba3ec6e91f3dd0ccb611a6fc90bddd17d960646ee7eb39402e) — start here. `AgentPool` (Spawn/Await/Cancel/Statuses + the handle lifecycle) and `NewSpawnSource` (the four tools). This is the whole mechanism.
2. [agent/agent_pool_test.go](https://github.com/panyam/mcpkit/pull/1169/files#diff-7d978a8e2c1c93a4c3c37d8870b8e9a1e08b7f8d62d0f5a5180417b237a3674f) — acceptance: spawn→await, idempotent await, cancel (deterministic via the blocking provider), unknown-handle errors, the tool surface.
3. [agent/host/runner_control.go](https://github.com/panyam/mcpkit/pull/1169/files#diff-9f4df852e1ae7e2221a382ab7b739cd8aed1db457f4e46919f0baba20aa92fb1) — builds the pool from the configured personas and adds the tools.
4. [agent/host/runner_control_test.go](https://github.com/panyam/mcpkit/pull/1169/files#diff-200efd2be7c480a852392ec2cd8465c2db75ba68c45b9001ce2c85cbd148fb6c) — wiring on/off.
5. `agent/host/{config,app}.go` + `kitchen-sink.json` — the `RunnerControl` flag and its wiring; skim.

## How it works

```
AgentPool.Spawn(ctx, name, task):
    spec = catalog[name]                     # unknown name -> error (not a started agent)
    guard depth < spec.maxDepth, call budget # refuse before spawning
    id = "agent-N"
    bgCtx = withScope(withDepth(DetachForBackground(ctx)))   # outlives the turn, threads depth/scope
    runCtx, cancel = WithCancel(bgCtx)
    handle = {id, done: chan, cancel, status: running}
    go: result, err = child.Run(runCtx, [task]); handle.finish(result, err)  # closes done once
    return id

AgentPool.Await(ctx, id):
    h = handles[id]                          # unknown -> error
    select { <-h.done ; <-ctx.Done() -> return ctx.Err() }   # respects turn cancellation
    return h.result (or h.err)               # idempotent: stored, so a 2nd await repeats it

AgentPool.Cancel(id):
    h = handles[id]; h.status = cancelled; h.cancel()   # child's runCtx done -> Run returns

# the tools are a thin FuncSource over the pool; await_agent BLOCKS as a slow
# tool call inside the Runner's normal concurrent dispatch — no Runner change.
```

Delivery is **pull-only**: a spawned result sits on its handle until `await_agent` pulls it. This is the deliberate contrast with `AsyncAgentSource`, which auto-injects on completion. Spawn+await = model-driven rendezvous the model *chooses* to join; a handle outlives the spawning turn, so it can spawn in one turn and await several turns later.

## Sequence diagram

```mermaid
sequenceDiagram
    participant M as Main model
    participant R as Main Runner (dispatch)
    participant SS as SpawnSource (tools)
    participant P as AgentPool
    participant C as Child Runner (goroutine)
    M->>R: call spawn_agent(name=worker, task)
    R->>SS: spawn_agent
    SS->>P: Spawn(ctx, worker, task)
    P->>C: go child.Run(DetachForBackground ctx)
    P-->>SS: "agent-1"
    SS-->>M: spawned worker as agent-1 (running)
    Note over M,C: main continues; child runs in the background
    M->>R: (later) call await_agent(id=agent-1)
    R->>SS: await_agent
    SS->>P: Await(ctx, agent-1)
    C-->>P: Run returns → handle.finish → close(done)
    P-->>SS: result
    SS-->>M: child's final text
    opt no longer needed
        M->>SS: cancel_agent(agent-1)
        SS->>P: Cancel → runCtx cancelled → child Run returns
    end
```

## Decision log

- **The pool is `agent/`-layer, not host** (the issue first sketched host-layer). Running a child in the background with correct **depth/scope threading** needs the unexported `withAgentDepth`/`withAgentScope`/`core.DetachForBackground` plumbing, so the reusable primitive belongs beside `AgentSource`/`AsyncAgentSource`. Host is a thin wiring layer (build the pool from personas, add the tools). Still **no Runner change** — the whole thing is goroutines + a `FuncSource`.
- **Pull-only delivery (await), not auto-injection.** Auto-injection is `AsyncAgentSource`'s model; mixing both would double-deliver and blur the two primitives. A handle the model explicitly awaits is the distinct value here (plus cancel, which async can't do).
- **`await_agent` blocks as a normal tool call.** The Runner already runs tool calls concurrently and joins; a blocking await is just a slow tool. No interruptible turn needed (that's piece C, for reacting to signals mid-fan-out).
- **Catalog = the configured personas.** Spawn resolves `name` against `Config.SubAgents`; a dynamic agent catalog (`add_agent`/`spawn(role)`) is issue 1038, out of scope. A persona is reachable both as a blocking tool and as a spawnable agent.
- **`transfer_to` stays Team's (943).** Folded in by not duplicating — handoff is a distinct control mode with its own swap loop.

## Risk / blast radius

- **Affects:** additive only. New `agent/agent_pool.go`, one host file, a `RunnerControl` config flag (default off). No existing type or signature changed; `RunnerControl` off = zero new tools, `agentPool` nil.
- **Concurrency:** the pool is mutex-guarded; a handle's `done` closes exactly once in `finish`; `Cancel` before completion is deterministic (the child can't finish until its ctx is cancelled — the cancel test relies on this).
- **Be paranoid about:** a background child sharing the main provider (in the host, personas reuse the main provider) — fine in production, but a **shared sequential `StubProvider`** across the main turn and a background child races, which is why the host test asserts wiring and the agent-layer tests use isolated providers.
- **Tests:** 6 agent-layer + 2 host wiring; full `just test-agent` green.

## Before / after

Before: a sub-agent was either blocking (`AgentSource`, answer now) or fire-and-inject (`AsyncAgentSource`, result arrives whenever). The model could not hold a handle, await at a chosen point, or cancel a background child.

After (from `TestSpawnSource_Tools` / `TestAgentPool_Cancel`):

```
spawn_agent(name=worker, task=go)   -> "spawned \"worker\" as agent-1 (running in the background)"
await_agent(id=agent-1)             -> "tool answer"        # the child's result, pulled
cancel_agent(id=agent-1)            -> "cancelled agent-1"  # for a child no longer needed
list_agents()                        -> "agent-1 (worker): done"
```

## Out of scope (deliberately deferred)

- Reacting to a signal / partial result mid-fan-out → the interruptible turn, issue 1167 (piece C).
- A dynamic agent catalog (`add_agent` / `spawn(role)`) with a recomputed graph → issue 1038.
- Auto-injection of a spawned result → already covered by `AsyncAgentSource` (1035); a spawn that also injects would blur the two.
- Model-visible durable poll/cancel that survives a restart → a real `ext/tasks` task, not an ephemeral goroutine.

