### PR TITLE
fix(conformance): repair malformed known-gaps.yaml holding CI red

### DIFF
--- a/conformance/known-gaps.yaml
+++ b/conformance/known-gaps.yaml
@@ -7,15 +7,6 @@
 #
 # Schema:
 #   scenarios:
-  "http-header-validation":
-    issue: "https://github.com/modelcontextprotocol/conformance/issues/323"
-    note: "The single remaining fail is fail-open on a missing Mcp-Method header, disputed upstream (mcpkit matches the TypeScript SDK). Deliberately not implemented while the dispute is open; disputed tests are excluded from tier scoring."
-  "http-custom-header-server-validation":
-    issue: "https://github.com/panyam/mcpkit/issues/1111"
-    note: "Server-side x-mcp-header param validation not implemented and cmd/testserver has no annotated tool; scoped in issue 1111, activates when upstream conformance PR 325 merges."
-  "tasks-status-notifications":
-    issue: "https://github.com/panyam/mcpkit/issues/433"
-    note: "Deliberately skipped: the upstream scenario predates subscriptions/listen and awaits its rewrite. mcpkit implements subscriptions/listen (server/stateless/subscriptions.go) and is ready to be graded."
 #     <scenario-id>:           # exact upstream scenario name after timestamp
 #       issue: <link>          #   normalization (e.g. "tools-dynamic")
 #       note: <one line>
@@ -27,6 +18,15 @@
 # Keep entries terse; the renderer puts them straight into a table cell.
 
 scenarios:
+  "http-header-validation":
+    issue: "https://github.com/modelcontextprotocol/conformance/issues/323"
+    note: "The single remaining fail is fail-open on a missing Mcp-Method header, disputed upstream (mcpkit matches the TypeScript SDK). Deliberately not implemented while the dispute is open; disputed tests are excluded from tier scoring."
+  "http-custom-header-server-validation":
+    issue: "https://github.com/panyam/mcpkit/issues/1111"
+    note: "Server-side x-mcp-header param validation not implemented and cmd/testserver has no annotated tool; scoped in issue 1111, activates when upstream conformance PR 325 merges."
+  "tasks-status-notifications":
+    issue: "https://github.com/panyam/mcpkit/issues/433"
+    note: "Deliberately skipped: the upstream scenario predates subscriptions/listen and awaits its rewrite. mcpkit implements subscriptions/listen (server/stateless/subscriptions.go) and is ready to be graded."
   "tasks-capability-negotiation":
     issue: "https://github.com/modelcontextprotocol/conformance/issues/424"
     note: "Upstream wire-schema validator gap: SEP-2663 task envelopes (resultType task, an extension result absent from the core schema) are validated as CallToolResult and fail on missing content. mcpkit's envelope is well-formed; tracked upstream in conformance issue 424."

