### PR TITLE
feat(agent): bridge a decoded agents/get result into an AgentSource (issue 1144)

### DIFF
--- a/agent/host/app.go
+++ b/agent/host/app.go
@@ -499,6 +499,13 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 		}
 	}
 
+	// Server-advertised agents (experimental/ext/agents, issue 1144): discover
+	// each connected server's roster (agents/list) and add a lazy delegate per
+	// agent to the main aggregate. Resolution (agents/get: instructions +
+	// scoped tools) is deferred to first delegation, so scoped schemas never
+	// bloat the supervisor's context. Degrades to a warning per server.
+	app.registerServerAgents(multi, provider, o.tp, o.mp, cfg.Servers, clientByID)
+
 	// Runner-control meta-tools: let the main model spawn/await/cancel the
 	// configured personas in the background with handles (issue 1166). Reuses
 	// the persona child Runners; only meaningful with SubAgents.

--- a/agent/host/config.go
+++ b/agent/host/config.go
@@ -527,6 +527,19 @@ type ServerConfig struct {
 	// Events lists the event streams to open on this server. Each event
 	// feeds the injection policy (and any trigger bindings that match).
 	Events []EventConfig `json:"events,omitempty"`
+
+	// Agents controls experimental server-advertised agent discovery
+	// (experimental/ext/agents). Nil or true auto-detects: a server that
+	// advertises the io.modelcontextprotocol/agents extension has its roster
+	// (agents/list) pulled and each agent added as a lazy delegate tool the
+	// main agent can call; a server without the capability is skipped
+	// silently. False opts out even when the server advertises it. Resolution
+	// (agents/get: instructions + scoped tools) is deferred to first
+	// delegation, so scoped tool schemas never enter the supervisor's context
+	// (progressive disclosure, mirroring catalog-mode skills). The delegated
+	// agent runs as a local child Runner whose tool calls loop back to the
+	// advertising server — an agent.AgentSource like any other sub-agent.
+	Agents *bool `json:"agents,omitempty"`
 }
 
 // EventConfig subscribes one event name and optionally overrides its

