### PR TITLE
feat(agent): opt-in interruptible turn (barrier break on signal) — 1036 piece C

### DIFF
--- a/agent/host/app.go
+++ b/agent/host/app.go
@@ -558,6 +558,10 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 		// (issue 1165); sub-agent Runners do not set a policy (they raise, they
 		// do not react). Nil for the inject-and-continue default.
 		SignalPolicy: signalPolicyFor(cfg.SignalPolicy),
+		// The main agent's turn may break the fan-out barrier on a mid-flight
+		// signal and re-plan (issue 1167); off by default. Sub-agent Runners
+		// stay pure fan-out-then-join.
+		Interruptible: cfg.Interruptible,
 	}
 	// Only set Approval when a policy exists: a nil *TieredApproval boxed in
 	// the interface would read as non-nil and gate every call to a deny.

--- a/agent/host/config.go
+++ b/agent/host/config.go
@@ -32,6 +32,15 @@ type Config struct {
 	MaxTreeSteps  int `json:"maxTreeSteps,omitempty"`
 	MaxTreeTokens int `json:"maxTreeTokens,omitempty"`
 
+	// Interruptible opts the main agent's turn into breaking the fan-out join
+	// barrier when a sub-agent raises a Signal mid-flight (issue 1167): the first
+	// signal cancels the remaining in-flight calls and the model re-plans with
+	// the partial results, instead of waiting for every sub-agent. Only useful
+	// with signalling sub-agents (SubAgents + CanSignal). False (the default)
+	// keeps the pure fan-out-then-join. Pairs with SignalPolicy: leave it unset
+	// (inject) so the turn re-plans rather than aborts.
+	Interruptible bool `json:"interruptible,omitempty"`
+
 	// RunnerControl, when true, gives the main agent the runner-control
 	// meta-tools (issue 1166): spawn_agent / await_agent / cancel_agent /
 	// list_agents, over the configured sub-agent personas. The model can run a

--- a/agent/interruptible_test.go
+++ b/agent/interruptible_test.go
@@ -1,0 +1,151 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+// twoChildParent builds a parent Runner that calls sub-agents A and B in one
+// turn, then answers "re-planned". A is the signalling child; B is supplied by
+// the caller (blocking or normal). interruptible toggles the gate.
+func twoChildParent(t *testing.T, a, b *AgentSource, interruptible bool) (*Runner, *StubProvider) {
+	t.Helper()
+	tools := NewMultiSource()
+	if err := tools.Add("a-src", a); err != nil {
+		t.Fatal(err)
+	}
+	if err := tools.Add("b-src", b); err != nil {
+		t.Fatal(err)
+	}
+	stub := NewStubProvider(
+		StubTurn{ToolCalls: []ToolCall{
+			{ID: "ca", Name: a.cfg.Name, Args: core.NewRawJSON(json.RawMessage(`{"task":"go"}`))},
+			{ID: "cb", Name: b.cfg.Name, Args: core.NewRawJSON(json.RawMessage(`{"task":"go"}`))},
+		}},
+		StubTurn{Text: "re-planned"},
+	)
+	r, err := NewRunner(RunnerConfig{Provider: stub, Tools: tools, Interruptible: interruptible})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return r, stub
+}
+
+func blockingChild(t *testing.T, name string) *AgentSource {
+	t.Helper()
+	r, err := NewRunner(RunnerConfig{Provider: blockingProvider{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	as, err := NewAgentSource(AgentSourceConfig{Name: name, Description: "blocks", Runner: r})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return as
+}
+
+func toolTexts(result *TurnResult) []string {
+	var out []string
+	for _, m := range result.Messages {
+		if m.Role == RoleTool {
+			out = append(out, m.Text)
+		}
+	}
+	return out
+}
+
+func containsSubstr(ss []string, sub string) bool {
+	for _, s := range ss {
+		if strings.Contains(s, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestInterruptibleTurn_SignalBreaksBarrier: child A signals mid-fan-out while
+// child B blocks forever. In an interruptible turn A's signal cancels B, the
+// dispatch returns partial results, and the parent re-plans — so the turn
+// completes instead of hanging on B.
+func TestInterruptibleTurn_SignalBreaksBarrier(t *testing.T) {
+	a := signalingChild(t, "A", "escalate", "found it")
+	b := blockingChild(t, "B")
+	parent, _ := twoChildParent(t, a, b, true)
+
+	var mu sync.Mutex
+	var sawSignal bool
+	result, err := parent.Run(context.Background(), []Message{{Role: RoleUser, Text: "go"}}, func(e Event) {
+		if e.Kind == EventSignal {
+			mu.Lock()
+			sawSignal = true
+			mu.Unlock()
+		}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Text != "re-planned" {
+		t.Fatalf("parent final = %q, want it to re-plan after the interrupt", result.Text)
+	}
+	if !sawSignal {
+		t.Fatal("no EventSignal; the interrupt was not signal-driven")
+	}
+	// B blocks forever, so its only possible terminal result is a cancellation.
+	if !containsSubstr(toolTexts(result), "cancelled by user") {
+		t.Fatalf("no cancelled sibling among %v; B was not interrupted", toolTexts(result))
+	}
+}
+
+// TestInterruptibleTurn_NoSignalWaitsForAll: with the gate on but no signal,
+// the dispatch still waits for every call — identical to the default barrier.
+func TestInterruptibleTurn_NoSignalWaitsForAll(t *testing.T) {
+	a, _ := NewAgentSource(AgentSourceConfig{Name: "A", Description: "d", Runner: childRunner(t, StubTurn{Text: "A done"})})
+	b, _ := NewAgentSource(AgentSourceConfig{Name: "B", Description: "d", Runner: childRunner(t, StubTurn{Text: "B done"})})
+	parent, _ := twoChildParent(t, a, b, true)
+
+	result, err := parent.Run(context.Background(), []Message{{Role: RoleUser, Text: "go"}}, func(Event) {})
+	if err != nil {
+		t.Fatal(err)
+	}
+	texts := toolTexts(result)
+	if !containsSubstr(texts, "A done") || !containsSubstr(texts, "B done") {
+		t.Fatalf("tool results = %v, want both children to complete", texts)
+	}
+	if containsSubstr(texts, "cancelled") {
+		t.Fatalf("a call was cancelled with no signal: %v", texts)
+	}
+}
+
+// TestInterruptibleOff_IgnoresSignalForBarrier: with the gate OFF, a child's
+// signal does not break the barrier — every call still completes (the signal is
+// only recorded/injected). B is a normal child (a blocking one would hang, which
+// is exactly the barrier the gate opts out of).
+func TestInterruptibleOff_IgnoresSignalForBarrier(t *testing.T) {
+	a := signalingChild(t, "A", "escalate", "found it")
+	b, _ := NewAgentSource(AgentSourceConfig{Name: "B", Description: "d", Runner: childRunner(t, StubTurn{Text: "B done"})})
+	parent, _ := twoChildParent(t, a, b, false)
+
+	var sawSignal bool
+	result, err := parent.Run(context.Background(), []Message{{Role: RoleUser, Text: "go"}}, func(e Event) {
+		if e.Kind == EventSignal {
+			sawSignal = true
+		}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !containsSubstr(toolTexts(result), "B done") {
+		t.Fatalf("B did not complete with the gate off: %v", toolTexts(result))
+	}
+	if containsSubstr(toolTexts(result), "cancelled") {
+		t.Fatalf("a call was cancelled with the gate off: %v", toolTexts(result))
+	}
+	if !sawSignal {
+		t.Fatal("signal should still be recorded/injected even with the gate off")
+	}
+}

--- a/agent/runner.go
+++ b/agent/runner.go
@@ -117,6 +117,19 @@ type RunnerConfig struct {
 	// pre-loop.
 	Compactor Compactor
 
+	// Interruptible opts this Runner's turn into breaking the fan-out join
+	// barrier when a child raises an upward Signal mid-flight (issue 1167, piece
+	// C of the 1036 control axis). Default false keeps the turn a pure
+	// fan-out-then-join — the property resume / fork / eval / compaction rely on;
+	// only a signal-wired turn should set it. When true, the first signal a
+	// child raises during a dispatch cancels the remaining in-flight calls
+	// (they feed back "cancelled by user") and the dispatch returns the partial
+	// results, so the turn's step loop re-enters the model to re-plan. With no
+	// signal, an interruptible turn still waits for every call, identical to the
+	// default. The re-entry ordering is the one bounded-nondeterminism exception
+	// to the pure turn; every emitted event still projects 1:1 (A2).
+	Interruptible bool
+
 	// SignalPolicy, when non-nil, decides how this Runner (as a parent) reacts
 	// to the upward Signals its children raised during a dispatch, read at the
 	// join (issue 1165). It runs after the fan-out has joined, so it chooses
@@ -554,9 +567,23 @@ func (g *callCancels) cancel(id string) {
 // the turn. A fresh signal sink is installed per dispatch (not shared across
 // the tree): a sub-agent spawned by one of these calls raises into THIS sink,
 // its immediate parent's, and a nested dispatch shadows it for grandchildren.
+//
+// In an interruptible turn (RunnerConfig.Interruptible, issue 1167), the first
+// signal a child raises cancels the remaining in-flight calls (they feed back
+// "cancelled by user") and dispatch returns the partial results, so the step
+// loop re-enters the model. parent stays the (sink-installed) step ctx and the
+// calls run under a cancellable child of it, so a fan cancel reads as a per-call
+// "cancelled by user" (parent live), never a turn abort.
 func (r *Runner) dispatch(ctx context.Context, step int, calls []ToolCall, tools []core.ToolDef, emit func(Event), reg *callCancels) ([]Message, []Signal) {
 	sink := &signalSink{}
-	ctx = withDispatchSink(ctx, sink)
+	parent := withDispatchSink(ctx, sink)
+	callBase := parent
+	var cancelFan context.CancelFunc
+	if r.cfg.Interruptible {
+		sink.notify = make(chan struct{})
+		callBase, cancelFan = context.WithCancel(parent)
+		defer cancelFan()
+	}
 	results := make([]Message, len(calls))
 	var emitMu sync.Mutex
 	locked := func(ev Event) {
@@ -570,10 +597,10 @@ func (r *Runner) dispatch(ctx context.Context, step int, calls []ToolCall, tools
 		wg.Add(1)
 		go func(i int, call ToolCall) {
 			defer wg.Done()
-			callCtx := ctx
+			callCtx := callBase
 			if reg != nil {
 				var cancel context.CancelFunc
-				callCtx, cancel = context.WithCancel(ctx)
+				callCtx, cancel = context.WithCancel(callBase)
 				reg.add(call.ID, cancel)
 				defer func() {
 					reg.remove(call.ID)
@@ -583,12 +610,28 @@ func (r *Runner) dispatch(ctx context.Context, step int, calls []ToolCall, tools
 			toolCtx, toolSpan := r.cfg.TracerProvider.StartSpan(callCtx, "agent.tool",
 				core.Attribute{Key: "agent.tool.name", Value: call.Name})
 			locked(Event{Kind: EventToolBegin, Step: step, ToolCall: &call})
-			text := r.callTool(toolCtx, ctx, step, call, tools, locked, toolSpan)
+			text := r.callTool(toolCtx, parent, step, call, tools, locked, toolSpan)
 			toolSpan.End()
 			results[i] = Message{Role: RoleTool, ToolCallID: call.ID, Text: text}
 		}(i, call)
 	}
-	wg.Wait()
+
+	if cancelFan == nil {
+		wg.Wait()
+		return results, sink.drain()
+	}
+	// Interruptible: stop waiting the moment a child signals, cancel the rest,
+	// then still wg.Wait for the cancelled calls to unwind so every result slot
+	// is filled (providers require a result per tool call). No signal => the
+	// select falls through on allDone, identical to the default barrier.
+	allDone := make(chan struct{})
+	go func() { wg.Wait(); close(allDone) }()
+	select {
+	case <-allDone:
+	case <-sink.notify:
+		cancelFan()
+		<-allDone
+	}
 	return results, sink.drain()
 }
 

--- a/agent/signal.go
+++ b/agent/signal.go
@@ -109,12 +109,23 @@ var ErrSignalAbort = errors.New("agent: turn aborted by child signal")
 type signalSink struct {
 	mu      sync.Mutex
 	signals []Signal
+
+	// notify, when non-nil, is closed exactly once on the first raise, so an
+	// interruptible dispatch (issue 1167) can break its join barrier the moment a
+	// child signals. Nil in the default (non-interruptible) path — signals are
+	// then only read at the join.
+	notify chan struct{}
+	once   sync.Once
 }
 
 func (s *signalSink) raise(sig Signal) {
 	s.mu.Lock()
 	s.signals = append(s.signals, sig)
+	n := s.notify
 	s.mu.Unlock()
+	if n != nil {
+		s.once.Do(func() { close(n) })
+	}
 }
 
 // drain returns the collected signals and clears the sink.

--- a/examples/agents/kitchen-sink/kitchen-sink.json
+++ b/examples/agents/kitchen-sink/kitchen-sink.json
@@ -1,6 +1,7 @@
 {
   "instructions": "You are a capable assistant with access to MCP tools, specialist sub-agents (researcher, analyst), a background deep_researcher, and a review_team fan-out tool. Use working memory to remember durable facts the user tells you; delegate research/analysis to the sub-agents when it helps; for a thorough report the user doesn't need immediately, call deep_researcher (it runs in the background and its report arrives on a later turn, so acknowledge and move on); and when asked for a review or multiple perspectives on a plan call review_team (three reviewers in parallel). Keep answers concise.",
   "signalPolicy": "inject",
+  "interruptible": true,
   "runnerControl": true,
   "connections": {
     "active": "deepseek-r1",


### PR DESCRIPTION
## What changes

Adds the **opt-in interruptible turn** (issue 1167, piece C of the 1036 control-axis epic) — the one deliberate exception to the pure fan-out-then-join. `RunnerConfig.Interruptible` (default **off**) lets a turn break its fan-out join barrier when a child raises an upward `Signal` (piece A) mid-flight: the first signal cancels the remaining in-flight calls and the dispatch returns the **partial** results, so the model re-plans instead of waiting for every sub-agent. This is what makes adaptive fan-out ("one finder found it, stop the rest and re-plan") possible.

The elegant part: **`RunTurn` doesn't change.** The re-entry falls out of the step loop that already appends tool results and injects the signal note (from piece A). C is a localized change to `dispatch` — break early on signal — and the existing loop provides the re-plan.

> **Stacked on #1169 (piece B), which is stacked on #1168 (piece A).** Base is `feat/1166-runner-control-metatools`, so this PR's own diff is just the C files. Retarget to `main` once A/B merge.

## Reviewer's guide

Read in this order:
1. [agent/runner.go](https://github.com/panyam/mcpkit/pull/1170/files#diff-6d787b427ac08cd61669af7e34ff0b747c4264d20b31b21b681a2ec2c826d9f0) — start here. The `dispatch` rewrite (the whole change) and the `RunnerConfig.Interruptible` doc. The subtle part is the **parent-vs-callBase ctx split**, see "How it works".
2. [agent/signal.go](https://github.com/panyam/mcpkit/pull/1170/files#diff-98761de362bbd0c99796bb3ab5360ee494436658720dedf38865cec20180dee4) — the sink gains a `notify` channel closed once on the first raise (nil in the default path).
3. [agent/interruptible_test.go](https://github.com/panyam/mcpkit/pull/1170/files#diff-b39f3eb63423f185905a91d925be1da13df1eb635b8e2297211d81655904efa8) — acceptance: signal-breaks-barrier (past a blocking sibling), gate-on-no-signal-waits-for-all (regression), gate-off-ignores-signal.
4. `agent/host/{config,app}.go` + `kitchen-sink.json` — `Config.Interruptible` threads to the main Runner only; skim.

## How it works (the ctx split is the load-bearing decision)

A fan cancel must cancel the *remaining calls* but NOT the step, so a cancelled sibling reads as a clean "cancelled by user" (which `callTool` detects as `callCtx done && parentCtx live`) rather than a turn abort. So `dispatch` keeps two contexts:

- **`parent`** = the sink-installed step ctx. Passed to `callTool` as its `parent` arg. Stays live.
- **`callBase`** = a cancellable child of `parent`, only in interruptible mode. The calls run under it. Cancelling it is the fan cancel.

```
dispatch(ctx, calls):
    sink = signalSink
    parent   = withDispatchSink(ctx, sink)     # stays live; passed as callTool's parent
    callBase = parent
    if Interruptible:
        sink.notify = make(chan)                # closed once on first raise
        callBase, cancelFan = WithCancel(parent)  # the calls run under this
    for each call: go callTool(toolCtx from callBase, parent, ...)   # note: parent, not callBase

    if not Interruptible:
        wg.Wait(); return results, sink.drain()   # unchanged default path

    allDone = chan; go { wg.Wait(); close(allDone) }
    select:
        <-allDone:            # no signal — every call finished, same as the barrier
        <-sink.notify:        # a child signalled mid-flight
            cancelFan()       # cancel the remaining in-flight calls
            <-allDone         # still wait for them to unwind → every result slot filled
    return results, sink.drain()

# RunTurn is UNCHANGED: it already appends the (partial) tool results, emits
# EventSignal, applies SignalPolicy, injects the signal note, and loops — that
# loop IS the model re-entry. C only makes dispatch return early.
```

Every tool call still gets a result (cancelled siblings feed back "cancelled by user"), so the assistant/tool-result pairing providers require is preserved. With no signal, the `select` falls through on `allDone` — byte-identical to the old barrier.

## Sequence diagram

```mermaid
sequenceDiagram
    participant M as Parent model
    participant PR as Parent Runner (RunTurn loop)
    participant D as dispatch
    participant A as Child A (signals)
    participant B as Child B (slow)
    participant SK as signal sink
    M->>PR: call [A, B] in one turn
    PR->>D: dispatch (Interruptible)
    D->>A: run A
    D->>B: run B (still working)
    A->>SK: signal_parent(escalate) → close(notify)
    Note over D,SK: select sees notify before allDone
    D->>B: cancelFan() → B ctx cancelled
    B-->>D: "cancelled by user"
    D-->>PR: (partial results: A real, B cancelled), [signal]
    PR->>M: emit EventSignal, inject signal note
    PR->>M: loop → next step: re-plan with partial context
```

## Decision log

- **No `RunTurn` change.** The re-entry is the existing post-dispatch loop (append results → inject signal → next step). C only changes when `dispatch` stops waiting. Keeping the barrier break inside `dispatch` is what preserves resume/fork/eval/compaction — they wrap `Run`, which stays a function of its inputs (the one bounded-nondeterminism being which calls finished before the interrupt).
- **`parent` stays live; calls run under a cancellable `callBase`.** Cancelling the *whole* step ctx would make cancelled siblings look like a turn abort (`callTool`'s `cancelled()` needs the parent live). The two-ctx split is what makes a fan cancel read as a clean per-call cancellation. In non-interruptible mode `callBase == parent`, so the default path is unchanged.
- **Still `wg.Wait()` after cancel.** Cancelled goroutines must unwind so every result slot is filled (a missing tool result breaks the provider contract). The cancel just makes that wait bounded.
- **Default off, main Runner only.** Sub-agent Runners stay pure fan-out-then-join. Only a signal-wired turn opts in.
- **Composes with `SignalPolicy` (A).** Interruptible controls *when dispatch returns*; SignalPolicy controls *abort vs inject at the join*. Interruptible + inject (the main use) = break early and re-plan; Interruptible + AbortOnEscalate = break early then abort. Independent knobs.

## Risk / blast radius

- **Affects:** `dispatch` only (plus a nil-by-default sink field and one config flag). `Interruptible=false` is byte-identical to before — guarded by `TestInterruptibleTurn_NoSignalWaitsForAll` and `TestInterruptibleOff_IgnoresSignalForBarrier`.
- **Concurrency:** the `notify` channel closes once (`sync.Once`); `select` on `allDone` vs `notify`; tests run under `-race`.
- **Be paranoid about:** the ctx split (a cancelled sibling must read "cancelled by user", not "failed"), and the "still wg.Wait after cancel" (no orphaned goroutine, every result slot filled). Both are asserted.
- **Tests:** 3 agent-layer (`-race`); full `just test-agent` green.

## Before / after

Before: a fan-out of N sub-agents always waits for all N (`wg.Wait()`), even if one finds the answer in the first second. No mid-flight re-planning.

After (`Interruptible: true`), from `TestInterruptibleTurn_SignalBreaksBarrier`:

```
turn: call [A, B]           # A finds it fast; B is slow/blocked
A: signal_parent(escalate, "found it")   → sink.notify fires
dispatch: cancel B          → B result = "cancelled by user"
dispatch returns partial [A result, B cancelled] + the signal
parent: re-plans → "re-planned"          # completes instead of waiting on B
```

## Out of scope (deliberately deferred)

- The preemption signal kind (`preempt`/`sufficient` — "cancel the losers by name") → its non-referential design was noted when `cancel_siblings` was dropped from piece A; a dedicated kind can land on top of this barrier-break if wanted.
- A per-`TurnRequest` interruptible override (vs the per-Runner flag) → additive later if a caller needs per-turn control.
- Reacting to a *partial result* (not just a signal) mid-fan-out → the same barrier-break machinery; a policy hook is a follow-up.

