### PR TITLE
feat(server): generalized resultType + DiscoverResult caching hints (issue 1174)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,19 @@ targeted spec version.
   for external `QuotaStore` implementors (experimental surface). (issue 774)
 
 ### Added / Fixed
+- **Generalized `resultType` discriminator + DiscoverResult caching hints
+  (2026-07-28 final revision, issue 1174).** Every result the server emits on
+  the 2026-07-28 wire now carries the required `resultType` field (stamped
+  `"complete"` when a result type doesn't set its own; the MRTR
+  `"input_required"` and tasks `"task"` variants keep their values), via a
+  new `core.InjectResultTypeIntoResult` applied at both dispatch chokepoints
+  — always on the stateless wire, feature-gated on the legacy wire so
+  pre-draft sessions keep byte-identical output. `DiscoverResult` gains the
+  now-required `ttlMs` + `cacheScope` fields (conformant defaults: 0,
+  public). Clears 11 of the 13 wire-schema-valid failures surfaced by
+  upstream conformance's new per-version schema validation; the remaining
+  task-envelope errors are an upstream validator gap (no `resultType: task`
+  branch), annotated in `conformance/known-gaps.yaml`.
 - **CIMD advertised-support gate + SEP-2207 refresh-token registration.**
   `OAuthTokenSource` now prefers its configured `ClientMetadataURL` as the
   client_id exactly when the AS advertises

--- a/conformance/UPSTREAM_AUDIT.md
+++ b/conformance/UPSTREAM_AUDIT.md
@@ -1,8 +1,8 @@
 # Upstream Conformance Audit
 