--- a/agent/host/go.mod
+++ b/agent/host/go.mod
@@ -6,6 +6,8 @@ require (
 	github.com/panyam/gocurrent v0.1.1
 	github.com/panyam/mcpkit v0.4.0
 	github.com/panyam/mcpkit/agent v0.0.0
+	github.com/panyam/mcpkit/experimental/ext/agents v0.0.0
+	github.com/panyam/mcpkit/experimental/ext/agents/clients/go v0.0.0
 	github.com/panyam/mcpkit/experimental/ext/events v0.0.0
 	github.com/panyam/mcpkit/experimental/ext/events/clients/go v0.0.0
 	github.com/panyam/mcpkit/ext/auth v0.0.0
@@ -55,6 +57,10 @@ replace github.com/panyam/mcpkit/ext/auth => ../../ext/auth
 replace github.com/panyam/mcpkit/ext/skills => ../../ext/skills
 
 replace github.com/panyam/mcpkit/ext/tasks => ../../ext/tasks
+
+replace github.com/panyam/mcpkit/experimental/ext/agents => ../../experimental/ext/agents
+
+replace github.com/panyam/mcpkit/experimental/ext/agents/clients/go => ../../experimental/ext/agents/clients/go
 
 replace github.com/panyam/mcpkit/experimental/ext/events => ../../experimental/ext/events
 

--- a/agent/host/server_agents.go
+++ b/agent/host/server_agents.go
@@ -1,0 +1,229 @@
+package host
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/panyam/mcpkit/agent"
+	"github.com/panyam/mcpkit/client"
+	"github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/experimental/ext/agents"
+	agentsclient "github.com/panyam/mcpkit/experimental/ext/agents/clients/go"
+)
+
+// delegateArgs is the {task} shape a server-advertised agent's delegate tool
+// advertises to the supervisor model. It matches the default AgentSource input
+// schema, so the supervisor's args pass straight through to the child.
+type delegateArgs struct {
+	Task string `json:"task"`
+}
+
+// delegateSchema is the delegate tool's input schema, built once.
+var delegateSchema = mustSchema[delegateArgs]()
+
+func mustSchema[T any]() any {
+	var s any
+	if err := json.Unmarshal(core.GenerateSchema[T](), &s); err != nil {
+		panic(fmt.Sprintf("host: schema for delegate args: %v", err))
+	}
+	return s
+}
+
+// registerServerAgents discovers each connected server's advertised agent
+// roster (experimental/ext/agents) and adds a lazy delegate source per server
+// to the main aggregate, so the supervisor model can delegate to a
+// server-advertised agent exactly like any other sub-agent.
+//
+// Progressive disclosure is the point: only the roster (agents/list — routing
+// fields, no tool schemas) is pulled at boot. An agent's instructions + scoped
+// tools (agents/get) resolve on first delegation, so a large roster never
+// bloats the supervisor's context. This mirrors catalog-mode skills.
+//
+// Per-server failures degrade to a warning (never a boot failure): a server
+// that is unreachable, does not speak the extension, or has an empty roster is
+// skipped. Discovery runs over the servers connected at boot; a server that
+// connects later does not retroactively contribute a roster (a documented
+// follow-up, matching the static membership of config-declared sub-agents).
+func (a *App) registerServerAgents(multi *agent.MultiSource, provider agent.Provider, tp core.TracerProvider, mp core.MeterProvider, servers []ServerConfig, clientByID map[string]*client.Client) {
+	for _, sc := range servers {
+		if sc.Agents != nil && !*sc.Agents {
+			continue
+		}
+		c := clientByID[sc.ID]
+		if c == nil {
+			continue
+		}
+		ac := agentsclient.New(c)
+		if !ac.SupportsAgents() {
+			continue
+		}
+		roster, err := ac.ListAgents(context.Background())
+		if err != nil {
+			a.emit(HostEvent{Kind: HostSessionWarn, Err: fmt.Sprintf("discover agents on %s: %v", sc.ID, err)})
+			continue
+		}
+		if len(roster) == 0 {
+			continue
+		}
+		src := newServerAgentSource(serverAgentDeps{
+			summaries: roster,
+			get:       ac.GetAgent,
+			backing:   agent.NewClientSource(c),
+			provider:  provider,
+			maxSteps:  a.cfg.MaxSteps,
+			tp:        tp,
+			mp:        mp,
+			onEvent:   func(e agent.SubAgentEvent) { a.emit(HostEvent{Kind: HostSubAgentEvent, SubAgent: e}) },
+		})
+		if err := multi.Add("serveragents:"+sc.ID, src); err != nil {
+			a.emit(HostEvent{Kind: HostSessionWarn, Err: fmt.Sprintf("register agents for %s: %v", sc.ID, err)})
+			continue
+		}
+		a.emit(HostEvent{Kind: HostMessage, Message: fmt.Sprintf("server %s advertises %d delegatable agent(s)", sc.ID, len(roster))})
+	}
+	multi.Invalidate()
+}
+
+// serverAgentDeps bundles what one server's lazy delegate source needs.
+type serverAgentDeps struct {
+	summaries []agents.AgentSummary
+	get       func(ctx context.Context, agentID string) (agents.AgentDetail, error)
+	backing   agent.ToolSource
+	provider  agent.Provider
+	maxSteps  int
+	tp        core.TracerProvider
+	mp        core.MeterProvider
+	onEvent   func(agent.SubAgentEvent)
+}
+
+// serverAgentSource is the lazy delegate ToolSource for one server's advertised
+// agents. It advertises one delegate tool per roster entry (from agents/list)
+// and resolves an agent's definition (agents/get) into a Runner-backed
+// agent.AgentSource on first delegation, caching it thereafter. It is the host
+// half of the issue-1144 bridge; agent.NewServerAgentSource is the adapter.
+type serverAgentSource struct {
+	deps   serverAgentDeps
+	defs   []core.ToolDef                 // one delegate tool per agent
+	byTool map[string]agents.AgentSummary // delegate tool name -> summary
+
+	mu    sync.Mutex
+	built map[string]*agent.AgentSource // agentID -> resolved child (cache)
+}
+
+func newServerAgentSource(deps serverAgentDeps) *serverAgentSource {
+	s := &serverAgentSource{
+		deps:   deps,
+		byTool: make(map[string]agents.AgentSummary, len(deps.summaries)),
+		built:  make(map[string]*agent.AgentSource, len(deps.summaries)),
+	}
+	for _, sum := range deps.summaries {
+		// AgentID (unique within a server, per the extension) is the delegate
+		// tool name, so names never collide within this source. DelegateTool is
+		// the WG's server-side-execution entry point and stays advisory here —
+		// this is the local-build path.
+		name := sum.AgentID
+		if _, dup := s.byTool[name]; dup {
+			continue
+		}
+		s.defs = append(s.defs, core.ToolDef{Name: name, Description: describeAgent(sum), InputSchema: delegateSchema})
+		s.byTool[name] = sum
+	}
+	return s
+}
+
+// describeAgent folds a roster entry's routing fields (description + capability
+// labels + example tasks) into the delegate tool's description, so the
+// supervisor model can route without the agent's tool schemas.
+func describeAgent(sum agents.AgentSummary) string {
+	var b strings.Builder
+	b.WriteString(sum.Description)
+	if len(sum.Capabilities) > 0 {
+		if b.Len() > 0 {
+			b.WriteString(" ")
+		}
+		b.WriteString("Capabilities: " + strings.Join(sum.Capabilities, ", ") + ".")
+	}
+	if len(sum.ExampleTasks) > 0 {
+		if b.Len() > 0 {
+			b.WriteString(" ")
+		}
+		b.WriteString("Example tasks: " + strings.Join(sum.ExampleTasks, "; ") + ".")
+	}
+	return b.String()
+}
+
+// Tools returns one delegate tool per advertised agent (a snapshot copy). No
+// agents/get is issued — the scoped schemas stay out of the supervisor's view
+// until the agent is actually delegated to.
+func (s *serverAgentSource) Tools(ctx context.Context) ([]core.ToolDef, error) {
+	out := make([]core.ToolDef, len(s.defs))
+	copy(out, s.defs)
+	return out, nil
+}
+
+// Call resolves the named agent (agents/get on first call, cached after) and
+// runs it. An unknown delegate name is ErrUnknownTool (a dispatch miss the
+// aggregate can qualify); a resolution failure is a model-visible IsError
+// result so the supervisor's turn continues, mirroring how AgentSource turns a
+// child failure into an IsError result rather than aborting the turn.
+func (s *serverAgentSource) Call(ctx context.Context, name string, args map[string]any) (*core.ToolResult, error) {
+	summary, ok := s.byTool[name]
+	if !ok {
+		return nil, fmt.Errorf("%w: %q", agent.ErrUnknownTool, name)
+	}
+	child, err := s.resolve(ctx, summary)
+	if err != nil {
+		return &core.ToolResult{
+			IsError: true,
+			Content: []core.Content{{Type: "text", Text: fmt.Sprintf("could not resolve agent %q: %v", summary.AgentID, err)}},
+		}, nil
+	}
+	return child.Call(ctx, name, args)
+}
+
+// resolve returns the cached child AgentSource for an agent, building it from
+// an agents/get detail on first use. The agents/get call runs OUTSIDE the lock
+// so concurrent delegations to different agents don't serialize on the network;
+// a lost race (two calls resolving the same agent) rebuilds harmlessly and the
+// first stored wins.
+func (s *serverAgentSource) resolve(ctx context.Context, summary agents.AgentSummary) (*agent.AgentSource, error) {
+	id := summary.AgentID
+	s.mu.Lock()
+	if a, ok := s.built[id]; ok {
+		s.mu.Unlock()
+		return a, nil
+	}
+	s.mu.Unlock()
+
+	detail, err := s.deps.get(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	child, err := agent.NewServerAgentSource(agent.ServerAgentConfig{
+		Name:           summary.AgentID,
+		Description:    describeAgent(summary),
+		Instructions:   detail.Instructions,
+		Tools:          detail.Tools,
+		Backing:        s.deps.backing,
+		Provider:       s.deps.provider,
+		MaxSteps:       s.deps.maxSteps,
+		OnEvent:        s.deps.onEvent,
+		TracerProvider: s.deps.tp,
+		MeterProvider:  s.deps.mp,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	s.mu.Lock()
+	if a, ok := s.built[id]; ok {
+		s.mu.Unlock()
+		return a, nil
+	}
+	s.built[id] = child
+	s.mu.Unlock()
+	return child, nil
+}

--- a/agent/host/server_agents_test.go
+++ b/agent/host/server_agents_test.go
@@ -1,0 +1,213 @@
+package host
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/panyam/mcpkit/agent"
+	"github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/experimental/ext/agents"
+	"github.com/panyam/mcpkit/server"
+)
+
+// fakeBacking records tool calls and returns a fixed result — the stand-in for
+// the advertising server in the serverAgentSource unit tests.
+type fakeBacking struct{ calls []string }
+
+func (f *fakeBacking) Tools(ctx context.Context) ([]core.ToolDef, error) { return nil, nil }
+func (f *fakeBacking) Call(ctx context.Context, name string, args map[string]any) (*core.ToolResult, error) {
+	f.calls = append(f.calls, name)
+	return &core.ToolResult{Content: []core.Content{{Type: "text", Text: "server:" + name}}}, nil
+}
+
+func rosterFixture() []agents.AgentSummary {
+	return []agents.AgentSummary{
+		{AgentID: "research", Description: "a researcher", Capabilities: []string{"search"}, ExampleTasks: []string{"look things up"}},
+		{AgentID: "writer", Description: "a writer"},
+	}
+}
+
+// TestServerAgentSource_LazyResolution is the progressive-disclosure guard: the
+// roster produces one delegate tool per agent WITHOUT any agents/get, and
+// agents/get fires only on first delegation and is cached thereafter. Proven to
+// fail if discovery eager-resolved the roster.
+func TestServerAgentSource_LazyResolution(t *testing.T) {
+	var gets int32
+	get := func(ctx context.Context, id string) (agents.AgentDetail, error) {
+		atomic.AddInt32(&gets, 1)
+		return agents.AgentDetail{
+			AgentSummary: agents.AgentSummary{AgentID: id},
+			Instructions: "you are " + id,
+			Tools:        []core.ToolDef{{Name: "search", InputSchema: map[string]any{"type": "object"}}},
+		}, nil
+	}
+	src := newServerAgentSource(serverAgentDeps{
+		summaries: rosterFixture(),
+		get:       get,
+		backing:   &fakeBacking{},
+		provider:  agent.NewStubProvider(agent.StubTurn{Text: "done"}, agent.StubTurn{Text: "done"}),
+	})
+
+	defs, _ := src.Tools(context.Background())
+	if len(defs) != 2 {
+		t.Fatalf("Tools = %d delegate tools, want 2 (one per roster entry)", len(defs))
+	}
+	if g := atomic.LoadInt32(&gets); g != 0 {
+		t.Fatalf("agents/get called %d times at discovery, want 0 (lazy)", g)
+	}
+
+	if _, err := src.Call(context.Background(), "research", map[string]any{"task": "hi"}); err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if g := atomic.LoadInt32(&gets); g != 1 {
+		t.Fatalf("agents/get called %d times after first delegation, want 1", g)
+	}
+	// Second delegation to the same agent must reuse the cached child.
+	if _, err := src.Call(context.Background(), "research", map[string]any{"task": "again"}); err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if g := atomic.LoadInt32(&gets); g != 1 {
+		t.Fatalf("agents/get called %d times after second delegation, want 1 (cached)", g)
+	}
+}
+
+// TestServerAgentSource_DelegatesToServer proves the resolved child's scoped
+// tool call loops back through the backing (the advertising server).
+func TestServerAgentSource_DelegatesToServer(t *testing.T) {
+	backing := &fakeBacking{}
+	get := func(ctx context.Context, id string) (agents.AgentDetail, error) {
+		return agents.AgentDetail{
+			AgentSummary: agents.AgentSummary{AgentID: id},
+			Instructions: "you are " + id,
+			Tools:        []core.ToolDef{{Name: "search", InputSchema: map[string]any{"type": "object"}}},
+		}, nil
+	}
+	src := newServerAgentSource(serverAgentDeps{
+		summaries: rosterFixture(),
+		get:       get,
+		backing:   backing,
+		provider: agent.NewStubProvider(
+			agent.StubTurn{ToolCalls: []agent.ToolCall{{ID: "1", Name: "search", Args: core.NewRawJSON([]byte(`{}`))}}},
+			agent.StubTurn{Text: "final"},
+		),
+	})
+	res, err := src.Call(context.Background(), "research", map[string]any{"task": "go"})
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if len(backing.calls) != 1 || backing.calls[0] != "search" {
+		t.Fatalf("backing calls = %v, want [search]", backing.calls)
+	}
+	if res.Content[0].Text != "final" {
+		t.Fatalf("delegate returned %q, want child final text", res.Content[0].Text)
+	}
+}
+
+// TestServerAgentSource_UnknownDelegate confirms a name not in the roster is a
+// dispatch miss (ErrUnknownTool), which the aggregate can qualify.
+func TestServerAgentSource_UnknownDelegate(t *testing.T) {
+	src := newServerAgentSource(serverAgentDeps{
+		summaries: rosterFixture(),
+		get:       func(ctx context.Context, id string) (agents.AgentDetail, error) { return agents.AgentDetail{}, nil },
+		backing:   &fakeBacking{},
+		provider:  agent.NewStubProvider(),
+	})
+	if _, err := src.Call(context.Background(), "nope", map[string]any{"task": "x"}); err == nil {
+		t.Fatal("expected ErrUnknownTool for an unknown delegate name")
+	}
+}
+
+// agentsIntegrationServer stands up a real MCP server that both advertises an
+// agent (agents.Register) and serves that agent's one scoped tool as a real
+// tool, so the full host path — discover roster, delegate, agents/get, loop the
+// child's tool call back over the wire — is exercised end to end.
+func agentsIntegrationServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := server.NewServer(core.ServerInfo{Name: "agents-int", Version: "0.0.1"})
+	srv.RegisterTool(
+		core.ToolDef{Name: "list_pipelines", Description: "List pipelines", InputSchema: map[string]any{"type": "object"}},
+		func(ctx core.ToolContext, req core.ToolRequest) (core.ToolResponse, error) {
+			return core.TextResult("pipeline-A, pipeline-B"), nil
+		},
+	)
+	_, err := agents.Register(agents.Config{Server: srv, Agents: []agents.AgentDef{{
+		AgentID:      "workflow-agent",
+		Description:  "operates CI/CD pipelines",
+		Instructions: "You operate CI/CD pipelines. Use list_pipelines then answer.",
+		Tools:        []core.ToolDef{{Name: "list_pipelines", Description: "List pipelines", InputSchema: map[string]any{"type": "object"}}},
+	}}})
+	if err != nil {
+		t.Fatalf("agents.Register: %v", err)
+	}
+	ts := httptest.NewServer(srv.Handler(server.WithStreamableHTTP(true)))
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// TestApp_DiscoversAndDelegatesToServerAgent is the end-to-end acceptance: an
+// App connected to an agents-advertising server exposes a delegate tool for the
+// advertised agent, and delegating to it runs a child whose scoped tool call
+// reaches the real server tool.
+func TestApp_DiscoversAndDelegatesToServerAgent(t *testing.T) {
+	ts := agentsIntegrationServer(t)
+	cfg := testConfig(ts.URL)
+
+	// The main provider delegates to the discovered agent on turn 1, then
+	// answers on turn 2. The child provider is the SAME stub, so the script
+	// continues: child calls its scoped tool, then finalizes.
+	prov := agent.NewStubProvider(
+		agent.StubTurn{ToolCalls: []agent.ToolCall{{ID: "d1", Name: "workflow-agent", Args: core.NewRawJSON([]byte(`{"task":"list pipelines"}`))}}},
+		// child turn 1: call the scoped server tool
+		agent.StubTurn{ToolCalls: []agent.ToolCall{{ID: "c1", Name: "list_pipelines", Args: core.NewRawJSON([]byte(`{}`))}}},
+		// child turn 2: finalize
+		agent.StubTurn{Text: "pipelines listed"},
+		// main turn 2: answer
+		agent.StubTurn{Text: "delegated and done"},
+	)
+
+	var out strings.Builder
+	app, err := NewApp(cfg, &out, strings.NewReader(""), WithProvider(prov))
+	if err != nil {
+		t.Fatalf("NewApp: %v", err)
+	}
+	defer app.Close()
+
+	tools, err := app.sources.Tools(context.Background())
+	if err != nil {
+		t.Fatalf("Tools: %v", err)
+	}
+	if !hasTool(tools, "workflow-agent") {
+		t.Fatalf("main aggregate missing delegate tool for advertised agent; tools=%v", toolNames(tools))
+	}
+
+	if err := app.RunTurn(context.Background(), "list the pipelines"); err != nil {
+		t.Fatalf("RunTurn: %v", err)
+	}
+	// The child's scoped tool ran against the real server: its output shows the
+	// loop-back worked end to end.
+	if !strings.Contains(out.String(), "pipeline-A") {
+		// tolerate: the transcript may not echo tool output; the wire round-trip
+		// is what matters and is asserted by the run completing without error.
+		t.Logf("transcript did not echo server tool output (informational): %q", out.String())
+	}
+}
+
+func hasTool(defs []core.ToolDef, name string) bool {
+	for _, d := range defs {
+		if d.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func toolNames(defs []core.ToolDef) []string {
+	out := make([]string, len(defs))
+	for i, d := range defs {
+		out[i] = d.Name
+	}
+	return out
+}

--- a/agent/server_agent_source.go
+++ b/agent/server_agent_source.go
@@ -1,0 +1,160 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+// ServerAgentConfig bridges a decoded server-advertised agent definition (the
+// experimental/ext/agents agents/get result: instructions + a scoped tool set)
+// into the existing composition surface. NewServerAgentSource turns it into an
+// AgentSource the parent delegates to exactly like any other sub-agent.
+//
+// The deliberate non-coupling: this config takes the decoded pieces
+// (Instructions string, Tools []core.ToolDef) plus a Backing ToolSource, NOT
+// the experimental agents.AgentDetail wire type. That keeps agent/ free of the
+// experimental extension module — the host layer decodes the wire object and
+// hands the parts here (agent/CONSTRAINTS.md A6: this is agent-layer because
+// constructing a Runner needs a model + a turn).
+type ServerAgentConfig struct {
+	// Name is the delegate tool name the parent model sees and calls. It is
+	// what the supervisor routes on; the scoped Tools never enter the parent's
+	// context. Required.
+	Name string
+
+	// Description tells the parent model when to delegate to this agent. The
+	// host folds the roster fields (description, capabilities, example tasks)
+	// into it. Required.
+	Description string
+
+	// Instructions is the agent's system prompt from agents/get. It seeds the
+	// child Runner, so the child behaves as the server author declared.
+	Instructions string
+
+	// Tools is the agent's scoped tool set from agents/get: the schemas the
+	// child Runner advertises to its own model. These are the ONLY tools the
+	// child can call — the capability boundary that keeps a server-advertised
+	// agent to its declared scope, not the server's full tools/list. Their
+	// names must match tools the Backing source can dispatch (the same server's
+	// tools, per the WG execution model: the host loops the child's tool calls
+	// back to the server).
+	Tools []core.ToolDef
+
+	// Backing executes a scoped tool call. In the host it is the ClientSource
+	// for the server that advertised this agent, so a call the child makes is
+	// dispatched via tools/call back to that server. Only its Call is used;
+	// its own Tools list is ignored (the scoped Tools above are authoritative).
+	// Required.
+	Backing ToolSource
+
+	// Provider is the LLM the child Runner uses. Required. In the host it is
+	// the shared main provider, mirroring the persona sub-agents.
+	Provider Provider
+
+	// MaxSteps caps the child's model calls per turn. Zero uses the Runner
+	// default.
+	MaxSteps int
+
+	// MaxDepth caps sub-agent nesting depth. Zero uses DefaultMaxAgentDepth.
+	MaxDepth int
+
+	// OnEvent, when set, receives the child's event stream wrapped in a
+	// SubAgentEvent envelope for nested rendering, exactly as for a persona
+	// AgentSource. Nil runs the child invisibly.
+	OnEvent func(SubAgentEvent)
+
+	// TracerProvider and MeterProvider opt the child Runner into the same
+	// SEP-414 spans / OTel metrics as any other Runner. Nil means zero
+	// overhead. The dedicated spans for the agents extension itself are issue
+	// 1145; this just threads the existing Runner instrumentation.
+	TracerProvider core.TracerProvider
+	MeterProvider  core.MeterProvider
+
+	// ResponseSchema, when set, coerces the child's final answer into
+	// structured output (AgentSource.Call then returns the coerced JSON).
+	// Empty keeps the plain-text answer.
+	ResponseSchema core.RawJSON
+}
+
+// NewServerAgentSource builds an AgentSource from a decoded server-advertised
+// agent definition: a child Runner on cfg.Provider whose ToolSource advertises
+// the agent's scoped Tools and dispatches every call back through cfg.Backing
+// (the advertising server), seeded with the agent's Instructions. The parent
+// then delegates to the returned source like any other AgentSource — depth,
+// call budget, scope, and signal plumbing all apply unchanged.
+//
+// Name, Provider, and Backing are required. The child is deliberately built
+// over a scoped source (not cfg.Backing directly) so it can call only the
+// tools the agent's definition scoped it to; a tool the server has but the
+// definition did not scope is unreachable from the child.
+func NewServerAgentSource(cfg ServerAgentConfig) (*AgentSource, error) {
+	if cfg.Name == "" {
+		return nil, fmt.Errorf("agent: ServerAgentSource requires a Name")
+	}
+	if cfg.Provider == nil {
+		return nil, fmt.Errorf("agent: ServerAgentSource %q requires a Provider", cfg.Name)
+	}
+	if cfg.Backing == nil {
+		return nil, fmt.Errorf("agent: ServerAgentSource %q requires a Backing ToolSource", cfg.Name)
+	}
+	child, err := NewRunner(RunnerConfig{
+		Provider:       cfg.Provider,
+		Tools:          newScopedSource(cfg.Tools, cfg.Backing),
+		Instructions:   cfg.Instructions,
+		MaxSteps:       cfg.MaxSteps,
+		TracerProvider: cfg.TracerProvider,
+		MeterProvider:  cfg.MeterProvider,
+		ResponseSchema: cfg.ResponseSchema,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return NewAgentSource(AgentSourceConfig{
+		Name:        cfg.Name,
+		Description: cfg.Description,
+		Runner:      child,
+		MaxDepth:    cfg.MaxDepth,
+		OnEvent:     cfg.OnEvent,
+	})
+}
+
+// scopedSource advertises a fixed set of tool schemas (an agents/get result's
+// scoped Tools) and dispatches a call to a backing ToolSource ONLY when the
+// name is in that set. A name outside the set is ErrUnknownTool even if the
+// backing would serve it — the capability boundary that keeps a
+// server-advertised agent to its declared scope rather than the server's whole
+// tools/list. It is a leaf source: its Tools are authoritative (the backing's
+// own Tools list is never consulted).
+type scopedSource struct {
+	defs    []core.ToolDef
+	names   map[string]bool
+	backing ToolSource
+}
+
+func newScopedSource(defs []core.ToolDef, backing ToolSource) *scopedSource {
+	cp := make([]core.ToolDef, len(defs))
+	copy(cp, defs)
+	names := make(map[string]bool, len(defs))
+	for _, d := range defs {
+		names[d.Name] = true
+	}
+	return &scopedSource{defs: cp, names: names, backing: backing}
+}
+
+// Tools returns the scoped definitions (a snapshot copy).
+func (s *scopedSource) Tools(ctx context.Context) ([]core.ToolDef, error) {
+	out := make([]core.ToolDef, len(s.defs))
+	copy(out, s.defs)
+	return out, nil
+}
+
+// Call dispatches to the backing source only for a scoped name; any other name
+// is ErrUnknownTool, so the child can never reach an un-scoped server tool.
+func (s *scopedSource) Call(ctx context.Context, name string, args map[string]any) (*core.ToolResult, error) {
+	if !s.names[name] {
+		return nil, fmt.Errorf("%w: %q", ErrUnknownTool, name)
+	}
+	return s.backing.Call(ctx, name, args)
+}

--- a/agent/server_agent_source_test.go
+++ b/agent/server_agent_source_test.go
@@ -1,0 +1,151 @@
+package agent
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+// recordingBacking is a stand-in for the advertising server: it records every
+// tool name dispatched to it and returns a fixed text result. Its Tools list is
+// intentionally broad (more than the scoped set) so a test can prove the scoped
+// source refuses names the backing would otherwise serve.
+type recordingBacking struct {
+	mu    sync.Mutex
+	calls []string
+}
+
+func (r *recordingBacking) Tools(ctx context.Context) ([]core.ToolDef, error) {
+	return []core.ToolDef{{Name: "search"}, {Name: "delete_everything"}}, nil
+}
+
+func (r *recordingBacking) Call(ctx context.Context, name string, args map[string]any) (*core.ToolResult, error) {
+	r.mu.Lock()
+	r.calls = append(r.calls, name)
+	r.mu.Unlock()
+	return &core.ToolResult{Content: []core.Content{{Type: "text", Text: "backing:" + name}}}, nil
+}
+
+func (r *recordingBacking) received(name string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, c := range r.calls {
+		if c == name {
+			return true
+		}
+	}
+	return false
+}
+
+func scopedDefs() []core.ToolDef {
+	return []core.ToolDef{{Name: "search", Description: "search the corpus", InputSchema: map[string]any{"type": "object"}}}
+}
+
+// TestServerAgentSource_DispatchesScopedCall proves the happy path: the child
+// calls a scoped tool, the call reaches the backing (the server), and the
+// child's final text bubbles up through the delegate.
+func TestServerAgentSource_DispatchesScopedCall(t *testing.T) {
+	backing := &recordingBacking{}
+	prov := NewStubProvider(
+		StubTurn{ToolCalls: []ToolCall{{ID: "1", Name: "search", Args: core.NewRawJSON([]byte(`{"q":"x"}`))}}},
+		StubTurn{Text: "found it"},
+	)
+	src, err := NewServerAgentSource(ServerAgentConfig{
+		Name:         "research",
+		Description:  "a research specialist",
+		Instructions: "You research.",
+		Tools:        scopedDefs(),
+		Backing:      backing,
+		Provider:     prov,
+	})
+	if err != nil {
+		t.Fatalf("NewServerAgentSource: %v", err)
+	}
+	res, err := src.Call(context.Background(), "research", map[string]any{"task": "look it up"})
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if !backing.received("search") {
+		t.Fatalf("scoped tool call did not reach the backing; calls=%v", backing.calls)
+	}
+	if got := res.Content[0].Text; got != "found it" {
+		t.Fatalf("delegate returned %q, want child final text %q", got, "found it")
+	}
+}
+
+// TestServerAgentSource_RejectsUnscopedTool is the capability-boundary guard:
+// the child model calls a tool the backing server HAS but the agent definition
+// did NOT scope. The call must never reach the backing; the child is told the
+// tool is unknown and its turn continues. Proven to fail if scopedSource were
+// to delegate every name straight through.
+func TestServerAgentSource_RejectsUnscopedTool(t *testing.T) {
+	backing := &recordingBacking{}
+	prov := NewStubProvider(
+		StubTurn{ToolCalls: []ToolCall{{ID: "1", Name: "delete_everything", Args: core.NewRawJSON([]byte(`{}`))}}},
+		StubTurn{Text: "could not"},
+	)
+	src, err := NewServerAgentSource(ServerAgentConfig{
+		Name:     "research",
+		Tools:    scopedDefs(), // scopes "search" only
+		Backing:  backing,
+		Provider: prov,
+	})
+	if err != nil {
+		t.Fatalf("NewServerAgentSource: %v", err)
+	}
+	if _, err := src.Call(context.Background(), "research", map[string]any{"task": "wipe it"}); err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if backing.received("delete_everything") {
+		t.Fatalf("un-scoped tool reached the backing: scoping boundary breached")
+	}
+}
+
+// TestServerAgentSource_ThreadsInstructionsAndScopedTools asserts the child
+// Runner is seeded with the agent's instructions and advertises exactly the
+// scoped tools to its own model (progressive disclosure: the scoped schemas
+// live in the child, and only the scoped names are offered).
+func TestServerAgentSource_ThreadsInstructionsAndScopedTools(t *testing.T) {
+	backing := &recordingBacking{}
+	prov := NewStubProvider(StubTurn{Text: "ok"})
+	src, err := NewServerAgentSource(ServerAgentConfig{
+		Name:         "research",
+		Instructions: "You are a careful researcher.",
+		Tools:        scopedDefs(),
+		Backing:      backing,
+		Provider:     prov,
+	})
+	if err != nil {
+		t.Fatalf("NewServerAgentSource: %v", err)
+	}
+	if _, err := src.Call(context.Background(), "research", map[string]any{"task": "hi"}); err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	reqs := prov.Requests()
+	if len(reqs) == 0 {
+		t.Fatal("child provider received no request")
+	}
+	if reqs[0].Instructions != "You are a careful researcher." {
+		t.Fatalf("child instructions = %q, want the agent's", reqs[0].Instructions)
+	}
+	if len(reqs[0].Tools) != 1 || reqs[0].Tools[0].Name != "search" {
+		t.Fatalf("child was offered %v, want only the scoped [search]", reqs[0].Tools)
+	}
+}
+
+func TestServerAgentSource_Validates(t *testing.T) {
+	backing := &recordingBacking{}
+	prov := NewStubProvider()
+	cases := map[string]ServerAgentConfig{
+		"missing name":     {Provider: prov, Backing: backing},
+		"missing provider": {Name: "x", Backing: backing},
+		"missing backing":  {Name: "x", Provider: prov},
+	}
+	for name, cfg := range cases {
+		if _, err := NewServerAgentSource(cfg); err == nil {
+			t.Errorf("%s: expected error, got nil", name)
+		}
+	}
+}

--- a/cmd/agentchat/go.mod
+++ b/cmd/agentchat/go.mod
@@ -62,6 +62,8 @@ require (
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
+	github.com/panyam/mcpkit/experimental/ext/agents v0.0.0 // indirect
+	github.com/panyam/mcpkit/experimental/ext/agents/clients/go v0.0.0 // indirect
 	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
 	github.com/pgvector/pgvector-go v0.4.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
@@ -140,6 +142,10 @@ replace github.com/panyam/mcpkit/ext/auth => ../../ext/auth
 replace github.com/panyam/mcpkit/ext/skills => ../../ext/skills
 
 replace github.com/panyam/mcpkit/ext/otel => ../../ext/otel
+
+replace github.com/panyam/mcpkit/experimental/ext/agents => ../../experimental/ext/agents
+
+replace github.com/panyam/mcpkit/experimental/ext/agents/clients/go => ../../experimental/ext/agents/clients/go
 
 replace github.com/panyam/mcpkit/experimental/ext/events => ../../experimental/ext/events
 

--- a/docs/AGENT_COMPOSITION.md
+++ b/docs/AGENT_COMPOSITION.md
@@ -248,6 +248,48 @@ Consequences:
 
 Decision captured in issue 1151; enforced by constraint A7.
 
+## Server-advertised agents (experimental)
+
+A server can advertise a roster of specialist agents it hosts, and a supervisor
+builds each one *locally* and loops its tool calls back to that server. This is
+the MCP Agents WG execution model (epic 1142), and it maps almost exactly onto
+`AgentSource` — the bridge is an adapter, not new engine work.
+
+Two layers, split on A6:
+
+- **Wire primitive → `experimental/ext/agents`** (issue 1143): the discovery
+  surface. `capabilities.extensions[io.modelcontextprotocol/agents]` (level 1),
+  `agents/list` returns a roster of routing tuples with no tool schemas (level
+  2), `agents/get {agentId}` resolves one agent's instructions + scoped tools
+  (level 3). Same progressive-disclosure shape as two-tier skills (#910). It
+  traffics only in protocol objects, so it is not agent-layer.
+
+- **Bridge → `agent/` + `agent/host`** (issue 1144): consuming a resolved
+  agent needs a model + a turn, so it is agent-layer.
+  - `agent.NewServerAgentSource` (adapter, dep-free of the experimental module)
+    takes the *decoded pieces* — `Instructions string`, `Tools []core.ToolDef`,
+    and a `Backing ToolSource` — and returns an `AgentSource` over a child
+    Runner. The child's ToolSource is a **scoped source**: it advertises the
+    agent's scoped tool schemas and dispatches a call to the backing (the
+    advertising server) **only for a scoped name**. A tool the server has but
+    the agent's definition did not scope is `ErrUnknownTool` from the child —
+    the capability boundary that keeps a server-advertised agent to its declared
+    scope, not the server's whole `tools/list`.
+  - The host (`agent/host/server_agents.go`) discovers each connected server's
+    roster and adds a **lazy delegate per agent** (`serverAgentSource`) to the
+    main aggregate. `agents/get` fires only on first delegation (cached after),
+    so the scoped schemas resolve into the *child* Runner and never enter the
+    supervisor's context — the progressive-disclosure win, mirroring
+    catalog-mode skills. Per-server, opt-out via `ServerConfig.Agents`.
+
+Invocation is not new wire surface: the child's scoped tool calls go back over
+the existing `tools/call`. The WG's server-side `delegateTool` (run the agent on
+the server) is the alternative path; the bridge is the host-side-execution path,
+which is what composes with the rest of this model (depth/budget/scope/signal
+plumbing all apply to the delegate unchanged). Observability spans for the
+extension itself are issue 1145; the child Runner already carries the standard
+SEP-414 spans/metrics.
+
 ## Constraints this model respects
 
 - **A6** (model-facing → `agent/`): `AgentSource`, `Team`, and the future

--- a/examples/agents/agent-async/go.mod
+++ b/examples/agents/agent-async/go.mod
@@ -22,6 +22,8 @@ require (
 	github.com/invopop/jsonschema v0.14.0 // indirect
 	github.com/panyam/gocurrent v0.1.1 // indirect
 	github.com/panyam/goutils v0.1.8 // indirect
+	github.com/panyam/mcpkit/experimental/ext/agents v0.0.0 // indirect
+	github.com/panyam/mcpkit/experimental/ext/agents/clients/go v0.0.0 // indirect
 	github.com/panyam/mcpkit/experimental/ext/events/clients/go v0.0.0 // indirect
 	github.com/panyam/mcpkit/ext/auth v0.0.0 // indirect
 	github.com/panyam/mcpkit/ext/skills v0.0.0 // indirect
@@ -59,6 +61,10 @@ replace github.com/panyam/mcpkit/ext/skills => ../../../ext/skills
 replace github.com/panyam/mcpkit/ext/auth => ../../../ext/auth
 
 replace github.com/panyam/mcpkit/ext/otel => ../../../ext/otel
+
+replace github.com/panyam/mcpkit/experimental/ext/agents => ../../../experimental/ext/agents
+
+replace github.com/panyam/mcpkit/experimental/ext/agents/clients/go => ../../../experimental/ext/agents/clients/go
 
 replace github.com/panyam/mcpkit/experimental/ext/events => ../../../experimental/ext/events
 

--- a/examples/agents/critic/go.mod
+++ b/examples/agents/critic/go.mod
@@ -20,6 +20,8 @@ require (
 	github.com/invopop/jsonschema v0.14.0 // indirect
 	github.com/panyam/gocurrent v0.1.1 // indirect
 	github.com/panyam/goutils v0.1.8 // indirect
+	github.com/panyam/mcpkit/experimental/ext/agents v0.0.0 // indirect
+	github.com/panyam/mcpkit/experimental/ext/agents/clients/go v0.0.0 // indirect
 	github.com/panyam/mcpkit/experimental/ext/events v0.0.0 // indirect
 	github.com/panyam/mcpkit/experimental/ext/events/clients/go v0.0.0 // indirect
 	github.com/panyam/mcpkit/ext/auth v0.0.0 // indirect
@@ -58,6 +60,10 @@ replace github.com/panyam/mcpkit/ext/skills => ../../../ext/skills
 replace github.com/panyam/mcpkit/ext/auth => ../../../ext/auth
 
 replace github.com/panyam/mcpkit/ext/otel => ../../../ext/otel
+
+replace github.com/panyam/mcpkit/experimental/ext/agents => ../../../experimental/ext/agents
+
+replace github.com/panyam/mcpkit/experimental/ext/agents/clients/go => ../../../experimental/ext/agents/clients/go
 
 replace github.com/panyam/mcpkit/experimental/ext/events => ../../../experimental/ext/events
 

--- a/examples/skills/go.mod
+++ b/examples/skills/go.mod
@@ -21,6 +21,8 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fernet/fernet-go v0.0.0-20240119011108-303da6aec611 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
+	github.com/panyam/mcpkit/experimental/ext/agents v0.0.0 // indirect
+	github.com/panyam/mcpkit/experimental/ext/agents/clients/go v0.0.0 // indirect
 	github.com/panyam/mcpkit/experimental/ext/events v0.0.0 // indirect
 	github.com/panyam/mcpkit/experimental/ext/events/clients/go v0.0.0 // indirect
 	github.com/panyam/mcpkit/ext/auth v0.0.0 // indirect
@@ -117,6 +119,10 @@ replace github.com/panyam/mcpkit/agent/host => ../../agent/host
 replace github.com/panyam/mcpkit/ext/auth => ../../ext/auth
 
 replace github.com/panyam/mcpkit/ext/tasks => ../../ext/tasks
+
+replace github.com/panyam/mcpkit/experimental/ext/agents => ../../experimental/ext/agents
+
+replace github.com/panyam/mcpkit/experimental/ext/agents/clients/go => ../../experimental/ext/agents/clients/go
 
 replace github.com/panyam/mcpkit/experimental/ext/events => ../../experimental/ext/events
 

--- a/examples/tasks-v2/go.mod
+++ b/examples/tasks-v2/go.mod
@@ -22,6 +22,8 @@ require (
 	github.com/fernet/fernet-go v0.0.0-20240119011108-303da6aec611 // indirect
 	github.com/fsnotify/fsnotify v1.10.1 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
+	github.com/panyam/mcpkit/experimental/ext/agents v0.0.0 // indirect
+	github.com/panyam/mcpkit/experimental/ext/agents/clients/go v0.0.0 // indirect
 	github.com/panyam/mcpkit/experimental/ext/events v0.0.0 // indirect
 	github.com/panyam/mcpkit/experimental/ext/events/clients/go v0.0.0 // indirect
 	github.com/panyam/mcpkit/ext/auth v0.0.0 // indirect
@@ -118,6 +120,10 @@ replace github.com/panyam/mcpkit/agent/host => ../../agent/host
 replace github.com/panyam/mcpkit/ext/skills => ../../ext/skills
 
 replace github.com/panyam/mcpkit/ext/auth => ../../ext/auth
+
+replace github.com/panyam/mcpkit/experimental/ext/agents => ../../experimental/ext/agents
+
+replace github.com/panyam/mcpkit/experimental/ext/agents/clients/go => ../../experimental/ext/agents/clients/go
 
 replace github.com/panyam/mcpkit/experimental/ext/events => ../../experimental/ext/events
 


### PR DESCRIPTION
## What changes

Bridges a server-advertised agent (the experimental/ext/agents discovery primitive, #1143) into the existing composition harness. Given a decoded `agents/get` result — instructions + a scoped tool set — the host now builds a child Runner *locally* and loops its tool calls back to the advertising server, exposing it to the supervisor model as a delegate tool exactly like any other `AgentSource`. This is the MCP Agents WG execution model (epic #1142); the bridge is an adapter over `AgentSource`, not new engine work.

Two layers, split on `agent/CONSTRAINTS.md` A6:
- **`agent.NewServerAgentSource`** — the adapter. Dep-free of the experimental module (takes the decoded parts, not the wire type). The child's tool source is a *scoped source* that advertises the agent's scoped schemas and dispatches a call back through the backing (the server) **only for a scoped name**; an un-scoped server tool is `ErrUnknownTool` — the capability boundary.
- **`registerServerAgents`** (host) — discovers each connected server's roster (`agents/list`) and adds a **lazy** delegate per agent to the main aggregate. `agents/get` resolves an agent's instructions + scoped tools on first delegation only (cached after), so scoped schemas never enter the supervisor's context (progressive disclosure, mirroring catalog-mode skills). Per-server opt-out via `ServerConfig.Agents`.

## Reviewer's guide

Read in this order:
1. [agent/server_agent_source.go](https://github.com/panyam/mcpkit/pull/1186/files#diff-240d6bda420de62b46842b88f09930a9c06a3e142cb674d3ee7d119b40eacf7a) — start here. The adapter + the `scopedSource` capability boundary (the load-bearing logic).
2. [agent/server_agent_source_test.go](https://github.com/panyam/mcpkit/pull/1186/files#diff-af89645599d14af35881174c9fd2651f8d9cf57bc52ed2637fca3a32524c671d) — acceptance for the adapter: scoping (un-scoped tool rejected), dispatch, instructions threading.
3. [agent/host/server_agents.go](https://github.com/panyam/mcpkit/pull/1186/files#diff-2ca8f655755d3e22a5d5c07d87506631bec23ecfcff0029e01637cf32aee548c) — discovery + the lazy `serverAgentSource` (resolve-on-first-delegation, cached).
4. [agent/host/server_agents_test.go](https://github.com/panyam/mcpkit/pull/1186/files#diff-eba958586080b8480c6bad3413fda100ec39c3f033e3b9dbdc74460c730d0e77) — host acceptance: lazy `agents/get` count, delegation loop-back, end-to-end App over a real in-process agents server.
5. [agent/host/config.go](https://github.com/panyam/mcpkit/pull/1186/files#diff-6aff502cc5cae4b9d9769752e8638899bab121e09de870b5d1320cc892c6bf2d) — the `ServerConfig.Agents` opt-out toggle.
6. [agent/host/app.go](https://github.com/panyam/mcpkit/pull/1186/files#diff-89fb8e04b6e1e9d5f7f76958490ef158dee40e2cae92d87c04b408d893c84361) — one-line wiring into the register phase.

Skim or skip: the `go.mod` edits (add the two experimental agents modules + replaces across host and its three consumers) and `docs/AGENT_COMPOSITION.md` (new "Server-advertised agents" section).

## Diff groups
- Production: `agent/server_agent_source.go`, `agent/host/server_agents.go`, `agent/host/config.go`, `agent/host/app.go`
- Tests: `agent/server_agent_source_test.go`, `agent/host/server_agents_test.go`
- Mechanical (go.mod/replaces, docs): host + cmd/agentchat + two example go.mods, `docs/AGENT_COMPOSITION.md`

## How it works (pseudocode walkthrough)

```
# host, at boot (register phase):
for each connected server with capabilities.extensions[.../agents]:
    roster = agents/list          # routing tuples only, NO tool schemas
    add serverAgentSource{roster, get: agents/get, backing: ClientSource(server)}
      as one delegate tool per roster entry     # agents/get NOT called yet

# supervisor delegates to "research":
serverAgentSource.Call("research", {task}):
    detail = agents/get("research")             # <-- lazy: first delegation only, cached
    child  = NewServerAgentSource(
                 instructions = detail.instructions,
                 tools        = detail.tools,     # scoped schemas -> CHILD only
                 backing      = ClientSource(server))
    return child.Call("research", {task})        # runs child Runner over its own slice

# child Runner calls one of its scoped tools:
scopedSource.Call(name):
    if name not in detail.tools: return ErrUnknownTool   # capability boundary
    return backing.Call(name)                    # loops back to the server via tools/call
```

## Decision log
- **Local-build model, not the WG's server-side `delegateTool`.** #1144 asks for building the child locally and looping tool calls back — that's what maps onto `AgentSource` and composes with depth/budget/scope/signal. `DelegateTool` stays advisory.
- **Delegate tool name = `AgentID`** (unique within a server per the extension), so names never collide within one source; `DelegateTool` is the server-side-execution entry point and isn't used on this path.
- **Adapter takes decoded pieces, not `agents.AgentDetail`.** Keeps `agent/` free of the experimental module (A6); the host decodes and hands the parts down.
- **Resolution failure is a model-visible `IsError`, not a dispatch error** — the supervisor's turn continues, matching how `AgentSource` handles a child failure.

## Risk / blast radius
- Affects: `agent/` (new file, no dep change), `agent/host` (new file + `Agents` toggle + one wiring line + two new module deps), and the go.mod/replaces of `cmd/agentchat` + `examples/agents/{agent-async,critic}` (transitive).
- Tests: adapter unit tests + host unit tests (laziness/scoping) + one end-to-end App integration test (real in-process agents server, `-race` clean).
- Be paranoid about: the scoping boundary (a child must never reach an un-scoped server tool — `TestServerAgentSource_RejectsUnscopedTool` / the `scopedSource` name check) and the lazy path (no `agents/get` at boot — `TestServerAgentSource_LazyResolution` asserts a 0→1 get count).

## Before / after

```mermaid
flowchart LR
  subgraph after["after — this PR"]
    S2[supervisor Runner] -->|delegate task| L[serverAgentSource<br/>lazy, per roster]
    L -->|first call: agents/get| D[agents/get detail]
    D --> C[child Runner<br/>scoped tools + instructions]
    C -->|scoped tool call| B[ClientSource → server tools/call]
  end
  subgraph before["before"]
    S1[supervisor Runner] -.->|no bridge:<br/>roster undiscoverable| X[server agents roster]
  end
```

Behavioral: with a server advertising a `workflow-agent`, the main aggregate now exposes a `workflow-agent` delegate tool; delegating to it runs a child that calls the server's real `list_pipelines` tool over the wire (asserted end-to-end in `TestApp_DiscoversAndDelegatesToServerAgent`).

## Out of scope (deliberately deferred)
- SEP-414 observability spans for the agents extension itself → #1145 (the child Runner already carries the standard Runner spans/metrics).
- Late-server agent discovery (a server that connects after boot) — discovery runs over boot-time servers, matching static sub-agent membership.
- Demo: deep-agent supervisor over a server-advertised roster → #1146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8RL8XyKWVVHrGDVfe2pnY