### PR TITLE
feat(agent/host): retained event log on gocurrent.Queue (E1, #1194)

### DIFF
--- a/agent/host/app.go
+++ b/agent/host/app.go
@@ -93,7 +93,19 @@ type App struct {
 	subs      map[string]*subscription
 	metaTools bool
 	turnMu    sync.Mutex
-	emitMu    sync.Mutex      // serializes emit so concurrent server-connect events don't race the renderer
+	emitMu    sync.Mutex // serializes emit's synchronous local delivery (the Group, turn, and event goroutines all emit)
+
+	// eventLog is the retained per-session event log. emit appends every
+	// HostEvent here in addition to delivering it synchronously to the local
+	// observers, so the log is the single source of truth a web surface
+	// subscribes onto (replay from offset 0 + live) and the barrier seam for
+	// multi-surface asks. Local observers stay synchronous because the terminal
+	// renderer writes to a caller-visible io.Writer; the async subscriber
+	// adapter that isolates a remote surface lands with that surface (issue
+	// 1196). Unbounded for now (issue 1194, Option A); a bounded gocurrent
+	// variant is a follow-up before long multi-subscriber sessions are common.
+	eventLog *gocurrent.Queue[HostEvent]
+
 	evCtx     context.Context // subscription lifetime ctx; the ready-observer subscribes late servers on it
 	eventStop context.CancelFunc
 
@@ -313,6 +325,9 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 	multi := agent.NewMultiSource()
 	app := &App{cfg: cfg, sources: multi, observers: observers, replOut: out, bgTasks: map[string]*client.BackgroundTask{}, subs: map[string]*subscription{}, store: o.store,
 		tp: o.tp, log: o.logger, skillBlocks: map[string]string{}, skillCatalog: map[string][]catalogSkill{}, oauthSources: map[string]loginSource{}}
+	// Bring the retained event log up before anything can emit (the
+	// server-connect hooks below capture app and fire asynchronously).
+	app.eventLog = gocurrent.NewQueue[HostEvent]()
 	for _, sc := range cfg.Servers {
 		app.serverOrder = append(app.serverOrder, sc.ID)
 	}
@@ -801,12 +816,15 @@ func (a *App) SwitchProvider(name string) error {
 	return nil
 }
 
-// emit fans a host event out to every registered observer. Fire-and-forget:
-// observers render, trace, or push it; none reply. Serialized: the async server
-// connections (Group observer), the turn goroutine, and event goroutines all
-// emit, so the lock keeps a not-inherently-concurrent observer (the terminal
-// renderer writing to one io.Writer) from racing.
+// emit records a host event on the retained log and delivers it synchronously
+// to every local observer. The append is the source of truth a web surface
+// replays and subscribes onto; the synchronous fan-out preserves the terminal
+// rendering contract (a caller reading the renderer's io.Writer sees the event
+// once emit returns). Serialized by emitMu: the async server connections (Group
+// observer), the turn goroutine, and event goroutines all emit, so the lock
+// keeps the not-inherently-concurrent terminal renderer from racing.
 func (a *App) emit(ev HostEvent) {
+	a.eventLog.Append(ev)
 	a.emitMu.Lock()
 	defer a.emitMu.Unlock()
 	for _, o := range a.observers {

--- a/agent/host/eventlog_test.go
+++ b/agent/host/eventlog_test.go
@@ -1,0 +1,60 @@
+package host
+
+import (
+	"reflect"
+	"testing"
+
+	gocurrent "github.com/panyam/gocurrent"
+)
+
+// TestEventLog_RetainsForLateReplay is the E1 substrate acceptance: emit
+// records every event on the retained log, so a subscriber that attaches after
+// events were emitted replays them from offset 0 and is notified of live ones.
+// This is what lets a web surface (issue 1196) join a running session and see
+// its history.
+func TestEventLog_RetainsForLateReplay(t *testing.T) {
+	a := &App{eventLog: gocurrent.NewQueue[HostEvent]()}
+	a.emit(HostEvent{Kind: HostSessionWarn, Err: "0"})
+	a.emit(HostEvent{Kind: HostSessionWarn, Err: "1"})
+
+	sub := a.eventLog.Subscribe() // subscribes late, after "0" and "1"
+	defer sub.Close()
+
+	a.emit(HostEvent{Kind: HostSessionWarn, Err: "2"})
+
+	select {
+	case <-sub.Notify():
+	default:
+		t.Fatal("late subscriber was not notified of the live event")
+	}
+
+	evs, _ := a.eventLog.ReadFrom(0)
+	got := make([]string, len(evs))
+	for i := range evs {
+		got[i] = evs[i].Err
+	}
+	if want := []string{"0", "1", "2"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("replay = %v, want %v", got, want)
+	}
+}
+
+// TestEmit_DeliversToLocalObserversSynchronously pins the terminal rendering
+// contract that the log must not break: emit delivers to registered observers
+// synchronously and in order (the event is present the instant emit returns, no
+// wait), and the same events land on the retained log.
+func TestEmit_DeliversToLocalObserversSynchronously(t *testing.T) {
+	rec := &recordObserver{}
+	a := &App{eventLog: gocurrent.NewQueue[HostEvent](), observers: []Observer{rec}}
+
+	want := []HostEventKind{HostRunnerEvent, HostTurnDone, HostSessionWarn}
+	for _, k := range want {
+		a.emit(HostEvent{Kind: k})
+	}
+
+	if got := rec.kinds(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("observer order = %v, want %v", got, want)
+	}
+	if n := a.eventLog.Len(); n != len(want) {
+		t.Fatalf("retained log length = %d, want %d", n, len(want))
+	}
+}

--- a/agent/host/hostevent.go
+++ b/agent/host/hostevent.go
@@ -112,10 +112,13 @@ type HostEvent struct {
 
 // Observer receives the host's HostEvent stream and does whatever it
 // wants with it — render to a terminal, emit spans, push to a socket,
-// record for a test. The host fans every event out to all registered
-// observers (WithObserver), so a renderer and a tracer coexist. On is
-// called from the turn goroutine and from event goroutines; an Observer
-// that is not inherently serialized must guard its own state.
+// record for a test. Every event is also recorded on the retained event
+// log (which a web surface replays and subscribes onto); an Observer is
+// the synchronous local delivery of that same stream. The host fans every
+// event out to all registered observers (WithObserver), so a renderer and
+// a tracer coexist. On is called from the turn goroutine and from event
+// goroutines; an Observer that is not inherently serialized must guard its
+// own state.
 //
 // This is the fire-and-forget half of the host's I/O. It is deliberately
 // NOT the input path: getting user input back is either surface-driven

--- a/docs/AGENT_WEB_UI_EPIC.md
+++ b/docs/AGENT_WEB_UI_EPIC.md
@@ -1,0 +1,170 @@
+# Epic — Web UI surface for the agent host (issue 1193)
+
+Status: proposed. Owner: agents workstream. Relationship to `AGENT_SDK_ROADMAP.md`: this is a
+surface/observability epic, not an SDK-parity phase. It sits beside Phases 4–7, not inside them.
+
+## Motivation
+
+Two reasons, and the second is the stronger one.
+
+1. **A second live surface.** The host layer (`agent/host`) was deliberately built surface-agnostic
+   so a web chat could reuse the whole thing and swap only stdin/stdout for a socket. `cmd/agentchat`
+   is a thin terminal surface over it. A browser surface should be another thin surface over the same
+   `App`, viewable at the same time as the TUI.
+
+2. **Observability the TUI cannot linearize.** A lot of what the agent does is not a linear scrollback:
+   sub-agent trees and fan-out concurrency, memory injection vs recall vs compaction, tool-result
+   offloading stubs and the blobs behind them, token and tree-budget consumption, upward signals and
+   preempt grants, team handoffs. A dockable-panel web UI where each of these is its own movable panel
+   is a materially better window into a running agent than scrollback can be. Every one of these
+   already has a distinct `HostEvent` kind, so the panels map onto an existing taxonomy.
+
+## Non-goals
+
+- **Not a Grafana/OTel dashboard.** The agent already emits SEP-414 spans + metrics and ships a
+  Grafana dashboard off Mimir/Tempo. That is ops-grade, aggregate, multi-session. This surface is live
+  single-session introspection for development and use. Draw the boundary explicitly.
+- **Not a rewrite of the host.** No web framework or proto types leak into `agent/host`, the same
+  discipline that keeps charm/lipgloss out of it. The web surface owns all of that.
+
+## The backbone: `gocurrent.Queue` as the per-session event log
+
+`gocurrent.Queue[T]` (already an indirect dep) is an append-only log with offset-based reads,
+per-subscriber wake-up channels, N-consumer fan-out, late-subscriber replay from offset 0, and
+`AppendBarrier`/`Resolve`/`AwaitResolution` barrier semantics. It fits this epic almost exactly:
+
+| Design need | Queue mechanism |
+|---|---|
+| Stream host events to N surfaces (TUI + every browser tab) | `Append(frame)` + per-subscriber `Notify`/`ReadFrom`, each surface tracks its own offset |
+| A tab joining a live session sees full history | late-subscriber replay from offset 0, no separate replay path |
+| Multi-surface ask: all get it, first responder wins, others auto-dismiss | `AppendBarrier(ask)` blocks the coordinator; any surface `Resolve(offset, resp)`; first writer wins (`ErrAlreadyResolved`); the resolution is a committed log entry every other surface reads and retracts on |
+
+Today the host uses `Observer` (fan-out to renderers) for host→surface and `gocurrent.FanIn` for the
+inbound MCP `events/stream` merge. `Queue` is unused. This epic makes a per-session `Queue` the spine:
+`emit` records every event on it (the retained source of truth), local observers read it synchronously,
+and the web streamer subscribes onto it asynchronously.
+
+### Do we still need `Observer`?
+
+The Queue is the source of truth; `Observer` is the synchronous local view of it. The decisive point
+stands: a pending ask **cannot** be an `Observer`, because `On(HostEvent)` returns nothing and an ask
+needs a resolution channel (`AppendBarrier`/`Resolve`). So asks ride the Queue regardless, and once
+events and asks both ride it, the Queue is the one substrate: retention, replay, the barrier, and the
+seam a remote surface subscribes onto.
+
+Implementation (E1) sharpened *how* local observers read it. The first cut made every observer an
+async drain goroutine, but that **races the terminal contract**: the built-in renderer writes to a
+caller-visible `io.Writer`, and several existing `-race` tests (plus the plain REPL's own prompt
+ordering) read that buffer synchronously right after an emit. Nothing needs the async isolation yet —
+the only remote consumer, the web streamer, does not exist until E3. So E1 keeps `emit` a **synchronous
+local fan-out** (unchanged behavior, `emitMu` retained) while **also appending to the retained log**.
+The async subscriber adapter, which a remote surface genuinely wants for backpressure isolation, lands
+with that surface in **E3**. Retention is unbounded for now (Option A); because `PersistingEmit`
+already writes each turn's events to `RunStore`, a bounded in-memory window with deep replay from the
+store is the filed follow-up.
+
+### Three wire categories
+
+Naming these explicitly clarifies the whole protocol. They map cleanly onto Queue ops:
+
+- **Host events** — push, fire-and-forget (the observability stream) → `Append`.
+- **Pending asks** — push delivery but correlated request/response resolution (elicitation, approval)
+  → `AppendBarrier` / `Resolve`. This does not violate the earlier "a prompt is request/response, not a
+  fire-and-forget event" decision. It stays request/response; it just has N delivery endpoints and a
+  first-wins collector.
+- **Queries / commands** — pull, unary request/response (`App.Dispatch` → `CmdResult`, plus the host
+  data methods `SessionsPage`, `ServerTools`, `ListMemories`, `ServerStatus`). Not on the Queue; these
+  are point-to-point reads of host state.
+
+## Frontend stack (reuse Agni)
+
+Agni's `web/` + `cmd/agni serve` pattern ports almost whole:
+
+- goapplib/templar server-rendered shell at `/`, esbuild bundle under `/static/`, Connect handlers
+  under their proto service paths, all on one `servicekit/http` listener.
+- `dockview-core` for the dockable layout; Solid islands mounted into server-rendered "holes" via the
+  park-container adopt/dispose pattern; `@panyam/tsappkit-solid` island shell.
+- Connect-Web typed clients generated from proto (buf), same-origin transport.
+- Agni's **saved-layout reconcile** (SavedLayout stores the panel-id registry beside the dockview
+  layout; a newly added panel appears in the menu without auto-opening, a user-closed one stays closed)
+  is a direct gift: an agent UI accretes panels over time and this handles that for free.
+
+The one net-new piece over Agni is the **live stream**. Agni is request/response only. Connect
+server-streaming RPC (`Watch`) is the idiomatic slot, with the Queue subscription as producer.
+
+## Layering
+
+`agent/web` is a new submodule (own go.mod) importing `agent/host`: the goapplib shell, the Connect
+bridge (Queue subscription → `Watch` stream; `Dispatch`/queries → unary; barrier → `RespondToAsk`),
+and the Solid/DockView frontend assets. A thin `cmd/agentweb serve` over it, mirroring how
+`cmd/agentchat` is thin over the host.
+
+## Open design decisions (resolve during E1/E3, not now)
+
+- **Frame envelope shape.** `HostEvent` and `CmdResult` are churning Go tagged unions. A full proto
+  `oneof` over a taxonomy that keeps gaining kinds is drift-prone. Lean toward an envelope with a
+  stable `kind` enum plus a structured payload where settled and a JSON/`Any` escape hatch for the long
+  tail. Decide against the actual `HostEvent` surface.
+- **Observer role (resolved in E1, see above).** The Queue is the one retained substrate; `emit`
+  appends to it and delivers synchronously to local observers (the terminal renderer writes a
+  caller-visible `io.Writer`, so async local delivery races callers). The async subscriber adapter for
+  a remote surface lands in E3, where the isolation is actually needed.
+- **Auth.** Local dev tool first. If the surface is ever exposed beyond localhost it needs auth; out of
+  scope for the first cut, note it.
+
+## Sub-tickets (dependency-ordered)
+
+### E1 (1194) — Session event log on `gocurrent.Queue` (`agent/host`) — SHIPPED
+Make a per-session `gocurrent.Queue[HostEvent]` the retained event substrate: `emit` appends every
+event to it *and* keeps delivering synchronously to the local observers (`emitMu` retained), so the
+terminal rendering contract is unchanged. The log is what a web surface (E3) subscribes onto (replay
+from offset 0 + live) and the barrier seam E2 builds on. Retention unbounded (Option A); a bounded
+gocurrent variant with deep replay from `RunStore` is a filed follow-up. The async subscriber adapter
+moved to E3 — see "Do we still need Observer?" for why async local delivery races the terminal contract.
+- Accept: a subscriber attached after events were emitted replays them from offset 0 and is notified of
+  live ones; `emit` still delivers to local observers synchronously and in order; `just test-agent`
+  green with `-race`; no TUI behavior change.
+
+### E2 (1195) — Pending-ask barrier (`agent/host`)
+Generalize the elicitation/approval ask path so an ask is `AppendBarrier`'d onto the session log and
+resolved by the first responder via `Resolve(offset, response)`, with the resolution committed so every
+subscriber can retract. The TUI `AskFunc`/`ElicitationCoordinator.Confirm` becomes a responder that
+races local input against the resolved-broadcast. Realizes the mediator idea from issue 1157.
+- Accept: two in-process responders on one ask, first wins, loser observes `ErrAlreadyResolved` and the
+  committed resolution; the coordinator stays the single serialization point.
+
+### E3 (1196) — `agent/web` submodule + Connect bridge
+New submodule + `cmd/agentweb serve`. Proto `HostService`: server-streaming `Watch` (drains the E1 log
+into Frame envelopes), unary `Submit` (turn), `Dispatch` (command → `CmdResult`), `RespondToAsk`
+(resolve the E2 barrier), and query methods mirroring the host data methods. goapplib serve of shell +
+`/static` + Connect handlers. Settle the Frame envelope shape here.
+- Accept: a raw Connect client can `Watch` a live session and `Submit` a turn; a TUI and a web client
+  attached to the same `App` both see the same stream simultaneously.
+
+### E4 (1197) — Frontend shell (DockView + Solid islands)
+Port Agni's dock shell: `dockview-core`, park-container adopt/dispose, saved-layout reconcile with the
+panel-id version marker, `tsappkit-solid` islands, Connect-Web clients from the E3 proto. First slice:
+one Conversation panel streaming the live turn + a prompt box that `Submit`s.
+- Accept: the browser renders live turns from the same `App` the TUI is on; closing and reopening the
+  Conversation panel preserves the island; layout persists across reload.
+
+### E5 (1198) — Observability panels
+The payoff. Each panel is a Solid island fed by a Frame projection, shipped incrementally:
+sub-agent tree (`SubAgentEvent` scope/depth), activity/event timeline, memory inspector (recall /
+injection / compaction events + `ListMemories` query), tool-call & offload-blob inspector
+(`read_tool_result`), budget/token gauges (tree budget + provider usage).
+- Accept: during a `kitchen-sink` run each panel reflects live agent state; adding a panel does not
+  re-crowd existing users' saved layouts (reconcile).
+
+### E6 (1199) — Multi-surface elicitation UX + symmetric submission
+Wire E2's barrier end to end across web (`RespondToAsk`) and TUI so a real elicitation/approval
+broadcasts to all surfaces, first answer wins, others dismiss with "answered by <surface>". Any surface
+can submit a turn (turnMu already serializes); everyone watches it stream.
+- Accept: a `kitchen-sink` approval-ladder prompt answered in the browser dismisses the TUI prompt and
+  vice versa; two near-simultaneous turn submissions serialize cleanly and both surfaces see both turns.
+
+## Suggested slice order
+
+E1 → E2 → E3 → E4 gets one end-to-end proof (TUI-and-browser-on-one-session, with real multi-surface
+asks). E5 is the incremental panel build-out on top. E6 is the multi-surface elicitation polish, which
+can land alongside E4/E5 once E2's barrier exists.


### PR DESCRIPTION
Closes #1194. First slice of the web-UI epic #1193.

## What changes

`agent/host` gains a per-session retained event log. `App.emit` now appends every `HostEvent` to a `gocurrent.Queue[HostEvent]` **in addition to** delivering it synchronously to the local observers. The log is the single source of truth a web surface will replay and subscribe onto (E3, #1196) and the barrier seam multi-surface asks build on (E2, #1195). No public API changes; the terminal/TUI behavior is unchanged.

## Reviewer's guide
Read in this order:
1. [docs/AGENT_WEB_UI_EPIC.md](https://github.com/panyam/mcpkit/pull/1201/files#diff-13fac47fac7d8263df64629292cc4cf90be42724ba059bbda3da255b0f2e0475) — start here for the epic and why the Queue is the backbone. The "Do we still need Observer?" section carries the one design decision this PR resolved.
2. [agent/host/app.go](https://github.com/panyam/mcpkit/pull/1201/files#diff-89fb8e04b6e1e9d5f7f76958490ef158dee40e2cae92d87c04b408d893c84361) — the `eventLog` field, its creation in `NewApp`, and the two-line change to `emit` (append + the existing synchronous fan-out).
3. [agent/host/eventlog_test.go](https://github.com/panyam/mcpkit/pull/1201/files#diff-14c5553ab0a00c8076ce3cc3c812e9d8d520bb1a5efb479d48d25b4f9f3905b9) — acceptance: late-subscriber replay off the log, and synchronous in-order local delivery.
4. [agent/host/hostevent.go](https://github.com/panyam/mcpkit/pull/1201/files#diff-19a6cb704e31f277e9bf65a111061678da30c84576e938e6ac2ef2f379e01095) — `Observer` doc updated to say it is the synchronous local view of the logged stream.

Skim or skip: the design doc's later sub-ticket sections (E2–E6) are forward-looking, not part of this diff.

## Decision log
- **Local observers stay synchronous; the async subscriber adapter moved to E3.** The plan was to reimplement `Observer` as an async Queue-drain adapter. Implementing it surfaced a real conflict: the built-in terminal renderer writes to a caller-visible `io.Writer`, and 7 existing `-race` tests (plus the plain REPL's own prompt ordering) read that buffer synchronously right after an emit. Async local delivery races them, and nothing needs the isolation yet — the only remote consumer, the web streamer, does not exist until E3. So E1 keeps `emit` synchronous for local observers (the Queue is the added retained substrate) and defers the async adapter to the surface that actually needs it. `emitMu` is retained for exactly this reason.
- **Retention unbounded (Option A).** The base `gocurrent.Queue` never evicts. Bounding interacts with deep-replay-from-`RunStore`, which is E3-shaped, so it is filed as a follow-up (#1200) rather than pulled into E1.

## Before / after (emit path)

```mermaid
sequenceDiagram
  participant C as emit caller
  participant A as App
  participant O as Local observers
  Note over C,O: Before
  C->>A: emit(ev)
  A->>A: emitMu.Lock
  A->>O: On(ev)  (synchronous)
  A->>A: emitMu.Unlock
```

```mermaid
sequenceDiagram
  participant C as emit caller
  participant A as App
  participant L as eventLog (gocurrent.Queue)
  participant O as Local observers
  participant W as Web subscriber (E3)
  Note over C,W: After
  C->>A: emit(ev)
  A->>L: Append(ev)  (retained, replayable)
  A->>A: emitMu.Lock
  A->>O: On(ev)  (synchronous, unchanged)
  A->>A: emitMu.Unlock
  W-->>L: ReadFrom(0) replay + Notify live  (E3, not in this diff)
```

## Risk / blast radius
- Affects: `agent/host` event delivery, which every host surface (terminal renderer, agentchat `tuiObserver`/`nbObserver`, tracers) sits behind. All reach `On` via `emit`, which is behavior-preserving here.
- Tests: `just test-agent` green with `-race` (agent, agent/host, cmd/agentchat, examples). New tests add 4 assertions; none removed or weakened.
- Be paranoid about: the added `eventLog.Append` runs on every emit under no extra lock (Append is concurrent-safe). Unbounded retention is the known, filed trade-off (#1200).

## Out of scope (deferred)
- Async subscriber adapter + web `Watch` stream → E3 (#1196).
- `AppendBarrier` pending-ask path → E2 (#1195).
- Bounded in-memory retention → #1200.

