### PR TITLE
fix(conformance): run split SEP-2640 skills scenarios in testconf-skills

### DIFF
--- a/conformance/scripts/conf-skills.sh
+++ b/conformance/scripts/conf-skills.sh
@@ -21,22 +21,33 @@ for i in 1 2 3 4 5 6 7 8 9 10; do
     curl -sf -o /dev/null -X OPTIONS http://localhost:18099/mcp && break
     sleep 0.3
 done
-(cd "${MCPCONFORMANCE_SKILLS_PATH}" && \
-    node dist/index.js server \
-        --url http://localhost:18099/mcp \
-        --scenario sep-2640-skills \
-        -o "$OUT/checks" > "$OUT/runner.log" 2>&1)
-RC=$?
+# The SEP-2640 server surface is split across three scenarios (mcpconformance
+# PR 330): index shape, SKILL.md manifest, and resources/directory/read. Each is
+# registered in both the active and pending suites and run by exact name.
+SKILLS_SCENARIOS="sep-2640-skills-index sep-2640-skills-manifest sep-2640-skills-directory"
+RC=0
+for S in ${SKILLS_SCENARIOS}; do
+    (cd "${MCPCONFORMANCE_SKILLS_PATH}" && \
+        node dist/index.js server \
+            --url http://localhost:18099/mcp \
+            --scenario "${S}" \
+            -o "$OUT/checks-${S}" > "$OUT/runner-${S}.log" 2>&1)
+    SRC=$?
+    SUMMARY=$(grep -E "Passed:" "$OUT/runner-${S}.log" | tail -1 | sed 's/\x1b\[[0-9;]*m//g')
+    echo "  ${S}: ${SUMMARY:-runner exited ${SRC} (see $OUT/runner-${S}.log)}"
+    [ ${SRC} -ne 0 ] && RC=${SRC}
+done
 kill $PID 2>/dev/null
 wait $PID 2>/dev/null
 if [ $RC -ne 0 ]; then
     echo "==================================================================="
-    echo "testconf-skills: INFORMATIONAL — runner exited $RC (artifacts in $OUT)"
+    echo "testconf-skills: INFORMATIONAL — a runner invocation exited $RC (artifacts in $OUT)"
     echo "This suite is INFO status in conformance/local-suites.yaml while the"
     echo "fork-side Scenario classes iterate on sep-2640.yaml (mcpconformance"
-    echo "PR 330). The check failures are pre-existing input-required-result"
-    echo "(SEP-2567) gaps the skills runner also exercises, not new regressions."
-    echo "Exiting 0 so the umbrella reaches refresh-conformance. See issue 613."
+    echo "PR 330). Exiting 0 so the umbrella reaches refresh-conformance. See issue 613."
     echo "==================================================================="
-    tail -30 "$OUT/runner.log" 2>/dev/null
+    for S in ${SKILLS_SCENARIOS}; do
+        echo "--- ${S} ---"; tail -20 "$OUT/runner-${S}.log" 2>/dev/null
+    done
 fi
+exit 0


### PR DESCRIPTION
mcpconformance PR 330 split the single `sep-2640-skills` scenario into three (`sep-2640-skills-index`, `-manifest`, `-directory`) as the skills coverage grew from the directory-read surface to the index and SKILL.md manifest surfaces. The runner matches `--scenario` by exact name, so `conf-skills.sh`'s old single hardcoded name now matches nothing.

Loop over the three scenario names, surface each `Passed:` summary on stdout, and keep the informational exit-0 contract.

## Verification
`just testconf-skills` against `examples/skills` (conf-skills checkout at the PR 330 head):
```
sep-2640-skills-index:     Passed: 6/6, 0 failed, 0 warnings
sep-2640-skills-manifest:  Passed: 6/6, 0 failed, 0 warnings
sep-2640-skills-directory: Passed: 7/7, 0 failed, 0 warnings
```

Pairs with mcpconformance PR 330 (the fork branch `chore/sep-2640-yaml` must be at the split-scenario commit and rebuilt).