### PR TITLE
feat(agent/host): multi-surface pending-ask barrier (E2, #1195)

### DIFF
--- a/agent/host/app.go
+++ b/agent/host/app.go
@@ -106,13 +106,6 @@ type App struct {
 	// variant is a follow-up before long multi-subscriber sessions are common.
 	eventLog *gocurrent.Queue[HostEvent]
 
-	// asks holds pending elicitations awaiting a response, so any surface can
-	// resolve one via RespondToAsk (the multi-surface ask barrier, issue 1195).
-	// askSeq mints ids. Guarded by asksMu.
-	asksMu sync.Mutex
-	asks   map[int64]*pendingAsk
-	askSeq int64
-
 	evCtx     context.Context // subscription lifetime ctx; the ready-observer subscribes late servers on it
 	eventStop context.CancelFunc
 
@@ -330,7 +323,7 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 
 	multi := agent.NewMultiSource()
 	app := &App{cfg: cfg, sources: multi, observers: observers, replOut: out, bgTasks: map[string]*client.BackgroundTask{}, subs: map[string]*subscription{}, store: o.store,
-		tp: o.tp, log: o.logger, skillBlocks: map[string]string{}, skillCatalog: map[string][]catalogSkill{}, oauthSources: map[string]loginSource{}, asks: map[int64]*pendingAsk{}}
+		tp: o.tp, log: o.logger, skillBlocks: map[string]string{}, skillCatalog: map[string][]catalogSkill{}, oauthSources: map[string]loginSource{}}
 	// Bring the retained event log up before anything can emit (the
 	// server-connect hooks below capture app and fire asynchronously).
 	app.eventLog = gocurrent.NewQueue[HostEvent]()
@@ -832,13 +825,14 @@ func (a *App) SwitchProvider(name string) error {
 // once emit returns). Serialized by emitMu: the async server connections (Group
 // observer), the turn goroutine, and event goroutines all emit, so the lock
 // keeps the not-inherently-concurrent terminal renderer from racing.
-func (a *App) emit(ev HostEvent) {
-	a.eventLog.Append(ev)
+func (a *App) emit(ev HostEvent) (offset int) {
+	offset = a.eventLog.Append(ev)
 	a.emitMu.Lock()
 	defer a.emitMu.Unlock()
 	for _, o := range a.observers {
 		o.On(ev)
 	}
+	return offset
 }
 
 // promptREPL draws the terminal REPL's input marker. The prompt is

--- a/agent/host/app.go
+++ b/agent/host/app.go
@@ -106,6 +106,13 @@ type App struct {
 	// variant is a follow-up before long multi-subscriber sessions are common.
 	eventLog *gocurrent.Queue[HostEvent]
 
+	// asks holds pending elicitations awaiting a response, so any surface can
+	// resolve one via RespondToAsk (the multi-surface ask barrier, issue 1195).
+	// askSeq mints ids. Guarded by asksMu.
+	asksMu sync.Mutex
+	asks   map[int64]*pendingAsk
+	askSeq int64
+
 	evCtx     context.Context // subscription lifetime ctx; the ready-observer subscribes late servers on it
 	eventStop context.CancelFunc
 
@@ -320,14 +327,16 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 	if elicUI == nil {
 		elicUI = terminalElicitationUI(bufio.NewReader(in), out)
 	}
-	coord := agent.NewElicitationCoordinator(elicUI)
 
 	multi := agent.NewMultiSource()
 	app := &App{cfg: cfg, sources: multi, observers: observers, replOut: out, bgTasks: map[string]*client.BackgroundTask{}, subs: map[string]*subscription{}, store: o.store,
-		tp: o.tp, log: o.logger, skillBlocks: map[string]string{}, skillCatalog: map[string][]catalogSkill{}, oauthSources: map[string]loginSource{}}
+		tp: o.tp, log: o.logger, skillBlocks: map[string]string{}, skillCatalog: map[string][]catalogSkill{}, oauthSources: map[string]loginSource{}, asks: map[int64]*pendingAsk{}}
 	// Bring the retained event log up before anything can emit (the
 	// server-connect hooks below capture app and fire asynchronously).
 	app.eventLog = gocurrent.NewQueue[HostEvent]()
+	// Elicitations broadcast to every surface via the event log and resolve on
+	// the first responder; the local UI is one responder (barrierElicit).
+	coord := agent.NewElicitationCoordinator(app.barrierElicit(elicUI))
 	for _, sc := range cfg.Servers {
 		app.serverOrder = append(app.serverOrder, sc.ID)
 	}

--- a/agent/host/ask.go
+++ b/agent/host/ask.go
@@ -2,113 +2,77 @@ package host
 
 import (
 	"context"
-	"fmt"
-	"sync"
 
 	"github.com/panyam/mcpkit/agent"
 	"github.com/panyam/mcpkit/core"
 )
 
 // elicitResolution is a pending ask's answer, delivered by whichever surface
-// responds first. err is the surface-presentation error (not a decline, which
-// is an ElicitationResult.Action); by names the resolving surface.
+// responds first (the barrier resolution value on the event log). err is a
+// surface-presentation failure (not a decline, which is an
+// ElicitationResult.Action); by names the resolving surface.
 type elicitResolution struct {
 	res core.ElicitationResult
 	err error
 	by  string
 }
 
-// pendingAsk is one outstanding elicitation awaiting a response. once makes the
-// first responder win: later Resolve calls are dropped.
-type pendingAsk struct {
-	ch   chan elicitResolution
-	once sync.Once
-}
-
-// registerAsk allocates an ask id and its one-shot resolution channel.
-func (a *App) registerAsk() (int64, *pendingAsk) {
-	a.asksMu.Lock()
-	defer a.asksMu.Unlock()
-	a.askSeq++
-	id := a.askSeq
-	p := &pendingAsk{ch: make(chan elicitResolution, 1)}
-	a.asks[id] = p
-	return id, p
-}
-
-func (a *App) clearAsk(id int64) {
-	a.asksMu.Lock()
-	delete(a.asks, id)
-	a.asksMu.Unlock()
-}
-
-func (a *App) lookupAsk(id int64) *pendingAsk {
-	a.asksMu.Lock()
-	defer a.asksMu.Unlock()
-	return a.asks[id]
-}
-
-// RespondToAsk resolves a pending elicitation (identified by the AskID a
-// surface read off the HostElicitRequest event) with a surface-supplied answer.
-// The first responder wins; a response to an unknown or already-answered ask
-// returns an error (app state, so a surface can report "already answered" or
-// "no such ask" rather than fail). This is the data-only capability a web
-// surface's respond RPC calls (issue 1196); the local terminal UI resolves the
-// same ask through the barrier below.
-func (a *App) RespondToAsk(id int64, res core.ElicitationResult, by string) error {
-	p := a.lookupAsk(id)
-	if p == nil {
-		return fmt.Errorf("host: no pending ask %d", id)
-	}
-	if !p.resolve(elicitResolution{res: res, by: by}) {
-		return fmt.Errorf("host: ask %d already answered", id)
-	}
-	return nil
-}
-
-// resolve delivers r to the ask exactly once; it reports whether this caller
-// was the winner.
-func (p *pendingAsk) resolve(r elicitResolution) bool {
-	won := false
-	p.once.Do(func() {
-		p.ch <- r
-		won = true
-	})
-	return won
+// RespondToAsk resolves a pending elicitation, identified by the event-log
+// offset the ask was announced at (a surface reads that offset from its Watch
+// frame). Resolution rides the log's barrier, so the first responder wins and a
+// stale or already-answered offset returns the log's ErrAlreadyResolved /
+// ErrOffsetOutOfRange. This is the data-only capability a web surface's respond
+// RPC calls (issue 1196); the local terminal UI resolves the same ask through
+// barrierElicit below.
+func (a *App) RespondToAsk(askOffset int, res core.ElicitationResult, by string) error {
+	return a.eventLog.Resolve(askOffset, elicitResolution{res: res, by: by})
 }
 
 // barrierElicit wraps a local ElicitationUI so an elicitation is broadcast to
-// every surface (HostElicitRequest) and resolved by the first responder. The
-// local UI runs as one responder, racing any surface that calls RespondToAsk;
-// whichever answers first wins and the other is cancelled. A HostElicitResolved
-// event then tells every surface to retract its prompt. With no other surface
-// attached the local UI always wins, so single-surface behavior is unchanged.
+// every surface (HostElicitRequest, at a known log offset) and resolved by the
+// first responder. The ask is a log entry; its resolution is the log's barrier
+// on that entry's offset. The local UI runs as one responder, racing any
+// surface that calls RespondToAsk on that offset; the log's Resolve makes the
+// first win and cancels the loser. A HostElicitResolved event then tells every
+// surface to retract. With no other surface attached the local UI always wins,
+// so single-surface behavior is unchanged.
 func (a *App) barrierElicit(local agent.ElicitationUI) agent.ElicitationUI {
 	return func(ctx context.Context, req core.ElicitationRequest) (core.ElicitationResult, error) {
-		id, p := a.registerAsk()
-		defer a.clearAsk(id)
-
 		reqCopy := req
-		a.emit(HostEvent{Kind: HostElicitRequest, AskID: id, Elicit: &reqCopy})
+		off := a.emit(HostEvent{Kind: HostElicitRequest, Elicit: &reqCopy})
 
-		// The local UI is one responder; cancel it when a remote surface wins.
+		// The local UI is one responder; cancel it when another surface wins.
 		localCtx, cancelLocal := context.WithCancel(ctx)
 		defer cancelLocal()
 		go func() {
 			res, err := local(localCtx, req)
-			if localCtx.Err() != nil {
-				return // cancelled because a remote surface already won
+			if localCtx.Err() == nil {
+				a.eventLog.Resolve(off, elicitResolution{res: res, err: err, by: "local"})
 			}
-			p.resolve(elicitResolution{res: res, err: err, by: "local"})
 		}()
 
+		// AwaitResolution has no ctx, so run it on a goroutine and abort a
+		// cancelled turn by resolving the ask ourselves (the goroutine then
+		// unblocks and exits; the buffered channel means it never leaks).
+		resolved := make(chan elicitResolution, 1)
+		go func() { resolved <- a.eventLog.AwaitResolution(off).(elicitResolution) }()
+
 		select {
-		case r := <-p.ch:
+		case r := <-resolved:
 			cancelLocal()
-			a.emit(HostEvent{Kind: HostElicitResolved, AskID: id, By: r.by})
+			if r.by == askCancelled {
+				return core.ElicitationResult{}, r.err
+			}
+			a.emit(HostEvent{Kind: HostElicitResolved, AskID: int64(off), By: r.by})
 			return r.res, r.err
 		case <-ctx.Done():
+			a.eventLog.Resolve(off, elicitResolution{err: ctx.Err(), by: askCancelled})
 			return core.ElicitationResult{}, ctx.Err()
 		}
 	}
 }
+
+// askCancelled is the resolver tag for a turn cancelled before any surface
+// answered; it unblocks the AwaitResolution goroutine without emitting a
+// HostElicitResolved (nothing was answered).
+const askCancelled = "cancelled"

--- a/agent/host/ask.go
+++ b/agent/host/ask.go
@@ -1,0 +1,114 @@
+package host
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/panyam/mcpkit/agent"
+	"github.com/panyam/mcpkit/core"
+)
+
+// elicitResolution is a pending ask's answer, delivered by whichever surface
+// responds first. err is the surface-presentation error (not a decline, which
+// is an ElicitationResult.Action); by names the resolving surface.
+type elicitResolution struct {
+	res core.ElicitationResult
+	err error
+	by  string
+}
+
+// pendingAsk is one outstanding elicitation awaiting a response. once makes the
+// first responder win: later Resolve calls are dropped.
+type pendingAsk struct {
+	ch   chan elicitResolution
+	once sync.Once
+}
+
+// registerAsk allocates an ask id and its one-shot resolution channel.
+func (a *App) registerAsk() (int64, *pendingAsk) {
+	a.asksMu.Lock()
+	defer a.asksMu.Unlock()
+	a.askSeq++
+	id := a.askSeq
+	p := &pendingAsk{ch: make(chan elicitResolution, 1)}
+	a.asks[id] = p
+	return id, p
+}
+
+func (a *App) clearAsk(id int64) {
+	a.asksMu.Lock()
+	delete(a.asks, id)
+	a.asksMu.Unlock()
+}
+
+func (a *App) lookupAsk(id int64) *pendingAsk {
+	a.asksMu.Lock()
+	defer a.asksMu.Unlock()
+	return a.asks[id]
+}
+
+// RespondToAsk resolves a pending elicitation (identified by the AskID a
+// surface read off the HostElicitRequest event) with a surface-supplied answer.
+// The first responder wins; a response to an unknown or already-answered ask
+// returns an error (app state, so a surface can report "already answered" or
+// "no such ask" rather than fail). This is the data-only capability a web
+// surface's respond RPC calls (issue 1196); the local terminal UI resolves the
+// same ask through the barrier below.
+func (a *App) RespondToAsk(id int64, res core.ElicitationResult, by string) error {
+	p := a.lookupAsk(id)
+	if p == nil {
+		return fmt.Errorf("host: no pending ask %d", id)
+	}
+	if !p.resolve(elicitResolution{res: res, by: by}) {
+		return fmt.Errorf("host: ask %d already answered", id)
+	}
+	return nil
+}
+
+// resolve delivers r to the ask exactly once; it reports whether this caller
+// was the winner.
+func (p *pendingAsk) resolve(r elicitResolution) bool {
+	won := false
+	p.once.Do(func() {
+		p.ch <- r
+		won = true
+	})
+	return won
+}
+
+// barrierElicit wraps a local ElicitationUI so an elicitation is broadcast to
+// every surface (HostElicitRequest) and resolved by the first responder. The
+// local UI runs as one responder, racing any surface that calls RespondToAsk;
+// whichever answers first wins and the other is cancelled. A HostElicitResolved
+// event then tells every surface to retract its prompt. With no other surface
+// attached the local UI always wins, so single-surface behavior is unchanged.
+func (a *App) barrierElicit(local agent.ElicitationUI) agent.ElicitationUI {
+	return func(ctx context.Context, req core.ElicitationRequest) (core.ElicitationResult, error) {
+		id, p := a.registerAsk()
+		defer a.clearAsk(id)
+
+		reqCopy := req
+		a.emit(HostEvent{Kind: HostElicitRequest, AskID: id, Elicit: &reqCopy})
+
+		// The local UI is one responder; cancel it when a remote surface wins.
+		localCtx, cancelLocal := context.WithCancel(ctx)
+		defer cancelLocal()
+		go func() {
+			res, err := local(localCtx, req)
+			if localCtx.Err() != nil {
+				return // cancelled because a remote surface already won
+			}
+			p.resolve(elicitResolution{res: res, err: err, by: "local"})
+		}()
+
+		select {
+		case r := <-p.ch:
+			cancelLocal()
+			a.emit(HostEvent{Kind: HostElicitResolved, AskID: id, By: r.by})
+			return r.res, r.err
+		case <-ctx.Done():
+			return core.ElicitationResult{}, ctx.Err()
+		}
+	}
+}

--- a/agent/host/ask_test.go
+++ b/agent/host/ask_test.go
@@ -10,43 +10,37 @@ import (
 )
 
 func newAskApp() *App {
-	rec := &recordObserver{}
 	return &App{
 		eventLog:  gocurrent.NewQueue[HostEvent](),
-		asks:      map[int64]*pendingAsk{},
-		observers: []Observer{rec},
+		observers: []Observer{&recordObserver{}},
 	}
 }
 
 func askRecorder(a *App) *recordObserver { return a.observers[0].(*recordObserver) }
 
-// waitAskID returns the AskID of the pending HostElicitRequest, waiting for the
-// barrier to emit it (barrierElicit runs the awaiting select on the caller's
-// goroutine, so a concurrent responder needs the id first).
-func waitAskID(t *testing.T, rec *recordObserver) int64 {
+// waitAskOffset returns the log offset of the pending HostElicitRequest — the
+// ask id a surface reads from its stream position and passes to RespondToAsk.
+func waitAskOffset(t *testing.T, a *App) int {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		rec.mu.Lock()
-		for _, e := range rec.evs {
-			if e.Kind == HostElicitRequest {
-				id := e.AskID
-				rec.mu.Unlock()
-				return id
+		evs, _ := a.eventLog.ReadFrom(0)
+		for i := range evs {
+			if evs[i].Kind == HostElicitRequest {
+				return i
 			}
 		}
-		rec.mu.Unlock()
 		time.Sleep(time.Millisecond)
 	}
 	t.Fatal("no HostElicitRequest was emitted")
 	return 0
 }
 
-func resolvedBy(rec *recordObserver, id int64) (string, bool) {
+func resolvedBy(rec *recordObserver, off int) (string, bool) {
 	rec.mu.Lock()
 	defer rec.mu.Unlock()
 	for _, e := range rec.evs {
-		if e.Kind == HostElicitResolved && e.AskID == id {
+		if e.Kind == HostElicitResolved && e.AskID == int64(off) {
 			return e.By, true
 		}
 	}
@@ -54,9 +48,9 @@ func resolvedBy(rec *recordObserver, id int64) (string, bool) {
 }
 
 // TestAsk_RemoteResponderWinsFirst is the E2 acceptance: with the local UI
-// still waiting, another surface answers via RespondToAsk, its answer is
-// returned, the local responder is cancelled, and a resolved event names the
-// winning surface so other surfaces retract.
+// still waiting, another surface answers via RespondToAsk on the ask's log
+// offset; its answer is returned, the local responder is cancelled, and a
+// resolved event names the winning surface so others retract.
 func TestAsk_RemoteResponderWinsFirst(t *testing.T) {
 	a := newAskApp()
 	rec := askRecorder(a)
@@ -79,9 +73,9 @@ func TestAsk_RemoteResponderWinsFirst(t *testing.T) {
 		done <- out{res, err}
 	}()
 
-	id := waitAskID(t, rec)
+	off := waitAskOffset(t, a)
 	remote := core.ElicitationResult{Action: "accept", Content: map[string]any{"confirm": true}}
-	if err := a.RespondToAsk(id, remote, "web"); err != nil {
+	if err := a.RespondToAsk(off, remote, "web"); err != nil {
 		t.Fatalf("RespondToAsk: %v", err)
 	}
 
@@ -97,7 +91,7 @@ func TestAsk_RemoteResponderWinsFirst(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("local responder was not cancelled after remote won")
 	}
-	if by, ok := resolvedBy(rec, id); !ok || by != "web" {
+	if by, ok := resolvedBy(rec, off); !ok || by != "web" {
 		t.Fatalf("resolved event = (%q, %v), want (web, true)", by, ok)
 	}
 }
@@ -119,26 +113,27 @@ func TestAsk_LocalResponderWins(t *testing.T) {
 	if res.Action != "accept" {
 		t.Fatalf("local answer not returned: %+v", res)
 	}
-	id := waitAskID(t, rec)
-	if by, ok := resolvedBy(rec, id); !ok || by != "local" {
+	off := waitAskOffset(t, a)
+	if by, ok := resolvedBy(rec, off); !ok || by != "local" {
 		t.Fatalf("resolved event = (%q, %v), want (local, true)", by, ok)
 	}
 }
 
 // TestRespondToAsk_Errors pins the app-state errors a surface reports rather
-// than fails on: an unknown ask and an already-answered ask.
+// than fails on, carried straight from the log's barrier: an out-of-range
+// offset and an already-answered ask.
 func TestRespondToAsk_Errors(t *testing.T) {
 	a := newAskApp()
 
-	if err := a.RespondToAsk(999, core.ElicitationResult{}, "web"); err == nil {
-		t.Fatal("expected an error responding to an unknown ask")
+	if err := a.RespondToAsk(999999, core.ElicitationResult{}, "web"); err == nil {
+		t.Fatal("expected an error responding to an out-of-range offset")
 	}
 
-	id, p := a.registerAsk()
-	if !p.resolve(elicitResolution{by: "first"}) {
-		t.Fatal("first resolve should win")
+	off := a.eventLog.Append(HostEvent{Kind: HostElicitRequest})
+	if err := a.RespondToAsk(off, core.ElicitationResult{}, "first"); err != nil {
+		t.Fatalf("first response should win: %v", err)
 	}
-	if err := a.RespondToAsk(id, core.ElicitationResult{}, "second"); err == nil {
+	if err := a.RespondToAsk(off, core.ElicitationResult{}, "second"); err == nil {
 		t.Fatal("expected an already-answered error")
 	}
 }

--- a/agent/host/ask_test.go
+++ b/agent/host/ask_test.go
@@ -1,0 +1,144 @@
+package host
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	gocurrent "github.com/panyam/gocurrent"
+	"github.com/panyam/mcpkit/core"
+)
+
+func newAskApp() *App {
+	rec := &recordObserver{}
+	return &App{
+		eventLog:  gocurrent.NewQueue[HostEvent](),
+		asks:      map[int64]*pendingAsk{},
+		observers: []Observer{rec},
+	}
+}
+
+func askRecorder(a *App) *recordObserver { return a.observers[0].(*recordObserver) }
+
+// waitAskID returns the AskID of the pending HostElicitRequest, waiting for the
+// barrier to emit it (barrierElicit runs the awaiting select on the caller's
+// goroutine, so a concurrent responder needs the id first).
+func waitAskID(t *testing.T, rec *recordObserver) int64 {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		rec.mu.Lock()
+		for _, e := range rec.evs {
+			if e.Kind == HostElicitRequest {
+				id := e.AskID
+				rec.mu.Unlock()
+				return id
+			}
+		}
+		rec.mu.Unlock()
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("no HostElicitRequest was emitted")
+	return 0
+}
+
+func resolvedBy(rec *recordObserver, id int64) (string, bool) {
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	for _, e := range rec.evs {
+		if e.Kind == HostElicitResolved && e.AskID == id {
+			return e.By, true
+		}
+	}
+	return "", false
+}
+
+// TestAsk_RemoteResponderWinsFirst is the E2 acceptance: with the local UI
+// still waiting, another surface answers via RespondToAsk, its answer is
+// returned, the local responder is cancelled, and a resolved event names the
+// winning surface so other surfaces retract.
+func TestAsk_RemoteResponderWinsFirst(t *testing.T) {
+	a := newAskApp()
+	rec := askRecorder(a)
+
+	localCancelled := make(chan struct{})
+	local := func(ctx context.Context, _ core.ElicitationRequest) (core.ElicitationResult, error) {
+		<-ctx.Done() // never answers on its own; waits to be cancelled
+		close(localCancelled)
+		return core.ElicitationResult{}, ctx.Err()
+	}
+	ui := a.barrierElicit(local)
+
+	type out struct {
+		res core.ElicitationResult
+		err error
+	}
+	done := make(chan out, 1)
+	go func() {
+		res, err := ui(context.Background(), core.ElicitationRequest{Message: "approve?"})
+		done <- out{res, err}
+	}()
+
+	id := waitAskID(t, rec)
+	remote := core.ElicitationResult{Action: "accept", Content: map[string]any{"confirm": true}}
+	if err := a.RespondToAsk(id, remote, "web"); err != nil {
+		t.Fatalf("RespondToAsk: %v", err)
+	}
+
+	got := <-done
+	if got.err != nil {
+		t.Fatalf("unexpected error: %v", got.err)
+	}
+	if got.res.Action != "accept" {
+		t.Fatalf("remote answer not returned: %+v", got.res)
+	}
+	select {
+	case <-localCancelled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("local responder was not cancelled after remote won")
+	}
+	if by, ok := resolvedBy(rec, id); !ok || by != "web" {
+		t.Fatalf("resolved event = (%q, %v), want (web, true)", by, ok)
+	}
+}
+
+// TestAsk_LocalResponderWins pins the single-surface path is unchanged: with no
+// other surface attached the local UI answers and its result is returned.
+func TestAsk_LocalResponderWins(t *testing.T) {
+	a := newAskApp()
+	rec := askRecorder(a)
+
+	want := core.ElicitationResult{Action: "accept", Content: map[string]any{"confirm": true}}
+	local := func(context.Context, core.ElicitationRequest) (core.ElicitationResult, error) {
+		return want, nil
+	}
+	res, err := a.barrierElicit(local)(context.Background(), core.ElicitationRequest{Message: "approve?"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Action != "accept" {
+		t.Fatalf("local answer not returned: %+v", res)
+	}
+	id := waitAskID(t, rec)
+	if by, ok := resolvedBy(rec, id); !ok || by != "local" {
+		t.Fatalf("resolved event = (%q, %v), want (local, true)", by, ok)
+	}
+}
+
+// TestRespondToAsk_Errors pins the app-state errors a surface reports rather
+// than fails on: an unknown ask and an already-answered ask.
+func TestRespondToAsk_Errors(t *testing.T) {
+	a := newAskApp()
+
+	if err := a.RespondToAsk(999, core.ElicitationResult{}, "web"); err == nil {
+		t.Fatal("expected an error responding to an unknown ask")
+	}
+
+	id, p := a.registerAsk()
+	if !p.resolve(elicitResolution{by: "first"}) {
+		t.Fatal("first resolve should win")
+	}
+	if err := a.RespondToAsk(id, core.ElicitationResult{}, "second"); err == nil {
+		t.Fatal("expected an already-answered error")
+	}
+}

--- a/agent/host/hostevent.go
+++ b/agent/host/hostevent.go
@@ -59,6 +59,14 @@ const (
 	// (From, To) — Config.Team only. The active agent changes, so a surface
 	// renders "→ handed off to <To>" and can update which agent is answering.
 	HostHandoff HostEventKind = "handoff"
+	// HostElicitRequest announces a pending elicitation/approval ask to every
+	// surface (AskID, Elicit). Unlike the fire-and-forget kinds this one is
+	// answerable: any surface reads it and calls RespondToAsk(AskID, ...); the
+	// first responder wins. The local terminal UI is one such responder.
+	HostElicitRequest HostEventKind = "elicit-request"
+	// HostElicitResolved reports that a pending ask (AskID) was answered, by
+	// which surface (By), so every other surface retracts its prompt.
+	HostElicitResolved HostEventKind = "elicit-resolved"
 )
 
 // HostEvent is one domain event the host announces: a thing that
@@ -108,6 +116,13 @@ type HostEvent struct {
 	// new active agent).
 	From string
 	To   string
+
+	// AskID identifies a pending ask on HostElicitRequest / HostElicitResolved;
+	// a surface passes it back to RespondToAsk. Elicit carries the request on
+	// HostElicitRequest; By names the resolving surface on HostElicitResolved.
+	AskID  int64
+	Elicit *core.ElicitationRequest
+	By     string
 }
 
 // Observer receives the host's HostEvent stream and does whatever it

--- a/agent/host/skills.go
+++ b/agent/host/skills.go
@@ -247,7 +247,7 @@ func (a *App) onServerSkills(sc ServerConfig, c *client.Client) {
 	if c == nil || (sc.Skills != nil && !*sc.Skills) {
 		return
 	}
-	block, cat, err := loadSkillsForServer(c, sc.ID, sc.SkillsMode, sc.SkillsAllow, a.emit, a.tp)
+	block, cat, err := loadSkillsForServer(c, sc.ID, sc.SkillsMode, sc.SkillsAllow, func(ev HostEvent) { a.emit(ev) }, a.tp)
 	if err != nil {
 		a.emit(HostEvent{Kind: HostSessionWarn, Err: fmt.Sprintf("load skills for %s: %v", sc.ID, err)})
 		return

--- a/docs/AGENT_WEB_UI_EPIC.md
+++ b/docs/AGENT_WEB_UI_EPIC.md
@@ -126,20 +126,22 @@ moved to E3 — see "Do we still need Observer?" for why async local delivery ra
   green with `-race`; no TUI behavior change.
 
 ### E2 (1195) — Pending-ask barrier (`agent/host`) — SHIPPED
-`barrierElicit` (`agent/host/ask.go`) wraps the local `ElicitationUI` the coordinator drives: it mints
-an `AskID`, emits a `HostElicitRequest{AskID, Elicit}` to every surface, runs the local UI as one
-responder, and races it against `RespondToAsk(AskID, result, by)` from any other surface. The first
-responder wins (a one-shot `sync.Once` per ask); the loser is cancelled; a `HostElicitResolved{AskID,
-By}` then tells every surface to retract. With no other surface attached the local UI always wins, so
-single-surface behavior is unchanged.
+`barrierElicit` (`agent/host/ask.go`) wraps the local `ElicitationUI` the coordinator drives: it emits a
+`HostElicitRequest{Elicit}` (appended to the log at offset `off`), runs the local UI as one responder,
+and races it against `RespondToAsk(off, result, by)` from any other surface. **Resolution rides the
+event log's own barrier**: local and remote responders both call `eventLog.Resolve(off, ...)`, so the
+first writer wins and `RespondToAsk` gets `ErrAlreadyResolved` / `ErrOffsetOutOfRange` for free; the
+loser's context is cancelled; a `HostElicitResolved{AskID: off, By}` tells every surface to retract.
+With no other surface attached the local UI always wins, so single-surface behavior is unchanged.
 
-**Design note**: this uses a host-owned pending-ask registry keyed by a minted `AskID`, **not**
-`gocurrent`'s offset-keyed `AppendBarrier`/`Resolve`. The reason is the id has to travel *in* the
-broadcast `HostElicitRequest` event so a surface knows what to answer, but a log offset is only known
-after `Append` returns (chicken-and-egg). The registry mints the id up front; the log still carries the
-request/resolved events for rendering and replay.
+**Design note**: the ask is identified by its **log offset** (the position a surface reads from its
+`Watch` frame), not a minted id, so it needs no id field in the request event. This is simpler than a
+separate pending-ask registry and reuses the log's tested first-writer-wins barrier; a late-joining
+surface can even call `eventLog.Resolution(off)` to see an ask was already answered. Two small costs:
+`AwaitResolution` is not ctx-cancellable, so a cancelled turn resolves the ask itself to unblock the
+awaiter; and `emit` now returns the append offset.
 - Accept: two responders on one ask, first wins, loser cancelled, resolved event names the winner;
-  unknown / already-answered `RespondToAsk` returns an app-state error; `just test-agent` green with
+  out-of-range / already-answered `RespondToAsk` returns the log's error; `just test-agent` green with
   `-race`.
 
 ### E3 (1196) — `agent/web` submodule + Connect bridge

--- a/docs/AGENT_WEB_UI_EPIC.md
+++ b/docs/AGENT_WEB_UI_EPIC.md
@@ -125,28 +125,45 @@ moved to E3 — see "Do we still need Observer?" for why async local delivery ra
   live ones; `emit` still delivers to local observers synchronously and in order; `just test-agent`
   green with `-race`; no TUI behavior change.
 
-### E2 (1195) — Pending-ask barrier (`agent/host`)
-Generalize the elicitation/approval ask path so an ask is `AppendBarrier`'d onto the session log and
-resolved by the first responder via `Resolve(offset, response)`, with the resolution committed so every
-subscriber can retract. The TUI `AskFunc`/`ElicitationCoordinator.Confirm` becomes a responder that
-races local input against the resolved-broadcast. Realizes the mediator idea from issue 1157.
-- Accept: two in-process responders on one ask, first wins, loser observes `ErrAlreadyResolved` and the
-  committed resolution; the coordinator stays the single serialization point.
+### E2 (1195) — Pending-ask barrier (`agent/host`) — SHIPPED
+`barrierElicit` (`agent/host/ask.go`) wraps the local `ElicitationUI` the coordinator drives: it mints
+an `AskID`, emits a `HostElicitRequest{AskID, Elicit}` to every surface, runs the local UI as one
+responder, and races it against `RespondToAsk(AskID, result, by)` from any other surface. The first
+responder wins (a one-shot `sync.Once` per ask); the loser is cancelled; a `HostElicitResolved{AskID,
+By}` then tells every surface to retract. With no other surface attached the local UI always wins, so
+single-surface behavior is unchanged.
+
+**Design note**: this uses a host-owned pending-ask registry keyed by a minted `AskID`, **not**
+`gocurrent`'s offset-keyed `AppendBarrier`/`Resolve`. The reason is the id has to travel *in* the
+broadcast `HostElicitRequest` event so a surface knows what to answer, but a log offset is only known
+after `Append` returns (chicken-and-egg). The registry mints the id up front; the log still carries the
+request/resolved events for rendering and replay.
+- Accept: two responders on one ask, first wins, loser cancelled, resolved event names the winner;
+  unknown / already-answered `RespondToAsk` returns an app-state error; `just test-agent` green with
+  `-race`.
 
 ### E3 (1196) — `agent/web` submodule + Connect bridge
-New submodule + `cmd/agentweb serve`. Proto `HostService`: server-streaming `Watch` (drains the E1 log
-into Frame envelopes), unary `Submit` (turn), `Dispatch` (command → `CmdResult`), `RespondToAsk`
-(resolve the E2 barrier), and query methods mirroring the host data methods. goapplib serve of shell +
-`/static` + Connect handlers. Settle the Frame envelope shape here.
-- Accept: a raw Connect client can `Watch` a live session and `Submit` a turn; a TUI and a web client
-  attached to the same `App` both see the same stream simultaneously.
+New submodule + `cmd/agentweb serve`. **Transport: Connect + buf + `@panyam/massrelay` for the live
+stream** — the stack the user's own web apps use (`~/projects/diffpp/main/web`, `~/work/hw/Agni`), and
+mcpkit already pulls in `servicekit` + `templar` (goapplib serving) so only `connectrpc`/`buf` are new.
+Proto `HostService`: a streaming `Watch` (drains the E1 log via massrelay), unary `Submit` (turn),
+`Dispatch` (command → `CmdResult`), `RespondToAsk` (the E2 registry), and query methods mirroring the
+host data methods. goapplib/`servicekit` serve of shell + `/static` + Connect handlers.
+- **Frame envelope, reconciled with A2**: the wire frame is a thin proto `{kind, payload bytes}` where
+  `payload` is the event's own A2 JSON — a 1:1 projection, no per-kind proto schema to drift (A2 forbids
+  a translation layer). `HostEvent`'s remaining live-pointer fields (`TaskStatus`, `Task`, failover)
+  need serializable snapshots first — that is the already-filed issue 994, a dependency of `Watch`.
+- Accept: a Connect client can `Watch` a live session and `Submit` a turn; a TUI and a web client on the
+  same `App` see the same stream simultaneously.
 
 ### E4 (1197) — Frontend shell (DockView + Solid islands)
-Port Agni's dock shell: `dockview-core`, park-container adopt/dispose, saved-layout reconcile with the
-panel-id version marker, `tsappkit-solid` islands, Connect-Web clients from the E3 proto. First slice:
-one Conversation panel streaming the live turn + a prompt box that `Submit`s.
-- Accept: the browser renders live turns from the same `App` the TUI is on; closing and reopening the
-  Conversation panel preserves the island; layout persists across reload.
+Model on **`~/projects/diffpp/main/web`** (preferred over Agni): `dockview-core` v4, `tsappkit-solid`
+islands, `@panyam/massrelay` + Connect-Web clients from the E3 proto, and **`MobileOverlays` for the
+mobile mode** (the dockview-vs-mobile mode switch the user wants). Saved-layout reconcile carries over.
+First slice: one Conversation panel streaming the live turn + a prompt box that `Submit`s, in both the
+dockview desktop mode and the mobile-overlay mode.
+- Accept: the browser renders live turns from the same `App` the TUI is on; the layout persists across
+  reload; the mobile mode presents the same panel as an overlay.
 
 ### E5 (1198) — Observability panels
 The payoff. Each panel is a Solid island fed by a Frame projection, shipped incrementally:


### PR DESCRIPTION
Closes #1195. Part of epic 1193. The E1 work this builds on (#1201) is now merged to main, so this targets main directly and runs CI. Supersedes #1202, which auto-closed when E1's branch was deleted on merge.

## What changes

Elicitation and approval asks become **multi-surface**: broadcast to every surface, resolved by the first responder. Today only the local terminal answers, so behavior is unchanged; the seam is what a web surface (E3, #1196) plugs into.

`barrierElicit` wraps the local `ElicitationUI` the `ElicitationCoordinator` already drives. Per ask it emits `HostElicitRequest{Elicit}` (appended to the event log at offset `off`), runs the local UI as one responder, and races it against `RespondToAsk(off, result, by)` from any other surface. **Resolution rides the event log's own barrier** — both responders call `eventLog.Resolve(off, ...)`, so the first writer wins; the loser's context is cancelled; `HostElicitResolved{AskID: off, By}` tells every other surface to retract.

## Reviewer's guide
Read in this order:
1. [agent/host/ask.go](https://github.com/panyam/mcpkit/pull/1205/files#diff-869d7583d9dfd3d2fdccf31a57a65421d31073ce2a9d40da2e68222c72e14d6b) — the whole mechanism: the pending-ask registry, `barrierElicit` (the race), and `RespondToAsk`.
2. [agent/host/app.go](https://github.com/panyam/mcpkit/pull/1205/files#diff-89fb8e04b6e1e9d5f7f76958490ef158dee40e2cae92d87c04b408d893c84361) — one wiring change: the coordinator is now built over `app.barrierElicit(elicUI)`; plus the `asks` registry fields.
3. [agent/host/hostevent.go](https://github.com/panyam/mcpkit/pull/1205/files#diff-19a6cb704e31f277e9bf65a111061678da30c84576e938e6ac2ef2f379e01095) — the two new event kinds and the `AskID`/`Elicit`/`By` fields.
4. [agent/host/ask_test.go](https://github.com/panyam/mcpkit/pull/1205/files#diff-4c83a9843f8a4615a7b892a08110dc1e6af4fd1c565d865d9abcb42167919c0b) — acceptance: remote-wins-with-retraction, local-wins, and the error paths.

## How it works (the race)
```
barrierElicit(local)(ctx, req):
  off := emit(HostElicitRequest{req})   # appended at log offset `off`; every surface sees it
  go { res := local(localCtx, req); if !cancelled: eventLog.Resolve(off, local answer) }
  go { resolved <- eventLog.AwaitResolution(off) }    # blocks until the first Resolve
  select {
    r := <-resolved:                    # first responder (local OR RespondToAsk(off)) wins
        cancelLocal()                   # stop the losing local UI
        emit(HostElicitResolved{off, by=r.by})   # others retract
        return r.res
    ctx.Done():                         # cancelled turn: resolve it ourselves to unblock, then bail
        eventLog.Resolve(off, cancelled); return ctx.Err()
  }
RespondToAsk(off, res, by): eventLog.Resolve(off, ...)   # ErrAlreadyResolved / ErrOffsetOutOfRange for free
```

## Decision log
- **Resolution rides the event log's barrier, not a separate registry.** The ask is identified by its log offset (the position a surface reads from its Watch frame), so `RespondToAsk(off, ...)` is just `eventLog.Resolve(off, ...)`: first-writer-wins, and `ErrAlreadyResolved` / `ErrOffsetOutOfRange` come for free with no parallel ask map or mutex. Two costs: `AwaitResolution` is not ctx-cancellable (a cancelled turn resolves the ask itself to unblock the awaiter), and `emit` now returns the append offset. (Reverses an earlier draft that used a minted-id registry.)
- **`barrierElicit` always wraps, even with one surface.** The local UI is just the first (only) responder, so it always wins and the terminal flow is byte-for-byte the same answer. No conditional path to drift.

## Before / after
```mermaid
sequenceDiagram
  participant Co as Coordinator
  participant U as Local UI
  Note over Co,U: Before
  Co->>U: ui(ctx, req)  (1:1, blocks)
  U-->>Co: result
```
```mermaid
sequenceDiagram
  participant Co as Coordinator
  participant B as barrierElicit
  participant S as All surfaces
  participant U as Local UI
  participant R as RespondToAsk (web, E3)
  Note over Co,R: After
  Co->>B: ui(ctx, req)
  B->>S: emit HostElicitRequest{AskID}
  B->>U: local(localCtx, req)
  U-->>B: answer  (racing)
  R-->>B: answer  (racing)
  B->>S: emit HostElicitResolved{AskID, By}  (retract)
  B-->>Co: first answer
```

## Risk / blast radius
- Affects: every elicitation and approval prompt (all route through the coordinator, now via `barrierElicit`). `just test-agent` green with `-race`, including the existing approval/elicitation tests.
- Be paranoid about: the local goroutine when a remote wins — its `localCtx` is cancelled, but a real terminal blocked in a stdin read won't unblock until the user types (then it sees `ctx.Err()` and drops its answer). A UX refinement for E3/E4, noted; harmless (the answer is dropped by the one-shot).

## Out of scope (deferred)
- The wire `RespondToAsk` RPC + `Watch` stream that lets a browser be the remote responder → E3 (#1196).
- Cancelling a real terminal prompt when a remote surface wins → E3/E4 UX.

