### PR TITLE
chore: tidy-all worktree guard + document the ask-barrier invariant

### DIFF
--- a/docs/AGENT_WEB_UI_EPIC.md
+++ b/docs/AGENT_WEB_UI_EPIC.md
@@ -168,6 +168,19 @@ separate pending-ask registry and reuses the log's tested first-writer-wins barr
 surface can even call `eventLog.Resolution(off)` to see an ask was already answered. Two small costs:
 `AwaitResolution` is not ctx-cancellable, so a cancelled turn resolves the ask itself to unblock the
 awaiter; and `emit` now returns the append offset.
+
+**Invariant — at most one pending input at a time.** The barrier per offset can in principle handle N
+concurrent pending asks, but there is never more than one: the `ElicitationCoordinator` FIFO-serializes
+*every* ask (elicitations and approvals alike) onto one UI via a single baton, and `barrierElicit` runs
+*inside* that baton, so a second ask (even from a parallel tool call in the same turn) blocks in the
+coordinator and its `HostElicitRequest` is never even emitted until the first resolves. The log is
+therefore always `… req_A … resolved_A … req_B …`, never two live asks. So the consumer side never has
+a queue of pending inputs to reconcile, and the FIFO stream stays non-blocking for consumers (they
+render the ask and keep draining; only the producer's tool call blocks). The one scenario that would
+create concurrent inputs is multi-user / multi-surface routing (different asks to different users, the
+issue-1157 mediator's territory) — and the per-offset barrier already scales to that with zero change,
+so keying resolution on the log offset is both simpler now and the right bet later. The load-bearing
+fact is the coordinator invariant; the barrier does not depend on it.
 - Accept: two responders on one ask, first wins, loser cancelled, resolved event names the winner;
   out-of-range / already-answered `RespondToAsk` returns the log's error; `just test-agent` green with
   `-race`.

--- a/justfile
+++ b/justfile
@@ -16,7 +16,7 @@ REPORT_DIR := "tests/reports"
 # Discovers every sub-module go.mod (root excluded). Kept as a command string
 # (not a backtick expression) so `find` only runs when a consuming recipe
 # executes, not on every just invocation. Consumers: tidy-all, bump-root.
-SUB_MODS_FIND := "find . -name go.mod -not -path '*/node_modules/*' -not -path './go.mod' | sed 's|^\\./||;s|/go.mod$||' | sort"
+SUB_MODS_FIND := "find . -name go.mod -not -path '*/node_modules/*' -not -path '*/.claude/*' -not -path './go.mod' | sed 's|^\\./||;s|/go.mod$||' | sort"
 
 # Keycloak (for interop tests)
 KC_IMAGE := "quay.io/keycloak/keycloak:26.0"


### PR DESCRIPTION
Two small cleanups from the web-UI epic (1193).

## What changes
- **tidy-all guard:** `SUB_MODS_FIND` now excludes `*/.claude/*`, so `just tidy-all` stops scanning stale agent worktrees. Those duplicate go.mods, at extra nesting depth, made the `examples/host` demokit replace `../../../../demokit` resolve to a nonexistent path — a phantom failure with no relation to the real module (which builds fine).
- **doc:** the E2 section of `AGENT_WEB_UI_EPIC.md` now records the load-bearing invariant that the `ElicitationCoordinator` serializes every ask to at most one pending input, so the per-offset barrier never reconciles a queue of inputs, and the FIFO stream stays non-blocking for consumers. It also notes the barrier scales to N (multi-user, issue 1157) without change.

No code behavior change.