### PR TITLE
feat(experimental/ext/agents): SEP-414 discovery spans (issue 1145)

### DIFF
--- a/agent/host/server_agents.go
+++ b/agent/host/server_agents.go
@@ -114,6 +114,9 @@ type serverAgentSource struct {
 }
 
 func newServerAgentSource(deps serverAgentDeps) *serverAgentSource {
+	if deps.tp == nil {
+		deps.tp = core.NoopTracerProvider{}
+	}
 	s := &serverAgentSource{
 		deps:   deps,
 		byTool: make(map[string]agents.AgentSummary, len(deps.summaries)),
@@ -198,8 +201,16 @@ func (s *serverAgentSource) resolve(ctx context.Context, summary agents.AgentSum
 	}
 	s.mu.Unlock()
 
+	// One span per first-use resolution ties the supervisor's delegation to the
+	// agents/get discovery span (on the server) and the child Runner's turn
+	// spans, so a trace reads supervisor -> resolve(agent.id) -> get -> child.
+	// Cache hits (the common case after warm-up) are not spanned.
+	ctx, span := s.deps.tp.StartSpan(ctx, "agents.resolve", core.Attribute{Key: "mcp.agent.id", Value: id})
+	defer span.End()
+
 	detail, err := s.deps.get(ctx, id)
 	if err != nil {
+		span.RecordError(err)
 		return nil, err
 	}
 	child, err := agent.NewServerAgentSource(agent.ServerAgentConfig{

--- a/agent/host/server_agents_test.go
+++ b/agent/host/server_agents_test.go
@@ -195,6 +195,70 @@ func TestApp_DiscoversAndDelegatesToServerAgent(t *testing.T) {
 	}
 }
 
+// hostRecSpan / hostRecTP are a local recording TracerProvider for asserting
+// the host-side agents.resolve span without pulling in ext/otel.
+type hostRecSpan struct {
+	name  string
+	attrs map[string]string
+}
+
+func (s *hostRecSpan) End()                     {}
+func (s *hostRecSpan) SetAttribute(k, v string) { s.attrs[k] = v }
+func (s *hostRecSpan) RecordError(error)        {}
+func (s *hostRecSpan) AddLink(core.Link)        {}
+
+type hostRecTP struct{ spans []*hostRecSpan }
+
+func (p *hostRecTP) StartSpan(ctx context.Context, name string, attrs ...core.Attribute) (context.Context, core.Span) {
+	sp := &hostRecSpan{name: name, attrs: make(map[string]string, len(attrs))}
+	for _, a := range attrs {
+		sp.attrs[a.Key] = a.Value
+	}
+	p.spans = append(p.spans, sp)
+	return core.WithActiveSpan(ctx, sp), sp
+}
+
+// TestServerAgentSource_ResolveSpan asserts the first delegation to an agent
+// emits an agents.resolve span tagged with the agent id, and that a cached
+// second delegation does not emit another (only the resolving call is spanned).
+func TestServerAgentSource_ResolveSpan(t *testing.T) {
+	tp := &hostRecTP{}
+	get := func(ctx context.Context, id string) (agents.AgentDetail, error) {
+		return agents.AgentDetail{
+			AgentSummary: agents.AgentSummary{AgentID: id},
+			Instructions: "you are " + id,
+			Tools:        []core.ToolDef{{Name: "search", InputSchema: map[string]any{"type": "object"}}},
+		}, nil
+	}
+	src := newServerAgentSource(serverAgentDeps{
+		summaries: rosterFixture(),
+		get:       get,
+		backing:   &fakeBacking{},
+		provider:  agent.NewStubProvider(agent.StubTurn{Text: "done"}, agent.StubTurn{Text: "done"}),
+		tp:        tp,
+	})
+
+	if _, err := src.Call(context.Background(), "research", map[string]any{"task": "hi"}); err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if _, err := src.Call(context.Background(), "research", map[string]any{"task": "again"}); err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+
+	var resolves []*hostRecSpan
+	for _, sp := range tp.spans {
+		if sp.name == "agents.resolve" {
+			resolves = append(resolves, sp)
+		}
+	}
+	if len(resolves) != 1 {
+		t.Fatalf("agents.resolve spans = %d, want 1 (first delegation only, cached after)", len(resolves))
+	}
+	if got := resolves[0].attrs["mcp.agent.id"]; got != "research" {
+		t.Fatalf("agents.resolve mcp.agent.id = %q, want %q", got, "research")
+	}
+}
+
 func hasTool(defs []core.ToolDef, name string) bool {
 	for _, d := range defs {
 		if d.Name == name {

--- a/docs/SEP_414_OTEL.md
+++ b/docs/SEP_414_OTEL.md
@@ -785,6 +785,27 @@ Coverage:
 
 **Runnable demo**: `examples/skills/walkthrough.go` exercises the wrap span + Activate path with the `--exporter=stdout` (or `--exporter=otlp`) flag pair. Run with `EXPORTER=stdout just serve` + `EXPORTER=stdout just demo`.
 
+### `experimental/ext/agents` discovery spans — landed (issue 1145)
+
+The server-declared agents primitive (`experimental/ext/agents`, epic 1142) advertises a roster via `agents/list` and resolves a specialist's instructions plus scoped tools via `agents/get`. The WG frames MCP's subagent gap versus ACP as an observability gap, so tracing the discovery + delegation lifecycle is part of the primitive's value, not a parity afterthought.
+
+The pass follows the established opt-in contract. `agents.Config.TracerProvider core.TracerProvider` defaults to `core.NoopTracerProvider{}` (zero allocation, no spans), and the extension depends only on the core tracing abstraction, never on `ext/otel`.
+
+**Server side — discovery spans** (`experimental/ext/agents/registry.go`):
+
+| Handler | Span name | Attributes |
+|---|---|---|
+| `agents/list` | `agents.list` | `agents.count` (roster size) |
+| `agents/get` | `agents.get` | `mcp.agent.id`, `agents.found` (`true` / `false`) |
+
+`agents.found` is set on every path (including empty / unknown `agentId`), so a failed lookup is visible in the trace rather than silent.
+
+**Host side — delegation edge** (`agent/host/server_agents.go`). The host's lazy `serverAgentSource.resolve` wraps the first-use `agents/get` + child build in an `agents.resolve` span carrying `mcp.agent.id`. Cache hits are not spanned. This ties the three pieces a delegation trace should show: `supervisor turn -> agents.resolve(agent.id) -> agents.get -> child turn`.
+
+**Sub-agent execution reuses the Runner's own spans.** A resolved specialist is a normal `agent.AgentSource` over a child `Runner`, so its work already emits `agent.turn` / `agent.step` / `agent.tool` spans (the same instrumentation any Runner gets). The host threads its `TracerProvider` through the bridge (`ServerAgentConfig.TracerProvider`), so no separate execution-span machinery is needed. The in-process delegation runs synchronously inside the supervisor's tool-call span, so those child spans nest naturally under it. A new-root-span + link shape (like `task.execute`) would only be warranted for an async delegation form (`AsyncAgentSource`) whose run outlives the dispatch; that is deferred until a demo needs it.
+
+Coverage: `experimental/ext/agents/tracing_test.go` pins the discovery spans (list count, get found / not-found, and the zero-overhead nil-TracerProvider path); `agent/host/server_agents_test.go` pins the `agents.resolve` span (emitted on first delegation, not on the cached second).
+
 ## Downstream consumers of the Phase 1 contract
 
 - **`experimental/ext/events/` cross-replica bus (issue #629).** The

--- a/experimental/ext/agents/README.md
+++ b/experimental/ext/agents/README.md
@@ -58,6 +58,17 @@ handlers. The returned `Registry` supports runtime `AddAgent` / `RemoveAgent`.
 first wins). An unknown `agentId` on `agents/get` is a `-32602` InvalidParams
 error.
 
+### Tracing (SEP-414)
+
+Set `Config.TracerProvider` to opt the discovery handlers into spans:
+`agents.list` (attribute `agents.count`) and `agents.get` (`mcp.agent.id`,
+`agents.found`). Nil or `core.NoopTracerProvider{}` — the default — emits
+nothing with zero allocation, and the extension depends only on the core
+tracing abstraction, never on `ext/otel`. A resolved specialist's own execution
+is traced by the child `Runner` the host builds from an `agents/get` result;
+the host also emits an `agents.resolve` span tying delegation to discovery. See
+`docs/SEP_414_OTEL.md` § "experimental/ext/agents discovery spans".
+
 ## Client side (`clients/go`)
 
 ```go

--- a/experimental/ext/agents/registry.go
+++ b/experimental/ext/agents/registry.go
@@ -3,6 +3,7 @@ package agents
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"sync"
 
 	"github.com/panyam/mcpkit/core"
@@ -19,6 +20,18 @@ type Config struct {
 	// unique; Register drops later duplicates with a returned error. May be
 	// empty and populated at runtime via Registry.AddAgent.
 	Agents []AgentDef
+
+	// TracerProvider opts the discovery handlers into SEP-414 spans
+	// (agents.list / agents.get). Nil or core.NoopTracerProvider{} — the
+	// default — skips emission with zero allocation, the same opt-in contract
+	// ext/tasks and events use. The extension depends only on the core tracing
+	// abstraction, never on ext/otel: hand it any core.TracerProvider (in
+	// production, ext/otel.NewProvider(otelTP)).
+	//
+	// This traces only discovery. A sub-agent's own execution is traced by the
+	// Runner the host builds from an agents/get result (agent.turn / step /
+	// tool spans), wired independently through the bridge's TracerProvider.
+	TracerProvider core.TracerProvider
 }
 
 // Registry is the runtime handle Register returns. It owns the thread-safe
@@ -38,6 +51,10 @@ type Registry struct {
 	byID  map[string]AgentDef
 	order []string
 	srv   *server.Server
+	// tp is the discovery TracerProvider, defaulted to core.NoopTracerProvider{}
+	// by Register so the handlers can StartSpan unconditionally without a nil
+	// check.
+	tp core.TracerProvider
 }
 
 // Register declares the agents extension on cfg.Server and wires the
@@ -50,9 +67,14 @@ type Registry struct {
 // still wired and the Registry is usable — the error is advisory so a typo in
 // one agent does not take the whole server down.
 func Register(cfg Config) (*Registry, error) {
+	tp := cfg.TracerProvider
+	if tp == nil {
+		tp = core.NoopTracerProvider{}
+	}
 	r := &Registry{
 		byID: make(map[string]AgentDef),
 		srv:  cfg.Server,
+		tp:   tp,
 	}
 
 	var dupes []string
@@ -110,12 +132,17 @@ func (r *Registry) RemoveAgent(agentID string) {
 // handleList answers agents/list with the roster of summaries (no tool
 // schemas). Params are ignored — the roster is unfiltered today.
 func (r *Registry) handleList(ctx core.MethodContext, id json.RawMessage, _ json.RawMessage) *core.Response {
+	_, span := r.tp.StartSpan(ctx, "agents.list")
+	defer span.End()
+
 	r.mu.RLock()
 	summaries := make([]AgentSummary, 0, len(r.order))
 	for _, agentID := range r.order {
 		summaries = append(summaries, r.byID[agentID].Summary())
 	}
 	r.mu.RUnlock()
+
+	span.SetAttribute("agents.count", strconv.Itoa(len(summaries)))
 	return core.NewResponse(id, ListResult{Agents: summaries})
 }
 
@@ -124,12 +151,17 @@ func (r *Registry) handleList(ctx core.MethodContext, id json.RawMessage, _ json
 // A known agentId returns the full AgentDetail (summary + instructions +
 // scoped tools).
 func (r *Registry) handleGet(ctx core.MethodContext, id json.RawMessage, params json.RawMessage) *core.Response {
+	_, span := r.tp.StartSpan(ctx, "agents.get")
+	defer span.End()
+	span.SetAttribute("agents.found", "false")
+
 	var p GetParams
 	if len(params) > 0 {
 		if err := json.Unmarshal(params, &p); err != nil {
 			return core.NewErrorResponse(id, core.ErrCodeInvalidParams, "agents/get: invalid params: "+err.Error())
 		}
 	}
+	span.SetAttribute("mcp.agent.id", p.AgentID)
 	if p.AgentID == "" {
 		return core.NewErrorResponse(id, core.ErrCodeInvalidParams, "agents/get: agentId is required")
 	}
@@ -140,5 +172,6 @@ func (r *Registry) handleGet(ctx core.MethodContext, id json.RawMessage, params 
 	if !ok {
 		return core.NewErrorResponse(id, core.ErrCodeInvalidParams, fmt.Sprintf("agents/get: unknown agentId %q", p.AgentID))
 	}
+	span.SetAttribute("agents.found", "true")
 	return core.NewResponse(id, GetResult{Agent: def.Detail()})
 }

--- a/experimental/ext/agents/tracing_test.go
+++ b/experimental/ext/agents/tracing_test.go
@@ -1,0 +1,126 @@
+package agents_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/experimental/ext/agents"
+	"github.com/panyam/mcpkit/server"
+	"github.com/panyam/mcpkit/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recSpan / recTP are a local recording TracerProvider — the same dep-free
+// shape events/webhook_span_test.go uses — so these tests assert the
+// discovery spans without pulling in ext/otel.
+type recSpan struct {
+	name  string
+	attrs map[string]string
+	ended bool
+}
+
+func (s *recSpan) End()                     { s.ended = true }
+func (s *recSpan) SetAttribute(k, v string) { s.attrs[k] = v }
+func (s *recSpan) RecordError(error)        {}
+func (s *recSpan) AddLink(core.Link)        {}
+
+type recTP struct {
+	mu    sync.Mutex
+	spans []*recSpan
+}
+
+func (p *recTP) StartSpan(ctx context.Context, name string, attrs ...core.Attribute) (context.Context, core.Span) {
+	sp := &recSpan{name: name, attrs: make(map[string]string, len(attrs))}
+	for _, a := range attrs {
+		sp.attrs[a.Key] = a.Value
+	}
+	p.mu.Lock()
+	p.spans = append(p.spans, sp)
+	p.mu.Unlock()
+	return core.WithActiveSpan(ctx, sp), sp
+}
+
+func (p *recTP) find(name string) *recSpan {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, sp := range p.spans {
+		if sp.name == name {
+			return sp
+		}
+	}
+	return nil
+}
+
+// newTracedAgentsServer mirrors newAgentsServer but wires a recording
+// TracerProvider so tests can inspect the discovery spans.
+func newTracedAgentsServer(t *testing.T, tp core.TracerProvider, defs ...agents.AgentDef) *testutil.TestClient {
+	t.Helper()
+	srv := server.NewServer(core.ServerInfo{Name: "agents-trace-test", Version: "0.0.1"})
+	_, err := agents.Register(agents.Config{Server: srv, Agents: defs, TracerProvider: tp})
+	require.NoError(t, err)
+	return testutil.NewTestClient(t, srv)
+}
+
+// TestListEmitsSpan asserts agents/list emits an agents.list span carrying the
+// roster size, so an operator can see discovery traffic and its cardinality.
+func TestListEmitsSpan(t *testing.T) {
+	tp := &recTP{}
+	tc := newTracedAgentsServer(t, tp, workflowAgent())
+
+	_, err := tc.Client.Call(agents.MethodList, nil)
+	require.NoError(t, err)
+
+	sp := tp.find("agents.list")
+	require.NotNil(t, sp, "agents/list must emit an agents.list span")
+	assert.True(t, sp.ended, "span must be ended")
+	assert.Equal(t, "1", sp.attrs["agents.count"])
+}
+
+// TestGetEmitsSpanFound asserts a resolvable agents/get emits an agents.get
+// span tagged with the agent id and found=true.
+func TestGetEmitsSpanFound(t *testing.T) {
+	tp := &recTP{}
+	tc := newTracedAgentsServer(t, tp, workflowAgent())
+
+	_, err := tc.Client.Call(agents.MethodGet, agents.GetParams{AgentID: "workflow-agent"})
+	require.NoError(t, err)
+
+	sp := tp.find("agents.get")
+	require.NotNil(t, sp, "agents/get must emit an agents.get span")
+	assert.True(t, sp.ended)
+	assert.Equal(t, "workflow-agent", sp.attrs["mcp.agent.id"])
+	assert.Equal(t, "true", sp.attrs["agents.found"])
+}
+
+// TestGetEmitsSpanNotFound asserts an unknown agents/get still emits the span
+// with found=false, so failed lookups are visible in traces (not silent).
+func TestGetEmitsSpanNotFound(t *testing.T) {
+	tp := &recTP{}
+	tc := newTracedAgentsServer(t, tp, workflowAgent())
+
+	_, err := tc.Client.Call(agents.MethodGet, agents.GetParams{AgentID: "no-such-agent"})
+	require.Error(t, err, "unknown agentId is a client error")
+
+	sp := tp.find("agents.get")
+	require.NotNil(t, sp)
+	assert.Equal(t, "no-such-agent", sp.attrs["mcp.agent.id"])
+	assert.Equal(t, "false", sp.attrs["agents.found"])
+}
+
+// TestNoTracerProviderNoPanic confirms the default (nil TracerProvider) path
+// serves discovery without spans and without panicking — the zero-overhead
+// opt-out contract.
+func TestNoTracerProviderNoPanic(t *testing.T) {
+	srv := server.NewServer(core.ServerInfo{Name: "agents-notrace", Version: "0.0.1"})
+	_, err := agents.Register(agents.Config{Server: srv, Agents: []agents.AgentDef{workflowAgent()}})
+	require.NoError(t, err)
+	tc := testutil.NewTestClient(t, srv)
+
+	_, err = tc.Client.Call(agents.MethodList, nil)
+	require.NoError(t, err)
+	_, err = tc.Client.Call(agents.MethodGet, agents.GetParams{AgentID: "workflow-agent"})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## What changes

Gives the `experimental/ext/agents` discovery primitive (epic 1142) its SEP-414 OpenTelemetry pass. A new opt-in `agents.Config.TracerProvider` emits spans around `agents/list` and `agents/get`, and the host's lazy delegate source emits an `agents.resolve` span tying a supervisor's delegation to the discovery call. Nil / `NoopTracerProvider` is the default: zero allocation, no spans, no `ext/otel` dependency (core tracing abstraction only), matching the contract ext/tasks and events already use.

Why this is on the critical path, not housekeeping: the WG frames MCP's subagent gap versus ACP as an observability gap (streaming, cancellation, resumption), so tracing the subagent discovery + delegation lifecycle is part of the primitive's value proposition. It also makes the deep-agent supervisor demo (issue 1146, stacked on this) show a coherent end-to-end trace.

## Reviewer's guide
Read in this order:
1. [experimental/ext/agents/registry.go](https://github.com/panyam/mcpkit/pull/1190/files#diff-7012170831182627551770acb3df368fcee88d3ebbe5b2be5a0712fe4d9341b2) — start here. `Config.TracerProvider` + defaulting; `handleList` / `handleGet` span emission.
2. [experimental/ext/agents/tracing_test.go](https://github.com/panyam/mcpkit/pull/1190/files#diff-478167515a2bc4cf1da7915c700f2cc69f810fd93d426f1580e1502ae907e154) — acceptance: list count, get found/not-found, zero-overhead nil-TP path. Driven through the real wire (`tc.Client.Call`).
3. [agent/host/server_agents.go](https://github.com/panyam/mcpkit/pull/1190/files#diff-2ca8f655755d3e22a5d5c07d87506631bec23ecfcff0029e01637cf32aee548c) — the `agents.resolve` span in `resolve` (first-use only; `tp` defaulted to Noop in `newServerAgentSource`).
4. [agent/host/server_agents_test.go](https://github.com/panyam/mcpkit/pull/1190/files#diff-eba958586080b8480c6bad3413fda100ec39c3f033e3b9dbdc74460c730d0e77) — acceptance for the resolve span (emitted once, cached second delegation not spanned).
5. [docs/SEP_414_OTEL.md](https://github.com/panyam/mcpkit/pull/1190/files#diff-471fd7f72ab0a2ff1e1398303fa41c3e0173c19ac5439e8b833ce242fa81f3e6) + [experimental/ext/agents/README.md](https://github.com/panyam/mcpkit/pull/1190/files#diff-6063e5c31f94ff30ec3d2708cd1e2f24686c649ad6e9e74e0d5a48157f7a36cc) — the documented contract.

## How it works (span map)

```
supervisor turn (agent.turn)
  └─ tool call: delegate to <agent>            (agent.tool)
       └─ agents.resolve   {mcp.agent.id}      [host, first use only]
            └─ agents.get   {mcp.agent.id, agents.found}   [server]
       └─ child turn (agent.turn / step / tool) [child Runner, threaded TP]
```

`agents/list` is its own `agents.list` span carrying `agents.count`. `agents.found` is set on every `agents/get` path (empty / unknown / hit) so failed lookups are visible, not silent.

## Decision log
- **Discovery spans only; sub-agent execution reuses the Runner's spans.** A resolved specialist is a normal `AgentSource` over a child `Runner`, already emitting `agent.turn/step/tool`; the host threads its `TracerProvider` through `ServerAgentConfig.TracerProvider`, so no separate execution-span machinery is added.
- **No new-root + link shape (à la `task.execute`).** In-process delegation runs synchronously inside the supervisor's tool-call span, so child spans nest naturally. The detached-root shape only earns its keep for an async delegation form (`AsyncAgentSource`) whose run outlives the dispatch — deferred until a demo needs it.
- **Extension owns its TracerProvider, not reliant on `server.WithTracerProvider`.** Matches the events-fanout precedent; discovery is observable even when the server itself isn't traced.

## Risk / blast radius
- Affects: `experimental/ext/agents` (new Config field, additive) and `agent/host` server-agent delegation (one span, `tp` now defaulted to Noop).
- Default path unchanged: nil TracerProvider = no spans, no allocation.
- Tests covering this: the two `*_test.go` above; both shown red-before-green.
- Note: `experimental/ext/agents` tests are not in the per-PR `test.yml` matrix (they run via the umbrella / `testall`), so GitHub CI here won't gate the extension tests — verified locally with `just -f experimental/justfile test-agents` equivalents.

## Before / after (agents/get trace attributes)
```
before:  agents/get  ->  (no span emitted)
after:   agents/get  ->  span "agents.get" { mcp.agent.id=workflow-agent, agents.found=true }
         agents/get(unknown) -> span "agents.get" { mcp.agent.id=no-such-agent, agents.found=false }
         agents/list -> span "agents.list" { agents.count=1 }
```

## Out of scope (deliberately deferred)
- Async-delegation detached-root spans → when `AsyncAgentSource` gets a server-agent form.
- The deep-agent supervisor demo that consumes these traces → issue 1146 (stacked on this branch).

Closes #1145.