--- a/tools/conformance-report/test/render.test.ts
+++ b/tools/conformance-report/test/render.test.ts
@@ -17,6 +17,12 @@ import {
 
 const here = fileURLToPath(new URL('./fixtures/', import.meta.url));
 
+// repoConformance points at the real committed conformance/ dir (test file is
+// at tools/conformance-report/test/, so up three levels is the repo root).
+const repoConformance = fileURLToPath(
+  new URL('../../../conformance/', import.meta.url)
+);
+
 function loadFixtures() {
   return {
     scorecard: loadScorecard(join(here, 'scorecard.json')),
@@ -136,5 +142,30 @@ describe('spliceGeneratedRegion', () => {
     expect(merged).toContain('marker convention inline');
     expect(merged).toContain('NEW BLOCK');
     expect(merged).not.toContain('OLD BLOCK');
+  });
+});
+
+// Guards the real committed overlay files so a malformed hand-edit (e.g. an
+// entry placed at the wrong indent) fails here — in the fast `npm test` step —
+// instead of only in the heavy full-refresh render, where it read as an opaque
+// "Unexpected scalar" YAML error and silently held CI red.
+describe('committed conformance overlays parse', () => {
+  it('known-gaps.yaml loads with well-formed scenarios and checks', () => {
+    const gaps = loadKnownGaps(join(repoConformance, 'known-gaps.yaml'));
+    expect(gaps).toBeTypeOf('object');
+    for (const section of ['scenarios', 'checks'] as const) {
+      const entries = (gaps as Record<string, unknown>)[section];
+      if (entries === undefined) continue;
+      expect(entries, `${section} must be a mapping`).toBeTypeOf('object');
+      for (const [id, body] of Object.entries(entries as object)) {
+        expect(body, `${section}.${id} must be a mapping`).toBeTypeOf('object');
+      }
+    }
+  });
+
+  it('local-suites.yaml loads without throwing', () => {
+    expect(() =>
+      loadLocalSuites(join(repoConformance, 'local-suites.yaml'))
+    ).not.toThrow();
   });
 });


### PR DESCRIPTION
## What changes

Repairs `conformance/known-gaps.yaml`, which has been malformed since the recent SEP-2243 / tasks-status-notifications annotation commits and has held the `conformance-report` CI job red on every push and PR since (including on `main`). `tier-check` was passing the whole time; the failure was purely the renderer crashing on a YAML parse error.

## Root cause

Three annotation entries were inserted **inside the schema doc-comment block**, indented two spaces as if they were under a `scenarios:` key — but the actual `scenarios:` key sits lower, at line 29. The YAML parser read lines 10–18 as orphaned indent-2 mappings at the document root, then hit `scenarios:` at indent 0 and errored:

```
=== Rendering CONFORMANCE.md ===
conformance-report: Unexpected scalar at node end at line 29, column 1:
scenarios:
^^^^^^^^^
error: recipe `refresh-conformance` failed with exit code 1
```

That aborted `refresh-conformance`, so `check-conformance-stale` failed. The three entries were meant to live under the real `scenarios:` key.

## The fix

- Move the three entries (`http-header-validation`, `http-custom-header-server-validation`, `tasks-status-notifications`) out of the comment block and under the real `scenarios:` key, next to the other scenario annotations.
- **`CONFORMANCE.md` is unchanged** — regenerating it locally against the pinned upstream SHA produces a byte-identical file (these particular gaps don't surface a visible row today), so only the YAML was broken, not the report.
- Add a renderer unit test that loads the **real committed** `known-gaps.yaml` / `local-suites.yaml`, so a future malformed hand-edit fails in the fast `npm test` step rather than only in the heavy full-refresh render.

## Reviewer's guide

1. [conformance/known-gaps.yaml](https://github.com/panyam/mcpkit/pull/1179/files#diff-bcd01920bd187fabe66d67bfeb497d62d841a9e3389985aac55b32955b6d2a30) — the fix. The three entries move from inside the comment block (wrong indent, no parent) to under `scenarios:`.
2. [tools/conformance-report/test/render.test.ts](https://github.com/panyam/mcpkit/pull/1179/files#diff-b40940fc3456a81861d60c3b5655a5b18f8445e86401a47b7fbbc5db112ed612) — the guard: parses the real overlay files and asserts well-formed structure.

## Before / after

```mermaid
flowchart LR
    subgraph before["BEFORE — parse error"]
        b1["# schema comment"] --> b2["3 entries at indent 2<br/>(no parent key)"] --> b3["# more comment"] --> b4["scenarios: (indent 0)"]
        b4 --> b5["✗ Unexpected scalar @ line 29"]
    end
    subgraph after["AFTER — valid"]
        a1["# schema comment (contiguous)"] --> a2["scenarios:"]
        a2 --> a3["3 relocated entries<br/>+ existing scenarios"]
        a3 --> a4["✓ 14 scenarios, 2 checks"]
    end
```

## Verification

- `known-gaps.yaml` now parses with the renderer's own `yaml` package: 14 scenarios + 2 checks.
- `just check-conformance-stale` passes locally end-to-end (upstream pinned at `49103de6`): `CONFORMANCE.md is up to date.` exit 0.
- The new guard test is red on the broken file (same `Unexpected scalar at node end at line 29` error) and green after the fix.

## Risk / blast radius

- Data-only + a test. No production code. `CONFORMANCE.md` byte-identical, so no reviewer-facing report change.
- The `conformance-report` job on this PR is the real end-to-end proof.