-Snapshot of mcpkit graded against `modelcontextprotocol/conformance@794dcab` — *chore: bump version to 0.2.0-alpha.9 (#377)*.
+Snapshot of mcpkit graded against `modelcontextprotocol/conformance@49103de` — *feat(sdk-runner): add rust-sdk + per-spec-version config overlays (#419)*.
 
-**mcpkit HEAD:** `794dcab`  
+**mcpkit HEAD:** `49103de`  
 **Driver:** `cmd/testserver` (server scenarios) + `cmd/testclient` (client scenarios). SEP-2663 `tasks-*` server scenarios are graded against `examples/tasks-v2` instead, which wires `ext/tasks` in its own module (keeping the root module free of that dependency) — mirroring how `testconf-stateless` uses `examples/stateless`.
 
 Informational report — not a CI gate. Regenerate via `just testconf-upstream-audit`.
@@ -13,9 +13,9 @@ Status legend: **pass** = no FAILURE checks · **partial** = at least one SUCCES
 
 | Surface | Scenarios | Checks | Pass | Fail | Warn | Info | Skipped | Harness-gap |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|
-| Server | 61 | 175 | 149 | 11 | 8 | 6 | 1 | 0 |
-| Client | 40 | 1263 | 449 | 9 | 2 | 801 | 2 | 0 |
-| **Total** | **101** | **1438** | **598** | **20** | **10** | **807** | **3** | **0** |
+| Server | 61 | 231 | 197 | 19 | 8 | 6 | 1 | 0 |
+| Client | 43 | 1536 | 536 | 8 | 0 | 990 | 2 | 0 |
+| **Total** | **104** | **1767** | **733** | **27** | **8** | **996** | **3** | **0** |
 
 ## Harness gaps
 
@@ -27,11 +27,10 @@ _None — every scenario produced results._
 
 | Scenario | Surface | Status | Checks | Note |
 |---|---|---|---|---|
-| `tools_call` | client | fail | 1 fail |  |
-| `auth/2025-03-26-oauth-endpoint-fallback` | client | partial | 3 fail / 10 info |  |
-| `auth/2025-03-26-oauth-metadata-backcompat` | client | partial | 4 fail / 10 info |  |
-| `auth/authorization-server-migration` | client | partial | 2 pass / 1 fail / 4 info |  |
-| `auth/basic-cimd` | client | pass | 17 pass / 1 warn / 34 info |  |
+| `auth/2025-03-26-oauth-endpoint-fallback` | client | pass | 11 pass / 36 info |  |
+| `auth/2025-03-26-oauth-metadata-backcompat` | client | pass | 16 pass / 36 info |  |
+| `auth/authorization-server-migration` | client | pass | 31 pass / 48 info |  |
+| `auth/basic-cimd` | client | pass | 17 pass / 32 info |  |
 | `auth/iss-normalized` | client | pass | 8 pass / 14 info |  |
 | `auth/iss-not-advertised` | client | pass | 12 pass / 18 info |  |
 | `auth/iss-supported` | client | pass | 12 pass / 18 info |  |
@@ -53,39 +52,40 @@ _None — every scenario produced results._
 | `auth/token-endpoint-auth-basic` | client | pass | 22 pass / 34 info |  |
 | `auth/token-endpoint-auth-none` | client | pass | 22 pass / 34 info |  |
 | `auth/token-endpoint-auth-post` | client | pass | 22 pass / 34 info |  |
-| `completion-complete` | server | pass | 1 pass |  |
+| `completion-complete` | server | pass | 2 pass |  |
 | `dns-rebinding-protection` | server | pass | 2 pass |  |
 | `initialize` | client | pass | 1 pass / 1 info |  |
-| `logging-set-level` | server | pass | 1 pass |  |
-| `ping` | server | pass | 1 pass |  |
-| `prompts-get-embedded-resource` | server | pass | 1 pass |  |
-| `prompts-get-simple` | server | pass | 1 pass |  |
-| `prompts-get-with-args` | server | pass | 1 pass |  |
-| `prompts-get-with-image` | server | pass | 1 pass |  |
-| `prompts-list` | server | pass | 1 pass |  |
-| `resources-list` | server | pass | 1 pass |  |
-| `resources-read-binary` | server | pass | 1 pass |  |
-| `resources-read-text` | server | pass | 1 pass |  |
-| `resources-subscribe` | server | pass | 1 pass |  |
-| `resources-templates-read` | server | pass | 1 pass |  |
-| `resources-unsubscribe` | server | pass | 1 pass |  |
-| `server-initialize` | server | pass | 2 pass |  |
-| `tools-call-audio` | server | pass | 1 pass |  |
-| `tools-call-elicitation` | server | pass | 1 pass |  |
-| `tools-call-embedded-resource` | server | pass | 1 pass |  |
-| `tools-call-error` | server | pass | 1 pass |  |
-| `tools-call-image` | server | pass | 1 pass |  |
-| `tools-call-mixed-content` | server | pass | 1 pass |  |
-| `tools-call-sampling` | server | pass | 1 pass |  |
-| `tools-call-simple-text` | server | pass | 1 pass |  |
-| `tools-call-with-logging` | server | pass | 1 pass |  |
-| `tools-call-with-progress` | server | pass | 1 pass |  |
+| `logging-set-level` | server | pass | 2 pass |  |
+| `ping` | server | pass | 2 pass |  |
+| `prompts-get-embedded-resource` | server | pass | 2 pass |  |
+| `prompts-get-simple` | server | pass | 2 pass |  |
+| `prompts-get-with-args` | server | pass | 2 pass |  |
+| `prompts-get-with-image` | server | pass | 2 pass |  |
+| `prompts-list` | server | pass | 2 pass |  |
+| `resources-list` | server | pass | 2 pass |  |
+| `resources-read-binary` | server | pass | 2 pass |  |
+| `resources-read-text` | server | pass | 2 pass |  |
+| `resources-subscribe` | server | pass | 2 pass |  |
+| `resources-templates-read` | server | pass | 2 pass |  |
+| `resources-unsubscribe` | server | pass | 2 pass |  |
+| `server-initialize` | server | pass | 3 pass |  |
+| `tools_call` | client | pass | 2 pass |  |
+| `tools-call-audio` | server | pass | 2 pass |  |
+| `tools-call-elicitation` | server | pass | 2 pass |  |
+| `tools-call-embedded-resource` | server | pass | 2 pass |  |
+| `tools-call-error` | server | pass | 2 pass |  |
+| `tools-call-image` | server | pass | 2 pass |  |
+| `tools-call-mixed-content` | server | pass | 2 pass |  |
+| `tools-call-sampling` | server | pass | 2 pass |  |
+| `tools-call-simple-text` | server | pass | 2 pass |  |
+| `tools-call-with-logging` | server | pass | 2 pass |  |
+| `tools-call-with-progress` | server | pass | 2 pass |  |
 
 ### [SEP-986](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/986) (1 scenarios)
 
 | Scenario | Surface | Status | Checks | Note |
 |---|---|---|---|---|
-| `tools-list` | server | pass | 2 pass |  |
+| `tools-list` | server | pass | 3 pass |  |
 
 ### [SEP-990-ENTERPRISE-MANAGED-OAUTH](https://github.com/modelcontextprotocol/ext-auth/blob/main/specification/draft/enterprise-managed-authorization.mdx) (1 scenarios)
 
@@ -98,7 +98,7 @@ _None — every scenario produced results._
 | Scenario | Surface | Status | Checks | Note |
 |---|---|---|---|---|
 | `elicitation-sep1034-client-defaults` | client | pass | 5 pass / 20 info |  |
-| `elicitation-sep1034-defaults` | server | pass | 5 pass |  |
+| `elicitation-sep1034-defaults` | server | pass | 6 pass |  |
 
 ### [SEP-1046-CLIENT-CREDENTIALS](https://github.com/modelcontextprotocol/ext-auth/blob/main/specification/draft/oauth-client-credentials.mdx) (2 scenarios)
 
@@ -111,13 +111,13 @@ _None — every scenario produced results._
 
 | Scenario | Surface | Status | Checks | Note |
 |---|---|---|---|---|
-| `elicitation-sep1330-enums` | server | pass | 5 pass |  |
+| `elicitation-sep1330-enums` | server | pass | 6 pass |  |
 
 ### [SEP-1613](https://github.com/modelcontextprotocol/specification/pull/655) (1 scenarios)
 
 | Scenario | Surface | Status | Checks | Note |
 |---|---|---|---|---|
-| `json-schema-2020-12` | server | pass | 7 pass |  |
+| `json-schema-2020-12` | server | pass | 8 pass |  |
 
 ### [SEP-1699](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1699) (3 scenarios)
 
@@ -126,6 +126,19 @@ _None — every scenario produced results._
 | `server-sse-multiple-streams` | server | pass | 2 pass |  |
 | `server-sse-polling` | server | pass | 3 warn / 6 info |  |
 | `sse-retry` | client | pass | 3 pass / 17 info |  |
+
+### [SEP-1932-DPOP](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1932) (2 scenarios)
+
+| Scenario | Surface | Status | Checks | Note |
+|---|---|---|---|---|
+| `auth/dpop` | client | partial | 9 pass / 3 fail / 34 info |  |
+| `auth/dpop-nonce` | client | partial | 9 pass / 5 fail / 34 info |  |
+
+### [SEP-1933-WORKLOAD-IDENTITY-FEDERATION](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1933) (1 scenarios)
+
+| Scenario | Surface | Status | Checks | Note |
+|---|---|---|---|---|
+| `auth/wif-jwt-bearer` | client | pass | 12 pass / 28 info |  |
 
 ### [SEP-2106](https://modelcontextprotocol.io/seps/2106-json-schema-2020-12#security-implications) (1 scenarios)
 
@@ -137,33 +150,33 @@ _None — every scenario produced results._
 
 | Scenario | Surface | Status | Checks | Note |
 |---|---|---|---|---|
-| `sep-2164-resource-not-found` | server | pass | 2 pass / 1 warn |  |
+| `sep-2164-resource-not-found` | server | pass | 3 pass / 1 warn |  |
 
 ### [SEP-2207-REFRESH-TOKEN-GUIDANCE](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2207) (2 scenarios)
 
 | Scenario | Surface | Status | Checks | Note |
 |---|---|---|---|---|
 | `auth/offline-access-not-supported` | client | pass | 12 pass / 18 info |  |
-| `auth/offline-access-scope` | client | pass | 11 pass / 1 warn / 19 info |  |
+| `auth/offline-access-scope` | client | pass | 9 pass / 18 info |  |
 
 ### [SEP-2243-CUSTOM-HEADERS](https://modelcontextprotocol.io/specification/draft/basic/transports#server-behavior-for-custom-headers) (2 scenarios)
 
 | Scenario | Surface | Status | Checks | Note |
 |---|---|---|---|---|
-| `http-custom-header-server-validation` | server | fail | 5 fail | `Not testable: server exposes no tool with x-mcp-header annotations, so none of the custom-header val…` |
+| `http-custom-header-server-validation` | server | partial | 1 pass / 5 fail |  |
 | `http-custom-headers` | client | pass | 18 pass |  |
 
 ### [SEP-2243-SERVER-VALIDATION](https://modelcontextprotocol.io/specification/draft/basic/transports#server-validation) (1 scenarios)
 
 | Scenario | Surface | Status | Checks | Note |
 |---|---|---|---|---|
-| `http-header-validation` | server | partial | 11 pass / 1 fail / 1 warn |  |
+| `http-header-validation` | server | partial | 12 pass / 1 fail / 1 warn |  |
 
 ### [SEP-2243](https://modelcontextprotocol.io/seps/2243-http-standardization) (1 scenarios)
 
 | Scenario | Surface | Status | Checks | Note |
 |---|---|---|---|---|
-| `tasks-request-headers` | server | pass | 4 pass |  |
+| `tasks-request-headers` | server | partial | 4 pass / 1 fail |  |
 
 ### [SEP-2243-X-MCP-HEADER](https://modelcontextprotocol.io/specification/draft/server/tools#x-mcp-header) (1 scenarios)
 
@@ -181,22 +194,22 @@ _None — every scenario produced results._
 
 | Scenario | Surface | Status | Checks | Note |
 |---|---|---|---|---|
-| `input-required-result-basic-elicitation` | server | pass | 2 pass |  |
-| `input-required-result-basic-list-roots` | server | pass | 2 pass |  |
-| `input-required-result-basic-sampling` | server | pass | 2 pass |  |
-| `input-required-result-capability-check` | server | pass | 1 pass |  |
-| `input-required-result-ignore-extra-params` | server | pass | 1 pass |  |
-| `input-required-result-missing-input-response` | server | pass | 1 pass |  |
-| `input-required-result-multi-round` | server | pass | 3 pass |  |
-| `input-required-result-multiple-input-requests` | server | pass | 2 pass |  |
-| `input-required-result-non-tool-request` | server | pass | 2 pass |  |
-| `input-required-result-request-state` | server | pass | 2 pass |  |
-| `input-required-result-result-type` | server | pass | 1 pass |  |
-| `input-required-result-tampered-state` | server | pass | 1 pass |  |
-| `input-required-result-unsupported-methods` | server | pass | 1 pass |  |
-| `input-required-result-validate-input` | server | pass | 1 pass / 1 warn |  |
-| `tasks-mrtr-composition` | server | pass | 1 pass |  |
-| `tasks-mrtr-input` | server | pass | 3 pass |  |
+| `tasks-mrtr-composition` | server | partial | 1 pass / 1 fail |  |
+| `tasks-mrtr-input` | server | partial | 3 pass / 1 fail |  |
+| `input-required-result-basic-elicitation` | server | pass | 3 pass |  |
+| `input-required-result-basic-list-roots` | server | pass | 3 pass |  |
+| `input-required-result-basic-sampling` | server | pass | 3 pass |  |
+| `input-required-result-capability-check` | server | pass | 2 pass |  |
+| `input-required-result-ignore-extra-params` | server | pass | 2 pass |  |
+| `input-required-result-missing-input-response` | server | pass | 2 pass |  |
+| `input-required-result-multi-round` | server | pass | 4 pass |  |
+| `input-required-result-multiple-input-requests` | server | pass | 3 pass |  |
+| `input-required-result-non-tool-request` | server | pass | 3 pass |  |
+| `input-required-result-request-state` | server | pass | 3 pass |  |
+| `input-required-result-result-type` | server | pass | 2 pass |  |
+| `input-required-result-tampered-state` | server | pass | 2 pass |  |
+| `input-required-result-unsupported-methods` | server | pass | 2 pass |  |
+| `input-required-result-validate-input` | server | pass | 2 pass / 1 warn |  |
 
 ### [SEP-2322-MRTR](https://modelcontextprotocol.io/specification/draft/basic/utilities/mrtr) (1 scenarios)
 
@@ -208,26 +221,26 @@ _None — every scenario produced results._
 
 | Scenario | Surface | Status | Checks | Note |
 |---|---|---|---|---|
-| `caching` | server | pass | 7 pass |  |
+| `caching` | server | pass | 8 pass |  |
 
 ### [SEP-2575](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2575) (3 scenarios)
 
 | Scenario | Surface | Status | Checks | Note |
 |---|---|---|---|---|
 | `server-stateless` | server | fork-covered | 23 pass / 5 fail / 2 warn | Also graded by `testconf-stateless` |
-| `request-metadata` | client | pass | 5 pass / 2 skip |  |
-| `tasks-required-task-error` | server | pass | 2 pass |  |
+| `request-metadata` | client | pass | 6 pass / 2 skip |  |
+| `tasks-required-task-error` | server | pass | 3 pass |  |
 
 ### [SEP-2663](https://modelcontextprotocol.io/seps/2663-tasks-extension) (6 scenarios)
 
 | Scenario | Surface | Status | Checks | Note |
 |---|---|---|---|---|
-| `tasks-capability-negotiation` | server | pass | 4 pass |  |
-| `tasks-dispatch-and-envelope` | server | pass | 8 pass |  |
-| `tasks-lifecycle` | server | pass | 8 pass |  |
-| `tasks-request-state-removal` | server | pass | 2 pass |  |
+| `tasks-capability-negotiation` | server | partial | 4 pass / 1 fail |  |
+| `tasks-dispatch-and-envelope` | server | partial | 8 pass / 1 fail |  |
+| `tasks-lifecycle` | server | partial | 8 pass / 1 fail |  |
+| `tasks-request-state-removal` | server | partial | 2 pass / 1 fail |  |
+| `tasks-wire-fields` | server | partial | 3 pass / 1 fail |  |
 | `tasks-status-notifications` | server | pass | 1 skip |  |
-| `tasks-wire-fields` | server | pass | 3 pass |  |
 
 
 ## Methodology

--- a/conformance/known-gaps.yaml
+++ b/conformance/known-gaps.yaml
@@ -18,6 +18,30 @@
 # Keep entries terse; the renderer puts them straight into a table cell.
 
 scenarios:
+  "tasks-capability-negotiation":
+    issue: "upstream validator gap (resultType task)"
+    note: "Upstream wire-schema validator gap: SEP-2663 task envelopes (resultType task, an extension result absent from the core schema) are validated as CallToolResult and fail on missing content. mcpkit's envelope is well-formed; upstream issue pending."
+  "tasks-dispatch-and-envelope":
+    issue: "upstream validator gap (resultType task)"
+    note: "Upstream wire-schema validator gap: SEP-2663 task envelopes (resultType task, an extension result absent from the core schema) are validated as CallToolResult and fail on missing content. mcpkit's envelope is well-formed; upstream issue pending."
+  "tasks-lifecycle":
+    issue: "upstream validator gap (resultType task)"
+    note: "Upstream wire-schema validator gap: SEP-2663 task envelopes (resultType task, an extension result absent from the core schema) are validated as CallToolResult and fail on missing content. mcpkit's envelope is well-formed; upstream issue pending."
+  "tasks-mrtr-composition":
+    issue: "upstream validator gap (resultType task)"
+    note: "Upstream wire-schema validator gap: SEP-2663 task envelopes (resultType task, an extension result absent from the core schema) are validated as CallToolResult and fail on missing content. mcpkit's envelope is well-formed; upstream issue pending."
+  "tasks-mrtr-input":
+    issue: "upstream validator gap (resultType task)"
+    note: "Upstream wire-schema validator gap: SEP-2663 task envelopes (resultType task, an extension result absent from the core schema) are validated as CallToolResult and fail on missing content. mcpkit's envelope is well-formed; upstream issue pending."
+  "tasks-request-headers":
+    issue: "upstream validator gap (resultType task)"
+    note: "Upstream wire-schema validator gap: SEP-2663 task envelopes (resultType task, an extension result absent from the core schema) are validated as CallToolResult and fail on missing content. mcpkit's envelope is well-formed; upstream issue pending."
+  "tasks-request-state-removal":
+    issue: "upstream validator gap (resultType task)"
+    note: "Upstream wire-schema validator gap: SEP-2663 task envelopes (resultType task, an extension result absent from the core schema) are validated as CallToolResult and fail on missing content. mcpkit's envelope is well-formed; upstream issue pending."
+  "tasks-wire-fields":
+    issue: "upstream validator gap (resultType task)"
+    note: "Upstream wire-schema validator gap: SEP-2663 task envelopes (resultType task, an extension result absent from the core schema) are validated as CallToolResult and fail on missing content. mcpkit's envelope is well-formed; upstream issue pending."
   "server-stateless":
     issue: "upstream conformance test bug"
     note: "ServerRejectsUndeclaredCapability checks requiredCapabilities as string-array but SEP-2575 schema says object — mcpkit follows schema. Tracked in CLAUDE.md gotchas."

--- a/core/stateless.go
+++ b/core/stateless.go
@@ -189,6 +189,40 @@ func InjectServerInfoIntoResult(result any, info ServerInfo) any {
 	return json.RawMessage(out)
 }
 
+// InjectResultTypeIntoResult stamps the generalized `resultType`
+// discriminator onto a result object when absent. The 2026-07-28 final
+// revision requires the field on every result a server emits; clients
+// treat absence from servers on earlier versions as "complete", which is
+// exactly the value stamped here. A caller-set discriminator (the MRTR
+// "input_required" and tasks "task" variants) always wins because the
+// stamp only fires when the key is missing. Same best-effort contract as
+// InjectServerInfoIntoResult: a non-object result or any marshal failure
+// returns the input unchanged — stamping is decoration, never a dispatch
+// error.
+func InjectResultTypeIntoResult(result any) any {
+	raw, err := MarshalJSON(result)
+	if err != nil {
+		return result
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil || obj == nil {
+		return result
+	}
+	if _, present := obj["resultType"]; present {
+		return result
+	}
+	rt, err := json.Marshal(ResultTypeComplete)
+	if err != nil {
+		return result
+	}
+	obj["resultType"] = rt
+	out, err := json.Marshal(obj)
+	if err != nil {
+		return result
+	}
+	return json.RawMessage(out)
+}
+
 // UnsupportedProtocolVersionData is the structured error payload returned
 // when a stateless request advertises a protocol version this server does
 // not implement. Supported lists the server's full SupportedStatelessVersions

--- a/core/stateless_test.go
+++ b/core/stateless_test.go
@@ -337,3 +337,36 @@ func TestErrorCodeConstants(t *testing.T) {
 		t.Errorf("ErrCodeUnsupportedProtocolVersion = %d, want -32022", ErrCodeUnsupportedProtocolVersion)
 	}
 }
+
+func TestInjectResultTypeIntoResult(t *testing.T) {
+	t.Run("absent gets complete", func(t *testing.T) {
+		out := InjectResultTypeIntoResult(map[string]any{"tools": []any{}})
+		raw, ok := out.(json.RawMessage)
+		if !ok {
+			t.Fatalf("expected json.RawMessage, got %T", out)
+		}
+		var obj map[string]any
+		json.Unmarshal(raw, &obj)
+		if got := obj["resultType"]; got != "complete" {
+			t.Errorf("resultType = %v, want complete", got)
+		}
+	})
+	t.Run("caller-set discriminator wins", func(t *testing.T) {
+		in := map[string]any{"taskId": "t1", "resultType": "task"}
+		out := InjectResultTypeIntoResult(in)
+		raw, err := MarshalJSON(out)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var obj map[string]any
+		json.Unmarshal(raw, &obj)
+		if got := obj["resultType"]; got != "task" {
+			t.Errorf("resultType = %v, want task preserved", got)
+		}
+	})
+	t.Run("non-object result unchanged", func(t *testing.T) {
+		if out := InjectResultTypeIntoResult("not-an-object"); out != "not-an-object" {
+			t.Errorf("non-object result mutated: %v", out)
+		}
+	})
+}

--- a/server/dispatch.go
+++ b/server/dispatch.go
@@ -377,6 +377,18 @@ func (d *Dispatcher) Dispatch(ctx context.Context, req *core.Request) (resp *cor
 		}
 	}()
 
+	// 2026-07-28 final revision: every result carries the generalized
+	// resultType discriminator. Stamped at this single exit point so every
+	// branch below is covered; version-gated through the feature table so
+	// pre-draft sessions keep byte-identical wire output. Registered after
+	// the recovery defer (LIFO: runs before it), so a panic-recovery error
+	// response is never stamped — the Error guard covers the normal path.
+	defer func() {
+		if resp != nil && resp.Error == nil && d.protocolFeatures().GeneralizedResultType {
+			resp.Result = core.InjectResultTypeIntoResult(resp.Result)
+		}
+	}()
+
 	switch req.Method {
 	case "initialize":
 		return d.handleInitialize(id, req.Params.Raw())

--- a/server/dispatch_test.go
+++ b/server/dispatch_test.go
@@ -1046,3 +1046,45 @@ func TestInitializeWithClientExtensions(t *testing.T) {
 		t.Errorf("stability = %q, want %q", uiExt["stability"], "experimental")
 	}
 }
+
+// 2026-07-28 final revision: the generalized resultType discriminator is
+// stamped on every legacy-wire result once the session negotiates the draft
+// version, and NOT on earlier versions (pre-draft wire output must stay
+// byte-identical).
+func TestDispatch_GeneralizedResultType_VersionGated(t *testing.T) {
+	pingResult := func(d *Dispatcher) map[string]any {
+		resp := d.Dispatch(context.Background(), &core.Request{
+			JSONRPC: "2.0", ID: json.RawMessage(`9`), Method: "ping",
+		})
+		raw, _ := json.Marshal(resp.Result)
+		var got map[string]any
+		json.Unmarshal(raw, &got)
+		return got
+	}
+
+	t.Run("2025-11-25 does not stamp", func(t *testing.T) {
+		srv := NewServer(core.ServerInfo{Name: "t", Version: "1"})
+		d := srv.dispatcher
+		d.allowReinitialize = true
+		d.Dispatch(context.Background(), &core.Request{
+			JSONRPC: "2.0", ID: json.RawMessage(`0`), Method: "initialize",
+			Params: core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"t","version":"1"}}`)),
+		})
+		if got := pingResult(d); got["resultType"] != nil {
+			t.Errorf("resultType = %v on 2025-11-25, want absent", got["resultType"])
+		}
+	})
+
+	t.Run("2026-07-28 stamps complete", func(t *testing.T) {
+		srv := NewServer(core.ServerInfo{Name: "t", Version: "1"}, WithAllowLegacyOnDraft())
+		d := srv.dispatcher
+		d.allowReinitialize = true
+		d.Dispatch(context.Background(), &core.Request{
+			JSONRPC: "2.0", ID: json.RawMessage(`0`), Method: "initialize",
+			Params: core.NewRawJSON(json.RawMessage(`{"protocolVersion":"2026-07-28","capabilities":{},"clientInfo":{"name":"t","version":"1"}}`)),
+		})
+		if got := pingResult(d); got["resultType"] != "complete" {
+			t.Errorf("resultType = %v on draft, want complete", got["resultType"])
+		}
+	})
+}

--- a/server/protocol_features.go
+++ b/server/protocol_features.go
@@ -65,6 +65,14 @@ type ProtocolFeatures struct {
 	// opt out of the strict check with WithAllowLegacyOnDraft (see
 	// Dispatcher.allowLegacyOnDraft), which is applied by the caller.
 	StatelessMetaRequired bool
+
+	// GeneralizedResultType stamps the 2026-07-28 final-revision
+	// `resultType` discriminator on every result the dispatcher emits
+	// (absent field defaults to "complete"; the MRTR and tasks variants
+	// keep their own values). Gated so pre-draft wire output stays
+	// byte-identical — clients on earlier versions are specified to
+	// treat the absent field as "complete" anyway.
+	GeneralizedResultType bool
 }
 
 // featuresForVersion resolves the version-gated feature set for a negotiated
@@ -76,6 +84,7 @@ func featuresForVersion(version string) ProtocolFeatures {
 		return ProtocolFeatures{
 			RoutingHeaderValidation: true,
 			StatelessMetaRequired:   true,
+			GeneralizedResultType:   true,
 		}
 	default:
 		return ProtocolFeatures{}

--- a/server/stateless/discover.go
+++ b/server/stateless/discover.go
@@ -26,6 +26,14 @@ import (
 type DiscoverResult struct {
 	SupportedVersions []string                `json:"supportedVersions"`
 	Capabilities      core.ServerCapabilities `json:"capabilities"`
+
+	// TTLMs and CacheScope are required on DiscoverResult in the
+	// 2026-07-28 final schema (the SEP-2549 hints extended to
+	// server/discover). Always emitted; the defaults mirror the
+	// conformant-by-default list-response posture from issue 496:
+	// immediately stale, publicly cacheable.
+	TTLMs      int    `json:"ttlMs"`
+	CacheScope string `json:"cacheScope"`
 }
 
 // handleDiscover assembles the discover response from the backend. The
@@ -35,5 +43,7 @@ func (d *Dispatcher) handleDiscover(id json.RawMessage) *core.Response {
 	return core.NewResponse(id, DiscoverResult{
 		SupportedVersions: d.Backend.SupportedVersions(),
 		Capabilities:      d.Backend.Capabilities(),
+		TTLMs:             0,
+		CacheScope:        core.CacheScopePublic,
 	})
 }

--- a/server/stateless/dispatch.go
+++ b/server/stateless/dispatch.go
@@ -72,6 +72,11 @@ func (d *Dispatcher) Dispatch(ctx context.Context, req *core.Request) (*core.Res
 	resp, err := d.dispatch(ctx, req)
 	if err == nil && resp != nil && resp.Error == nil {
 		resp.Result = core.InjectServerInfoIntoResult(resp.Result, d.Backend.ServerInfo())
+		// Generalized resultType (2026-07-28 final revision). The
+		// stateless wire only speaks the draft line, so no version gate:
+		// every success result carries the discriminator, with the MRTR
+		// and tasks variants keeping their caller-set values.
+		resp.Result = core.InjectResultTypeIntoResult(resp.Result)
 	}
 	return resp, err
 }

--- a/server/stateless/dispatch_test.go
+++ b/server/stateless/dispatch_test.go
@@ -442,3 +442,56 @@ func TestRequestMetaFromContext(t *testing.T) {
 		t.Errorf("RequestMetaFromContext: got %+v, want %+v", got, meta)
 	}
 }
+
+// 2026-07-28 final revision: every result carries the generalized resultType
+// discriminator, and DiscoverResult additionally carries the SEP-2549 caching
+// hints as required fields.
+func TestDispatch_GeneralizedResultType(t *testing.T) {
+	caps := core.ServerCapabilities{Tools: &core.ToolsCap{}}
+	info := core.ServerInfo{Name: "test", Version: "0.0.1"}
+	d := New(&fakeBackend{info: info, caps: caps})
+
+	t.Run("discover carries resultType and caching hints", func(t *testing.T) {
+		req := &core.Request{
+			JSONRPC: "2.0",
+			ID:      json.RawMessage("40"),
+			Method:  "server/discover",
+			Params:  core.NewRawJSON(validMetaParams(t)),
+		}
+		resp, _ := d.Dispatch(context.Background(), req)
+		if resp == nil || resp.Error != nil {
+			t.Fatalf("server/discover failed: %+v", resp)
+		}
+		raw, _ := json.Marshal(resp.Result)
+		var got map[string]any
+		json.Unmarshal(raw, &got)
+		if got["resultType"] != "complete" {
+			t.Errorf("resultType = %v, want complete", got["resultType"])
+		}
+		if _, ok := got["ttlMs"]; !ok {
+			t.Error("ttlMs missing from DiscoverResult")
+		}
+		if got["cacheScope"] != "public" {
+			t.Errorf("cacheScope = %v, want public", got["cacheScope"])
+		}
+	})
+
+	t.Run("tools list carries resultType", func(t *testing.T) {
+		req := &core.Request{
+			JSONRPC: "2.0",
+			ID:      json.RawMessage("41"),
+			Method:  "tools/list",
+			Params:  core.NewRawJSON(validMetaParams(t)),
+		}
+		resp, _ := d.Dispatch(context.Background(), req)
+		if resp == nil || resp.Error != nil {
+			t.Fatalf("tools/list failed: %+v", resp)
+		}
+		raw, _ := json.Marshal(resp.Result)
+		var got map[string]any
+		json.Unmarshal(raw, &got)
+		if got["resultType"] != "complete" {
+			t.Errorf("resultType = %v, want complete", got["resultType"])
+		}
+	})
+}


### PR DESCRIPTION
## What changes

The 2026-07-28 final revision generalized the SEP-2322 `resultType` field: every result object a server emits now requires the discriminator, and `DiscoverResult` requires `ttlMs` + `cacheScope`. mcpkit emitted `resultType` only on MRTR/tasks paths. Found by the GA-day gap audit after upstream conformance started validating every wire message against the per-version spec JSON schema — 13 scenarios failed `wire-schema-valid`; this PR clears the 11 that were ours.

## Reviewer's guide

Read in this order:
1. [core/stateless.go](https://github.com/panyam/mcpkit/pull/1175/files#diff-9a68784d645de8b02f898afae78118cfc63d9fe94dc4fc920c564a7cf3127fac) — `InjectResultTypeIntoResult`, sibling of `InjectServerInfoIntoResult`: post-marshal, inject-if-absent, so caller-set discriminators (MRTR `input_required`, tasks `task`) always win.
2. [core/stateless_test.go](https://github.com/panyam/mcpkit/pull/1175/files#diff-1393014576ef43e1befe8e54e173c368f9608a8191221205f74d2baba03d625c) — injector acceptance (absent→complete, caller-set wins, non-object unchanged).
3. [server/dispatch.go](https://github.com/panyam/mcpkit/pull/1175/files#diff-7640bcbef23148a16e477c63c7092f0ba89780f5278a9d6ba6ed513d62f68a92) — the legacy-wire stamp as a second defer at the single dispatch exit; the comment explains the LIFO ordering with the panic-recovery defer.
4. [server/protocol_features.go](https://github.com/panyam/mcpkit/pull/1175/files#diff-f08ce18af391b682e28dd8a742021572cdb5b9ae89460db51ff78adaf34735b2) — the `GeneralizedResultType` gate (draft-only), keeping pre-draft wire output byte-identical per the feature-table convention.
5. [server/stateless/dispatch.go](https://github.com/panyam/mcpkit/pull/1175/files#diff-1b101922de172cda20b6a044eae5a4fc36b2dce82e136a566765bae575a42b20) — unconditional stamp at the existing serverInfo chokepoint (the wire is draft-only).
6. [server/stateless/discover.go](https://github.com/panyam/mcpkit/pull/1175/files#diff-2cfe2e80c22352344169587e4bd6d537053493d3441c1e38d016565f8c68718a) + tests — the two new required DiscoverResult fields with issue-496 conformant defaults.
7. [conformance/known-gaps.yaml](https://github.com/panyam/mcpkit/pull/1175/files#diff-bcd01920bd187fabe66d67bfeb497d62d841a9e3389985aac55b32955b6d2a30) — 8 annotations for the remaining failures, which are an upstream validator gap (see decision log).

Skim or skip: `CONFORMANCE.md` + [conformance/UPSTREAM_AUDIT.md](https://github.com/panyam/mcpkit/pull/1175/files#diff-bf63f1699e28f43c702f9450df02d9e8ec1dae36200827f929a68513bdb34197) + badge (regenerated), [CHANGELOG.md](https://github.com/panyam/mcpkit/pull/1175/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed).

## Decision log

- **Version-gated on the legacy wire, unconditional on stateless**: old schemas tolerate the extra field (`additionalProperties` defaults open, verified against vendored 2025-11-25), but the feature-table gate keeps pre-draft sessions byte-identical, which is what the repo's wire-shape tests and the SEP-2243 precedent expect. The stateless wire only speaks the draft line, so no gate there.
- **Chokepoint injection over per-type fields**: the discriminator is required on every result type; adding a field + marshal logic to each struct would be a wide mechanical diff and would still miss custom-method results. The post-marshal injector covers everything at two points and preserves the typed variants for free.
- **The 8 remaining audit failures are upstream's, not ours** — verified by reading their validator: `wire-schema.ts` discriminates `resultType === 'input_required'` but has no `task` branch, so SEP-2663 extension envelopes (absent from the core schema by design — tasks moved to an extension) are validated as `CallToolResult` and fail on missing `content`. Our envelopes are well-formed, including `resultType: \"task\"` (violation payloads in the issue). Upstream issue to be filed; known-gaps annotations carry the explanation until then.

## Risk / blast radius

- Wire change on the 2026-07-28 line only: every success result grows `resultType` (and discover grows `ttlMs`/`cacheScope`). Spec-mandated; clients on the draft line must already parse it, and older-version sessions see zero change.
- Tests: 3 new test functions (~9 assertions added, 0 removed or weakened); full root suite, stateless 30/30, tasks-v2 47/47, MRTR, and the 43-scenario client suite all green; depth guard clean.
- Be paranoid about: the double-defer ordering in `Dispatch` (stamp runs before recovery in LIFO order; the `Error == nil` guard covers both paths), and any downstream consumer that unmarshals results with `DisallowUnknownFields`.

## Before / after

```
upstream audit, wire-schema-valid violations:
before: 13 scenarios failing — 11 mcpkit (missing resultType on list/get/read/
        complete/discover results; discover missing ttlMs+cacheScope) + the
        task-envelope errors
after:  8 scenarios failing — ALL the upstream validator's task-envelope gap;
        zero mcpkit-attributable violations

response to tools/list (draft wire):
before: {"_meta":{...serverInfo...},"cacheScope":"public","tools":[...],"ttlMs":0}
after:  {"_meta":{...serverInfo...},"cacheScope":"public","resultType":"complete","tools":[...],"ttlMs":0}
```

## Out of scope

- The upstream validator's missing `resultType: task` branch — upstream issue draft ready for filing (their repo).
- Close issue 1174 manually on merge.
