### PR TITLE
feat(agent/web): multi-session routing via session_id

### DIFF
--- a/agent/web/README.md
+++ b/agent/web/README.md
@@ -20,8 +20,34 @@ Proto `mcpkit.agentweb.v1.HostService` (`protos/`, generated Go + Connect under
 | `Submit` | `App.RunTurn` | run one turn |
 | `Dispatch` | `App.Dispatch` | run a slash command → `CmdResult` |
 | `RespondToAsk` | `App.RespondToAsk` | answer a pending elicitation (first responder wins) |
-| `ListSessions` | `App.SessionsPage` | one page of persisted sessions |
+| `ListSessions` | `App.SessionsPage` | one page of an App's persisted RunStore runs |
 | `GetStatus` | `App.ModelLabel` / `App.RunID` | status-line read |
+| `CreateSession` | `SessionManager.Create` | mint a fresh conversation (App) → its `session_id` |
+| `ListWebSessions` | `SessionManager.List` | the roster of live conversations (App ids) |
+| `CloseSession` | `SessionManager.Close` | close one conversation and drop it |
+
+### Multi-session (epic 1193)
+
+One agentweb server hosts many concurrent conversations, each its own live
+`host.App`. Every request carries a `session_id` routing field on its envelope
+that selects the App it acts on. A `SessionManager` (`sessions.go`) owns the Apps
+keyed by id and builds new ones on demand from a factory (a fresh App from the
+server's config). `HostService` routes each RPC through it: an unknown
+`session_id` is `CodeNotFound`. An **empty** `session_id` resolves to a default
+session created at startup, so a client that predates multi-session (and sends no
+`session_id` — the current frontend) keeps working unchanged.
+
+`session_id` is a routing field on the request, never part of an event payload —
+the `Frame` stays event-flat (A2). `web.HandlerWithSessions(mgr)` serves the
+multi-session mux; `web.Handler(app)` remains the single-App shortcut (it wraps
+`app` as the default session with no factory, so `CreateSession` is unavailable).
+
+`ListSessions` (an App's persisted RunStore runs) and `ListWebSessions` (the
+roster of concurrent conversations) are distinct: the former pages history inside
+one conversation, the latter enumerates the conversations themselves.
+
+A browser session-switcher UI (open / list / switch conversations) is a
+follow-up; this slice is the backend + wire + tests.
 
 ### Frame envelope (A2)
 

--- a/agent/web/cmd/agentweb/main.go
+++ b/agent/web/cmd/agentweb/main.go
@@ -10,6 +10,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"io"
@@ -30,20 +31,28 @@ func main() {
 	demo := flag.Bool("demo", false, "run over an offline streaming demo provider (no config needed)")
 	flag.Parse()
 
-	app, err := buildApp(*configPath, *demo)
+	// One factory builds a fresh App per web session from the same config, so a
+	// CreateSession over the wire mints an independent conversation. The
+	// SessionManager holds them all; its default session (created at startup)
+	// backs an empty session_id, keeping the single-surface flow unchanged.
+	factory := func(ctx context.Context) (*host.App, error) { return buildApp(*configPath, *demo) }
+	mgr := web.NewSessionManager(factory)
+	defaultApp, err := factory(context.Background())
 	if err != nil {
 		log.Fatalf("agentweb: %v", err)
 	}
-	defer app.Close()
+	mgr.SetDefault(defaultApp)
+	defer mgr.CloseAll()
 
-	srv := &http.Server{Addr: *addr, Handler: web.Handler(app)}
+	srv := &http.Server{Addr: *addr, Handler: web.HandlerWithSessions(mgr)}
 	fmt.Fprintf(os.Stderr, "agentweb serving at http://%s/ (Connect: /%s, Ctrl-C to stop)\n", *addr, "mcpkit.agentweb.v1.HostService")
 	if err := skhttp.ListenAndServeGraceful(srv); err != nil {
 		log.Fatalf("agentweb: serve: %v", err)
 	}
 }
 
-// buildApp builds the one shared App. In demo mode it wires the offline demo
+// buildApp builds one App: the factory the SessionManager calls for the default
+// session and every CreateSession. In demo mode it wires the offline demo
 // provider; otherwise it loads the host config. The web surface renders in the
 // browser off the event stream, so the App's own terminal renderer is discarded
 // (output to io.Discard) — events reach clients through Subscribe / Watch.

--- a/agent/web/gen/go/mcpkit/agentweb/v1/agentwebv1connect/host.connect.go
+++ b/agent/web/gen/go/mcpkit/agentweb/v1/agentwebv1connect/host.connect.go
@@ -47,6 +47,15 @@ const (
 	HostServiceListSessionsProcedure = "/mcpkit.agentweb.v1.HostService/ListSessions"
 	// HostServiceGetStatusProcedure is the fully-qualified name of the HostService's GetStatus RPC.
 	HostServiceGetStatusProcedure = "/mcpkit.agentweb.v1.HostService/GetStatus"
+	// HostServiceCreateSessionProcedure is the fully-qualified name of the HostService's CreateSession
+	// RPC.
+	HostServiceCreateSessionProcedure = "/mcpkit.agentweb.v1.HostService/CreateSession"
+	// HostServiceListWebSessionsProcedure is the fully-qualified name of the HostService's
+	// ListWebSessions RPC.
+	HostServiceListWebSessionsProcedure = "/mcpkit.agentweb.v1.HostService/ListWebSessions"
+	// HostServiceCloseSessionProcedure is the fully-qualified name of the HostService's CloseSession
+	// RPC.
+	HostServiceCloseSessionProcedure = "/mcpkit.agentweb.v1.HostService/CloseSession"
 )
 
 // HostServiceClient is a client for the mcpkit.agentweb.v1.HostService service.
@@ -68,6 +77,18 @@ type HostServiceClient interface {
 	// GetStatus returns the active model label and run id (App.ModelLabel /
 	// App.RunID) — the status-line read.
 	GetStatus(context.Context, *connect.Request[v1.GetStatusRequest]) (*connect.Response[v1.GetStatusResponse], error)
+	// CreateSession mints a fresh conversation (a new host.App built from the
+	// server's config) and returns its session_id. Subsequent requests carrying
+	// that session_id route to the new App.
+	CreateSession(context.Context, *connect.Request[v1.CreateSessionRequest]) (*connect.Response[v1.CreateSessionResponse], error)
+	// ListWebSessions returns the session_ids of every live web session (App)
+	// the server currently hosts, including the default one. This is the roster
+	// of concurrent conversations, distinct from ListSessions (which pages the
+	// persisted RunStore runs inside one App).
+	ListWebSessions(context.Context, *connect.Request[v1.ListWebSessionsRequest]) (*connect.Response[v1.ListWebSessionsResponse], error)
+	// CloseSession closes the App for session_id and drops it from the roster.
+	// An unknown session_id is CodeNotFound.
+	CloseSession(context.Context, *connect.Request[v1.CloseSessionRequest]) (*connect.Response[v1.CloseSessionResponse], error)
 }
 
 // NewHostServiceClient constructs a client for the mcpkit.agentweb.v1.HostService service. By
@@ -117,17 +138,38 @@ func NewHostServiceClient(httpClient connect.HTTPClient, baseURL string, opts ..
 			connect.WithSchema(hostServiceMethods.ByName("GetStatus")),
 			connect.WithClientOptions(opts...),
 		),
+		createSession: connect.NewClient[v1.CreateSessionRequest, v1.CreateSessionResponse](
+			httpClient,
+			baseURL+HostServiceCreateSessionProcedure,
+			connect.WithSchema(hostServiceMethods.ByName("CreateSession")),
+			connect.WithClientOptions(opts...),
+		),
+		listWebSessions: connect.NewClient[v1.ListWebSessionsRequest, v1.ListWebSessionsResponse](
+			httpClient,
+			baseURL+HostServiceListWebSessionsProcedure,
+			connect.WithSchema(hostServiceMethods.ByName("ListWebSessions")),
+			connect.WithClientOptions(opts...),
+		),
+		closeSession: connect.NewClient[v1.CloseSessionRequest, v1.CloseSessionResponse](
+			httpClient,
+			baseURL+HostServiceCloseSessionProcedure,
+			connect.WithSchema(hostServiceMethods.ByName("CloseSession")),
+			connect.WithClientOptions(opts...),
+		),
 	}
 }
 
 // hostServiceClient implements HostServiceClient.
 type hostServiceClient struct {
-	watch        *connect.Client[v1.WatchRequest, v1.Frame]
-	submit       *connect.Client[v1.SubmitRequest, v1.SubmitResponse]
-	dispatch     *connect.Client[v1.DispatchRequest, v1.DispatchResponse]
-	respondToAsk *connect.Client[v1.RespondToAskRequest, v1.RespondToAskResponse]
-	listSessions *connect.Client[v1.ListSessionsRequest, v1.ListSessionsResponse]
-	getStatus    *connect.Client[v1.GetStatusRequest, v1.GetStatusResponse]
+	watch           *connect.Client[v1.WatchRequest, v1.Frame]
+	submit          *connect.Client[v1.SubmitRequest, v1.SubmitResponse]
+	dispatch        *connect.Client[v1.DispatchRequest, v1.DispatchResponse]
+	respondToAsk    *connect.Client[v1.RespondToAskRequest, v1.RespondToAskResponse]
+	listSessions    *connect.Client[v1.ListSessionsRequest, v1.ListSessionsResponse]
+	getStatus       *connect.Client[v1.GetStatusRequest, v1.GetStatusResponse]
+	createSession   *connect.Client[v1.CreateSessionRequest, v1.CreateSessionResponse]
+	listWebSessions *connect.Client[v1.ListWebSessionsRequest, v1.ListWebSessionsResponse]
+	closeSession    *connect.Client[v1.CloseSessionRequest, v1.CloseSessionResponse]
 }
 
 // Watch calls mcpkit.agentweb.v1.HostService.Watch.
@@ -160,6 +202,21 @@ func (c *hostServiceClient) GetStatus(ctx context.Context, req *connect.Request[
 	return c.getStatus.CallUnary(ctx, req)
 }
 
+// CreateSession calls mcpkit.agentweb.v1.HostService.CreateSession.
+func (c *hostServiceClient) CreateSession(ctx context.Context, req *connect.Request[v1.CreateSessionRequest]) (*connect.Response[v1.CreateSessionResponse], error) {
+	return c.createSession.CallUnary(ctx, req)
+}
+
+// ListWebSessions calls mcpkit.agentweb.v1.HostService.ListWebSessions.
+func (c *hostServiceClient) ListWebSessions(ctx context.Context, req *connect.Request[v1.ListWebSessionsRequest]) (*connect.Response[v1.ListWebSessionsResponse], error) {
+	return c.listWebSessions.CallUnary(ctx, req)
+}
+
+// CloseSession calls mcpkit.agentweb.v1.HostService.CloseSession.
+func (c *hostServiceClient) CloseSession(ctx context.Context, req *connect.Request[v1.CloseSessionRequest]) (*connect.Response[v1.CloseSessionResponse], error) {
+	return c.closeSession.CallUnary(ctx, req)
+}
+
 // HostServiceHandler is an implementation of the mcpkit.agentweb.v1.HostService service.
 type HostServiceHandler interface {
 	// Watch streams host events: the retained backlog replayed from offset 0,
@@ -179,6 +236,18 @@ type HostServiceHandler interface {
 	// GetStatus returns the active model label and run id (App.ModelLabel /
 	// App.RunID) — the status-line read.
 	GetStatus(context.Context, *connect.Request[v1.GetStatusRequest]) (*connect.Response[v1.GetStatusResponse], error)
+	// CreateSession mints a fresh conversation (a new host.App built from the
+	// server's config) and returns its session_id. Subsequent requests carrying
+	// that session_id route to the new App.
+	CreateSession(context.Context, *connect.Request[v1.CreateSessionRequest]) (*connect.Response[v1.CreateSessionResponse], error)
+	// ListWebSessions returns the session_ids of every live web session (App)
+	// the server currently hosts, including the default one. This is the roster
+	// of concurrent conversations, distinct from ListSessions (which pages the
+	// persisted RunStore runs inside one App).
+	ListWebSessions(context.Context, *connect.Request[v1.ListWebSessionsRequest]) (*connect.Response[v1.ListWebSessionsResponse], error)
+	// CloseSession closes the App for session_id and drops it from the roster.
+	// An unknown session_id is CodeNotFound.
+	CloseSession(context.Context, *connect.Request[v1.CloseSessionRequest]) (*connect.Response[v1.CloseSessionResponse], error)
 }
 
 // NewHostServiceHandler builds an HTTP handler from the service implementation. It returns the path
@@ -224,6 +293,24 @@ func NewHostServiceHandler(svc HostServiceHandler, opts ...connect.HandlerOption
 		connect.WithSchema(hostServiceMethods.ByName("GetStatus")),
 		connect.WithHandlerOptions(opts...),
 	)
+	hostServiceCreateSessionHandler := connect.NewUnaryHandler(
+		HostServiceCreateSessionProcedure,
+		svc.CreateSession,
+		connect.WithSchema(hostServiceMethods.ByName("CreateSession")),
+		connect.WithHandlerOptions(opts...),
+	)
+	hostServiceListWebSessionsHandler := connect.NewUnaryHandler(
+		HostServiceListWebSessionsProcedure,
+		svc.ListWebSessions,
+		connect.WithSchema(hostServiceMethods.ByName("ListWebSessions")),
+		connect.WithHandlerOptions(opts...),
+	)
+	hostServiceCloseSessionHandler := connect.NewUnaryHandler(
+		HostServiceCloseSessionProcedure,
+		svc.CloseSession,
+		connect.WithSchema(hostServiceMethods.ByName("CloseSession")),
+		connect.WithHandlerOptions(opts...),
+	)
 	return "/mcpkit.agentweb.v1.HostService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case HostServiceWatchProcedure:
@@ -238,6 +325,12 @@ func NewHostServiceHandler(svc HostServiceHandler, opts ...connect.HandlerOption
 			hostServiceListSessionsHandler.ServeHTTP(w, r)
 		case HostServiceGetStatusProcedure:
 			hostServiceGetStatusHandler.ServeHTTP(w, r)
+		case HostServiceCreateSessionProcedure:
+			hostServiceCreateSessionHandler.ServeHTTP(w, r)
+		case HostServiceListWebSessionsProcedure:
+			hostServiceListWebSessionsHandler.ServeHTTP(w, r)
+		case HostServiceCloseSessionProcedure:
+			hostServiceCloseSessionHandler.ServeHTTP(w, r)
 		default:
 			http.NotFound(w, r)
 		}
@@ -269,4 +362,16 @@ func (UnimplementedHostServiceHandler) ListSessions(context.Context, *connect.Re
 
 func (UnimplementedHostServiceHandler) GetStatus(context.Context, *connect.Request[v1.GetStatusRequest]) (*connect.Response[v1.GetStatusResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("mcpkit.agentweb.v1.HostService.GetStatus is not implemented"))
+}
+
+func (UnimplementedHostServiceHandler) CreateSession(context.Context, *connect.Request[v1.CreateSessionRequest]) (*connect.Response[v1.CreateSessionResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("mcpkit.agentweb.v1.HostService.CreateSession is not implemented"))
+}
+
+func (UnimplementedHostServiceHandler) ListWebSessions(context.Context, *connect.Request[v1.ListWebSessionsRequest]) (*connect.Response[v1.ListWebSessionsResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("mcpkit.agentweb.v1.HostService.ListWebSessions is not implemented"))
+}
+
+func (UnimplementedHostServiceHandler) CloseSession(context.Context, *connect.Request[v1.CloseSessionRequest]) (*connect.Response[v1.CloseSessionResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("mcpkit.agentweb.v1.HostService.CloseSession is not implemented"))
 }

--- a/agent/web/gen/go/mcpkit/agentweb/v1/host.pb.go
+++ b/agent/web/gen/go/mcpkit/agentweb/v1/host.pb.go
@@ -22,7 +22,10 @@ const (
 )
 
 type WatchRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// session_id selects the conversation (App) to stream. Empty routes to the
+	// default session.
+	SessionId     string `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -55,6 +58,13 @@ func (x *WatchRequest) ProtoReflect() protoreflect.Message {
 // Deprecated: Use WatchRequest.ProtoReflect.Descriptor instead.
 func (*WatchRequest) Descriptor() ([]byte, []int) {
 	return file_mcpkit_agentweb_v1_host_proto_rawDescGZIP(), []int{0}
+}
+
+func (x *WatchRequest) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
 }
 
 // Frame is one host event on the wire. kind is the HostEvent.Kind
@@ -117,8 +127,10 @@ func (x *Frame) GetPayload() []byte {
 }
 
 type SubmitRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Input         string                 `protobuf:"bytes,1,opt,name=input,proto3" json:"input,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Input string                 `protobuf:"bytes,1,opt,name=input,proto3" json:"input,omitempty"`
+	// session_id selects the conversation (App). Empty routes to the default.
+	SessionId     string `protobuf:"bytes,2,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -160,6 +172,13 @@ func (x *SubmitRequest) GetInput() string {
 	return ""
 }
 
+func (x *SubmitRequest) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
 type SubmitResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -197,8 +216,10 @@ func (*SubmitResponse) Descriptor() ([]byte, []int) {
 }
 
 type DispatchRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Line          string                 `protobuf:"bytes,1,opt,name=line,proto3" json:"line,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Line  string                 `protobuf:"bytes,1,opt,name=line,proto3" json:"line,omitempty"`
+	// session_id selects the conversation (App). Empty routes to the default.
+	SessionId     string `protobuf:"bytes,2,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -236,6 +257,13 @@ func (*DispatchRequest) Descriptor() ([]byte, []int) {
 func (x *DispatchRequest) GetLine() string {
 	if x != nil {
 		return x.Line
+	}
+	return ""
+}
+
+func (x *DispatchRequest) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
 	}
 	return ""
 }
@@ -307,8 +335,11 @@ type RespondToAskRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	AskId int64                  `protobuf:"varint,1,opt,name=ask_id,json=askId,proto3" json:"ask_id,omitempty"`
 	// result is json.Marshal(core.ElicitationResult).
-	Result        []byte `protobuf:"bytes,2,opt,name=result,proto3" json:"result,omitempty"`
-	By            string `protobuf:"bytes,3,opt,name=by,proto3" json:"by,omitempty"`
+	Result []byte `protobuf:"bytes,2,opt,name=result,proto3" json:"result,omitempty"`
+	By     string `protobuf:"bytes,3,opt,name=by,proto3" json:"by,omitempty"`
+	// session_id selects the conversation (App) whose ask is being answered.
+	// Empty routes to the default.
+	SessionId     string `protobuf:"bytes,4,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -364,6 +395,13 @@ func (x *RespondToAskRequest) GetBy() string {
 	return ""
 }
 
+func (x *RespondToAskRequest) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
 type RespondToAskResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -401,8 +439,11 @@ func (*RespondToAskResponse) Descriptor() ([]byte, []int) {
 }
 
 type ListSessionsRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Cursor        string                 `protobuf:"bytes,1,opt,name=cursor,proto3" json:"cursor,omitempty"`
+	state  protoimpl.MessageState `protogen:"open.v1"`
+	Cursor string                 `protobuf:"bytes,1,opt,name=cursor,proto3" json:"cursor,omitempty"`
+	// session_id selects the conversation (App) whose persisted runs are paged.
+	// Empty routes to the default.
+	SessionId     string `protobuf:"bytes,2,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -440,6 +481,13 @@ func (*ListSessionsRequest) Descriptor() ([]byte, []int) {
 func (x *ListSessionsRequest) GetCursor() string {
 	if x != nil {
 		return x.Cursor
+	}
+	return ""
+}
+
+func (x *ListSessionsRequest) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
 	}
 	return ""
 }
@@ -506,7 +554,9 @@ func (x *ListSessionsResponse) GetActiveRunId() string {
 }
 
 type GetStatusRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// session_id selects the conversation (App). Empty routes to the default.
+	SessionId     string `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -539,6 +589,13 @@ func (x *GetStatusRequest) ProtoReflect() protoreflect.Message {
 // Deprecated: Use GetStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetStatusRequest) Descriptor() ([]byte, []int) {
 	return file_mcpkit_agentweb_v1_host_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *GetStatusRequest) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
 }
 
 type GetStatusResponse struct {
@@ -593,47 +650,317 @@ func (x *GetStatusResponse) GetRunId() string {
 	return ""
 }
 
+type CreateSessionRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateSessionRequest) Reset() {
+	*x = CreateSessionRequest{}
+	mi := &file_mcpkit_agentweb_v1_host_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateSessionRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateSessionRequest) ProtoMessage() {}
+
+func (x *CreateSessionRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_mcpkit_agentweb_v1_host_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateSessionRequest.ProtoReflect.Descriptor instead.
+func (*CreateSessionRequest) Descriptor() ([]byte, []int) {
+	return file_mcpkit_agentweb_v1_host_proto_rawDescGZIP(), []int{12}
+}
+
+type CreateSessionResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// session_id of the freshly created conversation (App).
+	SessionId     string `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateSessionResponse) Reset() {
+	*x = CreateSessionResponse{}
+	mi := &file_mcpkit_agentweb_v1_host_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateSessionResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateSessionResponse) ProtoMessage() {}
+
+func (x *CreateSessionResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_mcpkit_agentweb_v1_host_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateSessionResponse.ProtoReflect.Descriptor instead.
+func (*CreateSessionResponse) Descriptor() ([]byte, []int) {
+	return file_mcpkit_agentweb_v1_host_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *CreateSessionResponse) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
+type ListWebSessionsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListWebSessionsRequest) Reset() {
+	*x = ListWebSessionsRequest{}
+	mi := &file_mcpkit_agentweb_v1_host_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListWebSessionsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListWebSessionsRequest) ProtoMessage() {}
+
+func (x *ListWebSessionsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_mcpkit_agentweb_v1_host_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListWebSessionsRequest.ProtoReflect.Descriptor instead.
+func (*ListWebSessionsRequest) Descriptor() ([]byte, []int) {
+	return file_mcpkit_agentweb_v1_host_proto_rawDescGZIP(), []int{14}
+}
+
+type ListWebSessionsResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// session_ids of every live web session (App), including the default.
+	SessionIds    []string `protobuf:"bytes,1,rep,name=session_ids,json=sessionIds,proto3" json:"session_ids,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListWebSessionsResponse) Reset() {
+	*x = ListWebSessionsResponse{}
+	mi := &file_mcpkit_agentweb_v1_host_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListWebSessionsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListWebSessionsResponse) ProtoMessage() {}
+
+func (x *ListWebSessionsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_mcpkit_agentweb_v1_host_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListWebSessionsResponse.ProtoReflect.Descriptor instead.
+func (*ListWebSessionsResponse) Descriptor() ([]byte, []int) {
+	return file_mcpkit_agentweb_v1_host_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *ListWebSessionsResponse) GetSessionIds() []string {
+	if x != nil {
+		return x.SessionIds
+	}
+	return nil
+}
+
+type CloseSessionRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// session_id of the conversation (App) to close.
+	SessionId     string `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CloseSessionRequest) Reset() {
+	*x = CloseSessionRequest{}
+	mi := &file_mcpkit_agentweb_v1_host_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CloseSessionRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CloseSessionRequest) ProtoMessage() {}
+
+func (x *CloseSessionRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_mcpkit_agentweb_v1_host_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CloseSessionRequest.ProtoReflect.Descriptor instead.
+func (*CloseSessionRequest) Descriptor() ([]byte, []int) {
+	return file_mcpkit_agentweb_v1_host_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *CloseSessionRequest) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
+type CloseSessionResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CloseSessionResponse) Reset() {
+	*x = CloseSessionResponse{}
+	mi := &file_mcpkit_agentweb_v1_host_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CloseSessionResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CloseSessionResponse) ProtoMessage() {}
+
+func (x *CloseSessionResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_mcpkit_agentweb_v1_host_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CloseSessionResponse.ProtoReflect.Descriptor instead.
+func (*CloseSessionResponse) Descriptor() ([]byte, []int) {
+	return file_mcpkit_agentweb_v1_host_proto_rawDescGZIP(), []int{17}
+}
+
 var File_mcpkit_agentweb_v1_host_proto protoreflect.FileDescriptor
 
 const file_mcpkit_agentweb_v1_host_proto_rawDesc = "" +
 	"\n" +
-	"\x1dmcpkit/agentweb/v1/host.proto\x12\x12mcpkit.agentweb.v1\"\x0e\n" +
-	"\fWatchRequest\"5\n" +
+	"\x1dmcpkit/agentweb/v1/host.proto\x12\x12mcpkit.agentweb.v1\"-\n" +
+	"\fWatchRequest\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\"5\n" +
 	"\x05Frame\x12\x12\n" +
 	"\x04kind\x18\x01 \x01(\tR\x04kind\x12\x18\n" +
-	"\apayload\x18\x02 \x01(\fR\apayload\"%\n" +
+	"\apayload\x18\x02 \x01(\fR\apayload\"D\n" +
 	"\rSubmitRequest\x12\x14\n" +
-	"\x05input\x18\x01 \x01(\tR\x05input\"\x10\n" +
-	"\x0eSubmitResponse\"%\n" +
+	"\x05input\x18\x01 \x01(\tR\x05input\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x02 \x01(\tR\tsessionId\"\x10\n" +
+	"\x0eSubmitResponse\"D\n" +
 	"\x0fDispatchRequest\x12\x12\n" +
-	"\x04line\x18\x01 \x01(\tR\x04line\"T\n" +
+	"\x04line\x18\x01 \x01(\tR\x04line\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x02 \x01(\tR\tsessionId\"T\n" +
 	"\x10DispatchResponse\x12\x12\n" +
 	"\x04kind\x18\x01 \x01(\tR\x04kind\x12\x18\n" +
 	"\apayload\x18\x02 \x01(\fR\apayload\x12\x12\n" +
-	"\x04quit\x18\x03 \x01(\bR\x04quit\"T\n" +
+	"\x04quit\x18\x03 \x01(\bR\x04quit\"s\n" +
 	"\x13RespondToAskRequest\x12\x15\n" +
 	"\x06ask_id\x18\x01 \x01(\x03R\x05askId\x12\x16\n" +
 	"\x06result\x18\x02 \x01(\fR\x06result\x12\x0e\n" +
-	"\x02by\x18\x03 \x01(\tR\x02by\"\x16\n" +
-	"\x14RespondToAskResponse\"-\n" +
+	"\x02by\x18\x03 \x01(\tR\x02by\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x04 \x01(\tR\tsessionId\"\x16\n" +
+	"\x14RespondToAskResponse\"L\n" +
 	"\x13ListSessionsRequest\x12\x16\n" +
-	"\x06cursor\x18\x01 \x01(\tR\x06cursor\"i\n" +
+	"\x06cursor\x18\x01 \x01(\tR\x06cursor\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x02 \x01(\tR\tsessionId\"i\n" +
 	"\x14ListSessionsResponse\x12\x12\n" +
 	"\x04runs\x18\x01 \x01(\fR\x04runs\x12\x19\n" +
 	"\bhas_more\x18\x02 \x01(\bR\ahasMore\x12\"\n" +
-	"\ractive_run_id\x18\x03 \x01(\tR\vactiveRunId\"\x12\n" +
-	"\x10GetStatusRequest\"K\n" +
+	"\ractive_run_id\x18\x03 \x01(\tR\vactiveRunId\"1\n" +
+	"\x10GetStatusRequest\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\"K\n" +
 	"\x11GetStatusResponse\x12\x1f\n" +
 	"\vmodel_label\x18\x01 \x01(\tR\n" +
 	"modelLabel\x12\x15\n" +
-	"\x06run_id\x18\x02 \x01(\tR\x05runId2\x9d\x04\n" +
+	"\x06run_id\x18\x02 \x01(\tR\x05runId\"\x16\n" +
+	"\x14CreateSessionRequest\"6\n" +
+	"\x15CreateSessionResponse\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\"\x18\n" +
+	"\x16ListWebSessionsRequest\":\n" +
+	"\x17ListWebSessionsResponse\x12\x1f\n" +
+	"\vsession_ids\x18\x01 \x03(\tR\n" +
+	"sessionIds\"4\n" +
+	"\x13CloseSessionRequest\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\"\x16\n" +
+	"\x14CloseSessionResponse2\xd2\x06\n" +
 	"\vHostService\x12F\n" +
 	"\x05Watch\x12 .mcpkit.agentweb.v1.WatchRequest\x1a\x19.mcpkit.agentweb.v1.Frame0\x01\x12O\n" +
 	"\x06Submit\x12!.mcpkit.agentweb.v1.SubmitRequest\x1a\".mcpkit.agentweb.v1.SubmitResponse\x12U\n" +
 	"\bDispatch\x12#.mcpkit.agentweb.v1.DispatchRequest\x1a$.mcpkit.agentweb.v1.DispatchResponse\x12a\n" +
 	"\fRespondToAsk\x12'.mcpkit.agentweb.v1.RespondToAskRequest\x1a(.mcpkit.agentweb.v1.RespondToAskResponse\x12a\n" +
 	"\fListSessions\x12'.mcpkit.agentweb.v1.ListSessionsRequest\x1a(.mcpkit.agentweb.v1.ListSessionsResponse\x12X\n" +
-	"\tGetStatus\x12$.mcpkit.agentweb.v1.GetStatusRequest\x1a%.mcpkit.agentweb.v1.GetStatusResponseBIZGgithub.com/panyam/mcpkit/agent/web/gen/go/mcpkit/agentweb/v1;agentwebv1b\x06proto3"
+	"\tGetStatus\x12$.mcpkit.agentweb.v1.GetStatusRequest\x1a%.mcpkit.agentweb.v1.GetStatusResponse\x12d\n" +
+	"\rCreateSession\x12(.mcpkit.agentweb.v1.CreateSessionRequest\x1a).mcpkit.agentweb.v1.CreateSessionResponse\x12j\n" +
+	"\x0fListWebSessions\x12*.mcpkit.agentweb.v1.ListWebSessionsRequest\x1a+.mcpkit.agentweb.v1.ListWebSessionsResponse\x12a\n" +
+	"\fCloseSession\x12'.mcpkit.agentweb.v1.CloseSessionRequest\x1a(.mcpkit.agentweb.v1.CloseSessionResponseBIZGgithub.com/panyam/mcpkit/agent/web/gen/go/mcpkit/agentweb/v1;agentwebv1b\x06proto3"
 
 var (
 	file_mcpkit_agentweb_v1_host_proto_rawDescOnce sync.Once
@@ -647,20 +974,26 @@ func file_mcpkit_agentweb_v1_host_proto_rawDescGZIP() []byte {
 	return file_mcpkit_agentweb_v1_host_proto_rawDescData
 }
 
-var file_mcpkit_agentweb_v1_host_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
+var file_mcpkit_agentweb_v1_host_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
 var file_mcpkit_agentweb_v1_host_proto_goTypes = []any{
-	(*WatchRequest)(nil),         // 0: mcpkit.agentweb.v1.WatchRequest
-	(*Frame)(nil),                // 1: mcpkit.agentweb.v1.Frame
-	(*SubmitRequest)(nil),        // 2: mcpkit.agentweb.v1.SubmitRequest
-	(*SubmitResponse)(nil),       // 3: mcpkit.agentweb.v1.SubmitResponse
-	(*DispatchRequest)(nil),      // 4: mcpkit.agentweb.v1.DispatchRequest
-	(*DispatchResponse)(nil),     // 5: mcpkit.agentweb.v1.DispatchResponse
-	(*RespondToAskRequest)(nil),  // 6: mcpkit.agentweb.v1.RespondToAskRequest
-	(*RespondToAskResponse)(nil), // 7: mcpkit.agentweb.v1.RespondToAskResponse
-	(*ListSessionsRequest)(nil),  // 8: mcpkit.agentweb.v1.ListSessionsRequest
-	(*ListSessionsResponse)(nil), // 9: mcpkit.agentweb.v1.ListSessionsResponse
-	(*GetStatusRequest)(nil),     // 10: mcpkit.agentweb.v1.GetStatusRequest
-	(*GetStatusResponse)(nil),    // 11: mcpkit.agentweb.v1.GetStatusResponse
+	(*WatchRequest)(nil),            // 0: mcpkit.agentweb.v1.WatchRequest
+	(*Frame)(nil),                   // 1: mcpkit.agentweb.v1.Frame
+	(*SubmitRequest)(nil),           // 2: mcpkit.agentweb.v1.SubmitRequest
+	(*SubmitResponse)(nil),          // 3: mcpkit.agentweb.v1.SubmitResponse
+	(*DispatchRequest)(nil),         // 4: mcpkit.agentweb.v1.DispatchRequest
+	(*DispatchResponse)(nil),        // 5: mcpkit.agentweb.v1.DispatchResponse
+	(*RespondToAskRequest)(nil),     // 6: mcpkit.agentweb.v1.RespondToAskRequest
+	(*RespondToAskResponse)(nil),    // 7: mcpkit.agentweb.v1.RespondToAskResponse
+	(*ListSessionsRequest)(nil),     // 8: mcpkit.agentweb.v1.ListSessionsRequest
+	(*ListSessionsResponse)(nil),    // 9: mcpkit.agentweb.v1.ListSessionsResponse
+	(*GetStatusRequest)(nil),        // 10: mcpkit.agentweb.v1.GetStatusRequest
+	(*GetStatusResponse)(nil),       // 11: mcpkit.agentweb.v1.GetStatusResponse
+	(*CreateSessionRequest)(nil),    // 12: mcpkit.agentweb.v1.CreateSessionRequest
+	(*CreateSessionResponse)(nil),   // 13: mcpkit.agentweb.v1.CreateSessionResponse
+	(*ListWebSessionsRequest)(nil),  // 14: mcpkit.agentweb.v1.ListWebSessionsRequest
+	(*ListWebSessionsResponse)(nil), // 15: mcpkit.agentweb.v1.ListWebSessionsResponse
+	(*CloseSessionRequest)(nil),     // 16: mcpkit.agentweb.v1.CloseSessionRequest
+	(*CloseSessionResponse)(nil),    // 17: mcpkit.agentweb.v1.CloseSessionResponse
 }
 var file_mcpkit_agentweb_v1_host_proto_depIdxs = []int32{
 	0,  // 0: mcpkit.agentweb.v1.HostService.Watch:input_type -> mcpkit.agentweb.v1.WatchRequest
@@ -669,14 +1002,20 @@ var file_mcpkit_agentweb_v1_host_proto_depIdxs = []int32{
 	6,  // 3: mcpkit.agentweb.v1.HostService.RespondToAsk:input_type -> mcpkit.agentweb.v1.RespondToAskRequest
 	8,  // 4: mcpkit.agentweb.v1.HostService.ListSessions:input_type -> mcpkit.agentweb.v1.ListSessionsRequest
 	10, // 5: mcpkit.agentweb.v1.HostService.GetStatus:input_type -> mcpkit.agentweb.v1.GetStatusRequest
-	1,  // 6: mcpkit.agentweb.v1.HostService.Watch:output_type -> mcpkit.agentweb.v1.Frame
-	3,  // 7: mcpkit.agentweb.v1.HostService.Submit:output_type -> mcpkit.agentweb.v1.SubmitResponse
-	5,  // 8: mcpkit.agentweb.v1.HostService.Dispatch:output_type -> mcpkit.agentweb.v1.DispatchResponse
-	7,  // 9: mcpkit.agentweb.v1.HostService.RespondToAsk:output_type -> mcpkit.agentweb.v1.RespondToAskResponse
-	9,  // 10: mcpkit.agentweb.v1.HostService.ListSessions:output_type -> mcpkit.agentweb.v1.ListSessionsResponse
-	11, // 11: mcpkit.agentweb.v1.HostService.GetStatus:output_type -> mcpkit.agentweb.v1.GetStatusResponse
-	6,  // [6:12] is the sub-list for method output_type
-	0,  // [0:6] is the sub-list for method input_type
+	12, // 6: mcpkit.agentweb.v1.HostService.CreateSession:input_type -> mcpkit.agentweb.v1.CreateSessionRequest
+	14, // 7: mcpkit.agentweb.v1.HostService.ListWebSessions:input_type -> mcpkit.agentweb.v1.ListWebSessionsRequest
+	16, // 8: mcpkit.agentweb.v1.HostService.CloseSession:input_type -> mcpkit.agentweb.v1.CloseSessionRequest
+	1,  // 9: mcpkit.agentweb.v1.HostService.Watch:output_type -> mcpkit.agentweb.v1.Frame
+	3,  // 10: mcpkit.agentweb.v1.HostService.Submit:output_type -> mcpkit.agentweb.v1.SubmitResponse
+	5,  // 11: mcpkit.agentweb.v1.HostService.Dispatch:output_type -> mcpkit.agentweb.v1.DispatchResponse
+	7,  // 12: mcpkit.agentweb.v1.HostService.RespondToAsk:output_type -> mcpkit.agentweb.v1.RespondToAskResponse
+	9,  // 13: mcpkit.agentweb.v1.HostService.ListSessions:output_type -> mcpkit.agentweb.v1.ListSessionsResponse
+	11, // 14: mcpkit.agentweb.v1.HostService.GetStatus:output_type -> mcpkit.agentweb.v1.GetStatusResponse
+	13, // 15: mcpkit.agentweb.v1.HostService.CreateSession:output_type -> mcpkit.agentweb.v1.CreateSessionResponse
+	15, // 16: mcpkit.agentweb.v1.HostService.ListWebSessions:output_type -> mcpkit.agentweb.v1.ListWebSessionsResponse
+	17, // 17: mcpkit.agentweb.v1.HostService.CloseSession:output_type -> mcpkit.agentweb.v1.CloseSessionResponse
+	9,  // [9:18] is the sub-list for method output_type
+	0,  // [0:9] is the sub-list for method input_type
 	0,  // [0:0] is the sub-list for extension type_name
 	0,  // [0:0] is the sub-list for extension extendee
 	0,  // [0:0] is the sub-list for field type_name
@@ -693,7 +1032,7 @@ func file_mcpkit_agentweb_v1_host_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_mcpkit_agentweb_v1_host_proto_rawDesc), len(file_mcpkit_agentweb_v1_host_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   12,
+			NumMessages:   18,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/agent/web/hostservice.go
+++ b/agent/web/hostservice.go
@@ -1,15 +1,22 @@
 // Package web exposes agent/host.App over a Connect RPC bridge with a live
 // event stream, so a browser can drive the same surface-agnostic host the
 // terminal agentchat drives (issue 1196, epic 1193). The bridge is a thin
-// projection: it holds only an *App and translates each RPC to an App method.
-// No web or proto type leaks back into agent/host (agent/CONSTRAINTS A4/A6);
-// the host stays surface-agnostic and this module owns all the web wiring.
+// projection: it holds only a SessionManager of *App and translates each RPC to
+// an App method. No web or proto type leaks back into agent/host
+// (agent/CONSTRAINTS A4/A6); the host stays surface-agnostic and this module
+// owns all the web wiring.
+//
+// One server can host many concurrent conversations. Each RPC carries a
+// session_id routing field that selects its App via the SessionManager; an
+// empty session_id resolves to a default session created at startup, so a
+// single-surface client that predates multi-session keeps working unchanged.
 package web
 
 import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"connectrpc.com/connect"
 	"github.com/panyam/mcpkit/agent/host"
@@ -18,24 +25,51 @@ import (
 	"github.com/panyam/mcpkit/core"
 )
 
-// HostService is the Connect handler that bridges HostService RPCs to an App.
-// Embedding UnimplementedHostServiceHandler keeps it forward-compatible when the
-// proto gains methods.
+// HostService is the Connect handler that bridges HostService RPCs to the App
+// selected by each request's session_id. Embedding UnimplementedHostServiceHandler
+// keeps it forward-compatible when the proto gains methods.
 type HostService struct {
 	agentwebv1connect.UnimplementedHostServiceHandler
-	app *host.App
+	sessions *SessionManager
 }
 
-// NewHostService wraps app as a Connect handler. The App is shared: a terminal
-// surface and any number of web clients can be attached to the same one at
-// once, which is the multi-surface point.
-func NewHostService(app *host.App) *HostService { return &HostService{app: app} }
+// NewHostService wraps a single App as the default session with no factory, so
+// the existing single-surface flow works unchanged (an empty session_id routes
+// to app; CreateSession is unavailable without a factory). Use
+// NewHostServiceWithSessions to host multiple concurrent conversations.
+func NewHostService(app *host.App) *HostService {
+	mgr := NewSessionManager(nil)
+	mgr.SetDefault(app)
+	return &HostService{sessions: mgr}
+}
 
-// Watch streams the host event log: the retained backlog replayed from offset 0
-// (App.Subscribe), then live events, until the client disconnects. The derived
-// ctx is cancelled on return so the drain goroutine and its Subscription exit
-// even when Send fails before the request ctx is observed.
-func (s *HostService) Watch(ctx context.Context, _ *connect.Request[agentwebv1.WatchRequest], stream *connect.ServerStream[agentwebv1.Frame]) error {
+// NewHostServiceWithSessions bridges a SessionManager, so one server hosts many
+// concurrent conversations. The manager's default session backs the empty
+// session_id; CreateSession mints new ones from the manager's factory.
+func NewHostServiceWithSessions(mgr *SessionManager) *HostService {
+	return &HostService{sessions: mgr}
+}
+
+// appFor resolves a request's session_id to its App, or a Connect CodeNotFound
+// error when no such session exists. An empty session_id resolves to the
+// default session.
+func (s *HostService) appFor(sessionID string) (*host.App, error) {
+	app, ok := s.sessions.Get(sessionID)
+	if !ok {
+		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("session %q not found", sessionID))
+	}
+	return app, nil
+}
+
+// Watch streams the selected session's event log: the retained backlog replayed
+// from offset 0 (App.Subscribe), then live events, until the client disconnects.
+// The derived ctx is cancelled on return so the drain goroutine and its
+// Subscription exit even when Send fails before the request ctx is observed.
+func (s *HostService) Watch(ctx context.Context, req *connect.Request[agentwebv1.WatchRequest], stream *connect.ServerStream[agentwebv1.Frame]) error {
+	app, err := s.appFor(req.Msg.GetSessionId())
+	if err != nil {
+		return err
+	}
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	// Open the stream immediately with a ready sentinel (empty kind). The
@@ -45,7 +79,7 @@ func (s *HostService) Watch(ctx context.Context, _ *connect.Request[agentwebv1.W
 	if err := stream.Send(&agentwebv1.Frame{}); err != nil {
 		return err
 	}
-	for ev := range s.app.Subscribe(ctx) {
+	for ev := range app.Subscribe(ctx) {
 		if err := stream.Send(eventToFrame(ev)); err != nil {
 			return err
 		}
@@ -53,21 +87,30 @@ func (s *HostService) Watch(ctx context.Context, _ *connect.Request[agentwebv1.W
 	return nil
 }
 
-// Submit runs one conversational turn. The turn's events stream on Watch; this
-// returns when the turn finishes. A failed turn maps to a Connect error (the
-// same failure is also announced as a HostTurnFailed frame on Watch).
+// Submit runs one conversational turn on the selected session. The turn's events
+// stream on that session's Watch; this returns when the turn finishes. A failed
+// turn maps to a Connect error (the same failure is also announced as a
+// HostTurnFailed frame on Watch).
 func (s *HostService) Submit(ctx context.Context, req *connect.Request[agentwebv1.SubmitRequest]) (*connect.Response[agentwebv1.SubmitResponse], error) {
-	if err := s.app.RunTurn(ctx, req.Msg.GetInput()); err != nil {
+	app, err := s.appFor(req.Msg.GetSessionId())
+	if err != nil {
+		return nil, err
+	}
+	if err := app.RunTurn(ctx, req.Msg.GetInput()); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 	return connect.NewResponse(&agentwebv1.SubmitResponse{}), nil
 }
 
-// Dispatch runs a slash command and returns its CmdResult as {kind, json}. An
-// unknown command is CodeInvalidArgument (a client can retry it as a turn); any
-// other command error is CodeInternal.
+// Dispatch runs a slash command on the selected session and returns its
+// CmdResult as {kind, json}. An unknown command is CodeInvalidArgument (a client
+// can retry it as a turn); any other command error is CodeInternal.
 func (s *HostService) Dispatch(ctx context.Context, req *connect.Request[agentwebv1.DispatchRequest]) (*connect.Response[agentwebv1.DispatchResponse], error) {
-	res, err := s.app.Dispatch(ctx, req.Msg.GetLine())
+	app, err := s.appFor(req.Msg.GetSessionId())
+	if err != nil {
+		return nil, err
+	}
+	res, err := app.Dispatch(ctx, req.Msg.GetLine())
 	if errors.Is(err, host.ErrUnknownCommand) {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
@@ -81,11 +124,15 @@ func (s *HostService) Dispatch(ctx context.Context, req *connect.Request[agentwe
 	}), nil
 }
 
-// RespondToAsk answers a pending elicitation by the AskID a client read off a
-// Frame. First responder wins; an unknown or already-answered ask is
-// CodeFailedPrecondition (app state, not a transport failure). An empty By
-// defaults to "web" so the resolved frame names the surface.
+// RespondToAsk answers a pending elicitation on the selected session by the
+// AskID a client read off a Frame. First responder wins; an unknown or
+// already-answered ask is CodeFailedPrecondition (app state, not a transport
+// failure). An empty By defaults to "web" so the resolved frame names the surface.
 func (s *HostService) RespondToAsk(_ context.Context, req *connect.Request[agentwebv1.RespondToAskRequest]) (*connect.Response[agentwebv1.RespondToAskResponse], error) {
+	app, err := s.appFor(req.Msg.GetSessionId())
+	if err != nil {
+		return nil, err
+	}
 	var result core.ElicitationResult
 	if raw := req.Msg.GetResult(); len(raw) > 0 {
 		if err := json.Unmarshal(raw, &result); err != nil {
@@ -101,16 +148,22 @@ func (s *HostService) RespondToAsk(_ context.Context, req *connect.Request[agent
 	// rides the log barrier, so a stale or already-answered offset returns the
 	// log's ErrAlreadyResolved / ErrOffsetOutOfRange (app state, reported as a
 	// failed precondition, not a transport failure).
-	if err := s.app.RespondToAsk(int(req.Msg.GetAskId()), result, by); err != nil {
+	if err := app.RespondToAsk(int(req.Msg.GetAskId()), result, by); err != nil {
 		return nil, connect.NewError(connect.CodeFailedPrecondition, err)
 	}
 	return connect.NewResponse(&agentwebv1.RespondToAskResponse{}), nil
 }
 
-// ListSessions returns one page of persisted sessions. No RunStore configured is
-// CodeFailedPrecondition (persistence is off, an app-state fact).
+// ListSessions returns one page of the selected session's persisted RunStore
+// runs. No RunStore configured is CodeFailedPrecondition (persistence is off, an
+// app-state fact). This pages the runs inside one conversation; the roster of
+// concurrent conversations is ListWebSessions.
 func (s *HostService) ListSessions(ctx context.Context, req *connect.Request[agentwebv1.ListSessionsRequest]) (*connect.Response[agentwebv1.ListSessionsResponse], error) {
-	page, err := s.app.SessionsPage(ctx, req.Msg.GetCursor())
+	app, err := s.appFor(req.Msg.GetSessionId())
+	if err != nil {
+		return nil, err
+	}
+	page, err := app.SessionsPage(ctx, req.Msg.GetCursor())
 	if err != nil {
 		return nil, connect.NewError(connect.CodeFailedPrecondition, err)
 	}
@@ -118,14 +171,50 @@ func (s *HostService) ListSessions(ctx context.Context, req *connect.Request[age
 	return connect.NewResponse(&agentwebv1.ListSessionsResponse{
 		Runs:        runs,
 		HasMore:     page.HasMore,
-		ActiveRunId: s.app.RunID(),
+		ActiveRunId: app.RunID(),
 	}), nil
 }
 
-// GetStatus returns the active model label and run id — the status-line read.
-func (s *HostService) GetStatus(_ context.Context, _ *connect.Request[agentwebv1.GetStatusRequest]) (*connect.Response[agentwebv1.GetStatusResponse], error) {
+// GetStatus returns the selected session's active model label and run id — the
+// status-line read.
+func (s *HostService) GetStatus(_ context.Context, req *connect.Request[agentwebv1.GetStatusRequest]) (*connect.Response[agentwebv1.GetStatusResponse], error) {
+	app, err := s.appFor(req.Msg.GetSessionId())
+	if err != nil {
+		return nil, err
+	}
 	return connect.NewResponse(&agentwebv1.GetStatusResponse{
-		ModelLabel: s.app.ModelLabel(),
-		RunId:      s.app.RunID(),
+		ModelLabel: app.ModelLabel(),
+		RunId:      app.RunID(),
 	}), nil
+}
+
+// CreateSession mints a fresh conversation (a new App built from the server's
+// config) and returns its session_id. A server built without a factory (the
+// single-App case) returns CodeFailedPrecondition; a factory error is
+// CodeInternal.
+func (s *HostService) CreateSession(ctx context.Context, _ *connect.Request[agentwebv1.CreateSessionRequest]) (*connect.Response[agentwebv1.CreateSessionResponse], error) {
+	id, _, err := s.sessions.Create(ctx)
+	if errors.Is(err, ErrNoSessionFactory) {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, err)
+	}
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+	return connect.NewResponse(&agentwebv1.CreateSessionResponse{SessionId: id}), nil
+}
+
+// ListWebSessions returns the session_ids of every live conversation (App) the
+// server hosts, including the default. This is the roster of concurrent
+// conversations, distinct from ListSessions (persisted runs inside one App).
+func (s *HostService) ListWebSessions(_ context.Context, _ *connect.Request[agentwebv1.ListWebSessionsRequest]) (*connect.Response[agentwebv1.ListWebSessionsResponse], error) {
+	return connect.NewResponse(&agentwebv1.ListWebSessionsResponse{SessionIds: s.sessions.List()}), nil
+}
+
+// CloseSession closes the App for session_id and drops it from the roster. An
+// unknown session_id is CodeNotFound.
+func (s *HostService) CloseSession(_ context.Context, req *connect.Request[agentwebv1.CloseSessionRequest]) (*connect.Response[agentwebv1.CloseSessionResponse], error) {
+	if !s.sessions.Close(req.Msg.GetSessionId()) {
+		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("session %q not found", req.Msg.GetSessionId()))
+	}
+	return connect.NewResponse(&agentwebv1.CloseSessionResponse{}), nil
 }

--- a/agent/web/protos/mcpkit/agentweb/v1/host.proto
+++ b/agent/web/protos/mcpkit/agentweb/v1/host.proto
@@ -13,6 +13,15 @@ option go_package = "github.com/panyam/mcpkit/agent/web/gen/go/mcpkit/agentweb/v
 //   - Dispatch      — a slash command (App.Dispatch -> CmdResult).
 //   - RespondToAsk  — the multi-surface ask barrier (App.RespondToAsk).
 //   - queries       — point-to-point reads of host state (ListSessions, GetStatus).
+//
+// One agentweb server can host many concurrent conversations, each its own
+// live host.App. Every request carries a session_id routing field on its
+// envelope that selects the App it acts on (an empty session_id routes to a
+// default session created at startup, so a client that predates multi-session
+// keeps working unchanged). The web-session lifecycle RPCs (CreateSession,
+// ListWebSessions, CloseSession) mint, enumerate, and tear down those Apps.
+// Note session_id is a routing field on each request, never part of an event
+// payload — the Frame stays event-flat (agent/CONSTRAINTS A2).
 service HostService {
   // Watch streams host events: the retained backlog replayed from offset 0,
   // then live events, until the client disconnects. It drains App.Subscribe;
@@ -36,9 +45,28 @@ service HostService {
   // GetStatus returns the active model label and run id (App.ModelLabel /
   // App.RunID) — the status-line read.
   rpc GetStatus(GetStatusRequest) returns (GetStatusResponse);
+
+  // CreateSession mints a fresh conversation (a new host.App built from the
+  // server's config) and returns its session_id. Subsequent requests carrying
+  // that session_id route to the new App.
+  rpc CreateSession(CreateSessionRequest) returns (CreateSessionResponse);
+
+  // ListWebSessions returns the session_ids of every live web session (App)
+  // the server currently hosts, including the default one. This is the roster
+  // of concurrent conversations, distinct from ListSessions (which pages the
+  // persisted RunStore runs inside one App).
+  rpc ListWebSessions(ListWebSessionsRequest) returns (ListWebSessionsResponse);
+
+  // CloseSession closes the App for session_id and drops it from the roster.
+  // An unknown session_id is CodeNotFound.
+  rpc CloseSession(CloseSessionRequest) returns (CloseSessionResponse);
 }
 
-message WatchRequest {}
+message WatchRequest {
+  // session_id selects the conversation (App) to stream. Empty routes to the
+  // default session.
+  string session_id = 1;
+}
 
 // Frame is one host event on the wire. kind is the HostEvent.Kind
 // discriminator; payload is the event's own JSON, json.Marshal(HostEvent). It
@@ -54,11 +82,15 @@ message Frame {
 
 message SubmitRequest {
   string input = 1;
+  // session_id selects the conversation (App). Empty routes to the default.
+  string session_id = 2;
 }
 message SubmitResponse {}
 
 message DispatchRequest {
   string line = 1;
+  // session_id selects the conversation (App). Empty routes to the default.
+  string session_id = 2;
 }
 // kind is CmdResult.Kind; payload is json.Marshal(CmdResult) — the same
 // data-only projection as Frame, so a web surface renders a command result the
@@ -74,11 +106,17 @@ message RespondToAskRequest {
   // result is json.Marshal(core.ElicitationResult).
   bytes result = 2;
   string by = 3;
+  // session_id selects the conversation (App) whose ask is being answered.
+  // Empty routes to the default.
+  string session_id = 4;
 }
 message RespondToAskResponse {}
 
 message ListSessionsRequest {
   string cursor = 1;
+  // session_id selects the conversation (App) whose persisted runs are paged.
+  // Empty routes to the default.
+  string session_id = 2;
 }
 // runs is json.Marshal([]agent.RunInfo); active_run_id is the current session.
 message ListSessionsResponse {
@@ -87,8 +125,29 @@ message ListSessionsResponse {
   string active_run_id = 3;
 }
 
-message GetStatusRequest {}
+message GetStatusRequest {
+  // session_id selects the conversation (App). Empty routes to the default.
+  string session_id = 1;
+}
 message GetStatusResponse {
   string model_label = 1;
   string run_id = 2;
 }
+
+message CreateSessionRequest {}
+message CreateSessionResponse {
+  // session_id of the freshly created conversation (App).
+  string session_id = 1;
+}
+
+message ListWebSessionsRequest {}
+message ListWebSessionsResponse {
+  // session_ids of every live web session (App), including the default.
+  repeated string session_ids = 1;
+}
+
+message CloseSessionRequest {
+  // session_id of the conversation (App) to close.
+  string session_id = 1;
+}
+message CloseSessionResponse {}

--- a/agent/web/serve.go
+++ b/agent/web/serve.go
@@ -19,9 +19,20 @@ import (
 // server streams over HTTP/1.1, so no h2c is required for local dev; a
 // production deployment behind HTTP/2 works unchanged.
 func Handler(app *host.App) http.Handler {
+	return handlerFor(NewHostService(app))
+}
+
+// HandlerWithSessions is Handler for a multi-session server: it serves the same
+// mux over a SessionManager, so one server hosts many concurrent conversations
+// (empty session_id routes to the manager's default, CreateSession mints more).
+func HandlerWithSessions(mgr *SessionManager) http.Handler {
+	return handlerFor(NewHostServiceWithSessions(mgr))
+}
+
+func handlerFor(svc *HostService) http.Handler {
 	mux := http.NewServeMux()
 
-	path, h := agentwebv1connect.NewHostServiceHandler(NewHostService(app))
+	path, h := agentwebv1connect.NewHostServiceHandler(svc)
 	mux.Handle(path, h)
 
 	mux.Handle("/static/", http.StripPrefix("/static/", http.FileServer(http.FS(staticAssets()))))

--- a/agent/web/sessions.go
+++ b/agent/web/sessions.go
@@ -1,0 +1,138 @@
+package web
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"sync"
+
+	"github.com/panyam/mcpkit/agent/host"
+)
+
+// DefaultSessionID is the id of the session an empty session_id routes to. One
+// agentweb server always has a default session so a client that predates
+// multi-session (and sends no session_id) keeps working unchanged.
+const DefaultSessionID = "default"
+
+// ErrNoSessionFactory is returned by SessionManager.Create when the manager was
+// built without a factory, so it can only serve its pre-built default session
+// (the single-App back-compat path).
+var ErrNoSessionFactory = errors.New("web: session manager has no factory; cannot create sessions")
+
+// SessionManager owns the live host.Apps a single agentweb server hosts, one
+// per concurrent conversation, keyed by session id. It is safe for concurrent
+// use. A request's session_id selects its App via Get; an empty session_id
+// resolves to the default session. New sessions are built on demand from a
+// factory that produces a fresh App from the server's config.
+type SessionManager struct {
+	mu       sync.Mutex
+	sessions map[string]*host.App
+	factory  func(context.Context) (*host.App, error)
+}
+
+// NewSessionManager returns a manager whose Create builds fresh Apps from
+// factory. factory may be nil, in which case the manager can only serve a
+// default session registered via SetDefault and Create returns
+// ErrNoSessionFactory.
+func NewSessionManager(factory func(context.Context) (*host.App, error)) *SessionManager {
+	return &SessionManager{sessions: map[string]*host.App{}, factory: factory}
+}
+
+// resolve maps an empty id to the default session id, so an empty session_id on
+// the wire always addresses the default session.
+func resolve(id string) string {
+	if id == "" {
+		return DefaultSessionID
+	}
+	return id
+}
+
+// SetDefault registers app as the default session (the one an empty session_id
+// routes to). It is called once at startup; a prior default is not closed.
+func (m *SessionManager) SetDefault(app *host.App) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.sessions[DefaultSessionID] = app
+}
+
+// Create builds a fresh App via the factory, stores it under a newly minted id,
+// and returns the id with the App. It returns ErrNoSessionFactory when the
+// manager has no factory. A factory error is propagated and nothing is stored.
+func (m *SessionManager) Create(ctx context.Context) (string, *host.App, error) {
+	if m.factory == nil {
+		return "", nil, ErrNoSessionFactory
+	}
+	app, err := m.factory(ctx)
+	if err != nil {
+		return "", nil, err
+	}
+	id := m.mintID()
+	m.mu.Lock()
+	m.sessions[id] = app
+	m.mu.Unlock()
+	return id, app, nil
+}
+
+// Get returns the App for id and whether it was found. An empty id resolves to
+// the default session. A missing session is app state (found=false), not an
+// error, so the caller maps it to a Connect CodeNotFound.
+func (m *SessionManager) Get(id string) (*host.App, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	app, ok := m.sessions[resolve(id)]
+	return app, ok
+}
+
+// List returns the ids of every live session, unordered. The default session's
+// id is included.
+func (m *SessionManager) List() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	ids := make([]string, 0, len(m.sessions))
+	for id := range m.sessions {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+// Close closes the App for id and drops it from the roster, returning whether a
+// session was found. An empty id resolves to the default session. Closing is
+// idempotent: a second Close of the same id returns false.
+func (m *SessionManager) Close(id string) bool {
+	rid := resolve(id)
+	m.mu.Lock()
+	app, ok := m.sessions[rid]
+	if ok {
+		delete(m.sessions, rid)
+	}
+	m.mu.Unlock()
+	if ok {
+		app.Close()
+	}
+	return ok
+}
+
+// CloseAll closes every live session and empties the roster. It is used to tear
+// the whole server down.
+func (m *SessionManager) CloseAll() {
+	m.mu.Lock()
+	apps := make([]*host.App, 0, len(m.sessions))
+	for id, app := range m.sessions {
+		apps = append(apps, app)
+		delete(m.sessions, id)
+	}
+	m.mu.Unlock()
+	for _, app := range apps {
+		app.Close()
+	}
+}
+
+// mintID returns a fresh, unpredictable session id (crypto/rand hex). It never
+// collides with DefaultSessionID and, being 128 bits, never collides in
+// practice with a live session.
+func (m *SessionManager) mintID() string {
+	var b [16]byte
+	_, _ = rand.Read(b[:])
+	return hex.EncodeToString(b[:])
+}

--- a/agent/web/sessions_test.go
+++ b/agent/web/sessions_test.go
@@ -1,0 +1,391 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+
+	"github.com/panyam/mcpkit/agent"
+	"github.com/panyam/mcpkit/agent/host"
+	agentwebv1 "github.com/panyam/mcpkit/agent/web/gen/go/mcpkit/agentweb/v1"
+	"github.com/panyam/mcpkit/agent/web/gen/go/mcpkit/agentweb/v1/agentwebv1connect"
+	"github.com/panyam/mcpkit/core"
+)
+
+// stubApp builds an App over a fresh StubProvider with the given scripted turns,
+// discarding terminal output. Each call is an independent session (its own event
+// log and provider), which is what the SessionManager hands out per session.
+func stubApp(t *testing.T, turns ...agent.StubTurn) *host.App {
+	t.Helper()
+	stub := agent.NewStubProvider(turns...)
+	cfg := &host.Config{Model: host.ModelConfig{BaseURL: "http://stub", Model: "stub-model"}}
+	app, err := host.NewApp(cfg, io.Discard, strings.NewReader(""), host.WithProvider(stub))
+	if err != nil {
+		t.Fatalf("NewApp: %v", err)
+	}
+	return app
+}
+
+// startWatchSession drives a Watch stream for a specific session in the
+// background and records frames (the session-aware sibling of startWatch).
+func startWatchSession(t *testing.T, ctx context.Context, client agentwebv1connect.HostServiceClient, sessionID string) *watcher {
+	t.Helper()
+	stream, err := client.Watch(ctx, connect.NewRequest(&agentwebv1.WatchRequest{SessionId: sessionID}))
+	if err != nil {
+		t.Fatalf("Watch(%q): %v", sessionID, err)
+	}
+	w := &watcher{}
+	go func() {
+		for stream.Receive() {
+			f := stream.Msg()
+			w.mu.Lock()
+			w.frames = append(w.frames, f)
+			w.mu.Unlock()
+		}
+	}()
+	return w
+}
+
+// TestBridge_SessionsAreIsolated is the multi-session acceptance: two sessions
+// on one server have independent event streams. A Submit on session A appears on
+// A's Watch but never on B's, and B runs its own turn independently.
+func TestBridge_SessionsAreIsolated(t *testing.T) {
+	mgr := NewSessionManager(func(context.Context) (*host.App, error) {
+		return stubApp(t, agent.StubTurn{Text: "reply", FinishReason: "stop"}), nil
+	})
+	srv := httptest.NewServer(HandlerWithSessions(mgr))
+	defer srv.Close()
+	defer mgr.CloseAll()
+	client := agentwebv1connect.NewHostServiceClient(srv.Client(), srv.URL)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	idA := mustCreate(t, ctx, client)
+	idB := mustCreate(t, ctx, client)
+	if idA == idB {
+		t.Fatalf("CreateSession minted colliding ids: %q", idA)
+	}
+
+	wa := startWatchSession(t, ctx, client, idA)
+	wb := startWatchSession(t, ctx, client, idB)
+
+	// A turn on session A.
+	if _, err := client.Submit(ctx, connect.NewRequest(&agentwebv1.SubmitRequest{Input: "hi A", SessionId: idA})); err != nil {
+		t.Fatalf("Submit A: %v", err)
+	}
+	wa.waitForKind(t, string(host.HostTurnDone))
+
+	// Session B's stream must NOT carry A's turn.
+	time.Sleep(150 * time.Millisecond) // let any cross-talk arrive if it were going to
+	if contains(wb.kinds(), string(host.HostTurnDone)) {
+		t.Fatalf("session B saw session A's turn-done; B frames=%v", wb.kinds())
+	}
+
+	// B runs its own turn independently.
+	if _, err := client.Submit(ctx, connect.NewRequest(&agentwebv1.SubmitRequest{Input: "hi B", SessionId: idB})); err != nil {
+		t.Fatalf("Submit B: %v", err)
+	}
+	wb.waitForKind(t, string(host.HostTurnDone))
+}
+
+// TestBridge_RespondToAskTargetsSession is the multi-session ask acceptance: an
+// ask raised on session A is answerable only through session A. B's stream never
+// sees the ask, a RespondToAsk aimed at B is refused, and the A-targeted respond
+// wins the turn.
+func TestBridge_RespondToAskTargetsSession(t *testing.T) {
+	askApp := askGatedApp(t)
+	idleApp := stubApp(t, agent.StubTurn{Text: "idle", FinishReason: "stop"})
+
+	// Hand the ask-gated app out first, then the idle one, so their ids are known.
+	apps := []*host.App{askApp, idleApp}
+	var mu sync.Mutex
+	var i int
+	mgr := NewSessionManager(func(context.Context) (*host.App, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		a := apps[i]
+		i++
+		return a, nil
+	})
+	srv := httptest.NewServer(HandlerWithSessions(mgr))
+	defer srv.Close()
+	defer mgr.CloseAll()
+	client := agentwebv1connect.NewHostServiceClient(srv.Client(), srv.URL)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	idAsk := mustCreate(t, ctx, client)
+	idIdle := mustCreate(t, ctx, client)
+
+	wAsk := startWatchSession(t, ctx, client, idAsk)
+	wIdle := startWatchSession(t, ctx, client, idIdle)
+
+	submitErr := make(chan error, 1)
+	go func() {
+		_, err := client.Submit(ctx, connect.NewRequest(&agentwebv1.SubmitRequest{Input: "please act", SessionId: idAsk}))
+		submitErr <- err
+	}()
+
+	frame := wAsk.waitForKind(t, string(host.HostElicitRequest))
+	var reqEv host.HostEvent
+	if err := json.Unmarshal(frame.GetPayload(), &reqEv); err != nil {
+		t.Fatalf("decode elicit-request frame: %v", err)
+	}
+	if reqEv.AskID == 0 {
+		t.Fatalf("elicit-request frame carried no AskID: %s", frame.GetPayload())
+	}
+
+	// The idle session's stream never saw the ask.
+	if contains(wIdle.kinds(), string(host.HostElicitRequest)) {
+		t.Fatalf("idle session saw the ask; idle frames=%v", wIdle.kinds())
+	}
+
+	// A RespondToAsk aimed at the wrong session is refused (the offset is not a
+	// pending ask in the idle session's log).
+	result, _ := json.Marshal(core.ElicitationResult{Action: "accept", Content: map[string]any{"confirm": true}})
+	_, err := client.RespondToAsk(ctx, connect.NewRequest(&agentwebv1.RespondToAskRequest{
+		AskId: reqEv.AskID, Result: result, By: "web", SessionId: idIdle,
+	}))
+	if err == nil {
+		t.Fatalf("RespondToAsk aimed at the idle session should have failed")
+	}
+	if got := connect.CodeOf(err); got != connect.CodeFailedPrecondition {
+		t.Fatalf("wrong-session RespondToAsk code = %v, want FailedPrecondition", got)
+	}
+
+	// The correctly targeted respond wins the ask.
+	if _, err := client.RespondToAsk(ctx, connect.NewRequest(&agentwebv1.RespondToAskRequest{
+		AskId: reqEv.AskID, Result: result, By: "web", SessionId: idAsk,
+	})); err != nil {
+		t.Fatalf("RespondToAsk on the ask session: %v", err)
+	}
+	resolved := wAsk.waitForKind(t, string(host.HostElicitResolved))
+	var resEv host.HostEvent
+	if err := json.Unmarshal(resolved.GetPayload(), &resEv); err != nil {
+		t.Fatalf("decode elicit-resolved frame: %v", err)
+	}
+	if resEv.By != "web" {
+		t.Fatalf("ask resolved By = %q, want web", resEv.By)
+	}
+
+	select {
+	case err := <-submitErr:
+		if err != nil {
+			t.Fatalf("Submit after ask: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Submit did not finish after the ask was answered")
+	}
+}
+
+// askGatedApp builds an App whose first turn is a tool call gated by approval
+// "ask" mode, with a local elicitation UI that blocks forever, so only a remote
+// RespondToAsk can resolve the ask. The second turn finishes the turn.
+func askGatedApp(t *testing.T) *host.App {
+	t.Helper()
+	stub := agent.NewStubProvider(
+		agent.StubTurn{ToolCalls: []agent.ToolCall{{ID: "c1", Name: "do_it"}}, FinishReason: "tool_calls"},
+		agent.StubTurn{Text: "done", FinishReason: "stop"},
+	)
+	blockingUI := func(ctx context.Context, _ core.ElicitationRequest) (core.ElicitationResult, error) {
+		<-ctx.Done()
+		return core.ElicitationResult{}, ctx.Err()
+	}
+	cfg := &host.Config{
+		Model:    host.ModelConfig{BaseURL: "http://stub", Model: "stub-model"},
+		Approval: &host.ApprovalConfig{Mode: "ask"},
+	}
+	app, err := host.NewApp(cfg, io.Discard, strings.NewReader(""),
+		host.WithProvider(stub), host.WithElicitationUI(blockingUI))
+	if err != nil {
+		t.Fatalf("NewApp: %v", err)
+	}
+	return app
+}
+
+// TestBridge_EmptySessionRoutesToDefault is the backward-compat acceptance: a
+// client that sends no session_id drives the default session created at startup,
+// exactly as the single-surface flow always has.
+func TestBridge_EmptySessionRoutesToDefault(t *testing.T) {
+	mgr := NewSessionManager(nil) // no factory: default-only, single-surface shape
+	mgr.SetDefault(stubApp(t, agent.StubTurn{Text: "hi", FinishReason: "stop"}))
+	srv := httptest.NewServer(HandlerWithSessions(mgr))
+	defer srv.Close()
+	defer mgr.CloseAll()
+	client := agentwebv1connect.NewHostServiceClient(srv.Client(), srv.URL)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w := startWatch(t, ctx, client) // empty session_id
+	if _, err := client.Submit(ctx, connect.NewRequest(&agentwebv1.SubmitRequest{Input: "x"})); err != nil {
+		t.Fatalf("Submit (default): %v", err)
+	}
+	w.waitForKind(t, string(host.HostTurnDone))
+
+	st, err := client.GetStatus(ctx, connect.NewRequest(&agentwebv1.GetStatusRequest{}))
+	if err != nil {
+		t.Fatalf("GetStatus (default): %v", err)
+	}
+	if st.Msg.GetModelLabel() != "stub-model" {
+		t.Fatalf("GetStatus model = %q, want stub-model", st.Msg.GetModelLabel())
+	}
+
+	// The default session is on the roster under its well-known id.
+	lw, err := client.ListWebSessions(ctx, connect.NewRequest(&agentwebv1.ListWebSessionsRequest{}))
+	if err != nil {
+		t.Fatalf("ListWebSessions: %v", err)
+	}
+	if got := lw.Msg.GetSessionIds(); len(got) != 1 || got[0] != DefaultSessionID {
+		t.Fatalf("ListWebSessions = %v, want [%q]", got, DefaultSessionID)
+	}
+}
+
+// TestBridge_SessionLifecycle covers CreateSession / ListWebSessions /
+// CloseSession: a create mints a fresh App on the roster, and a close removes it
+// and closes the App so a later request to it is CodeNotFound.
+func TestBridge_SessionLifecycle(t *testing.T) {
+	mgr := NewSessionManager(func(context.Context) (*host.App, error) { return stubApp(t), nil })
+	mgr.SetDefault(stubApp(t))
+	srv := httptest.NewServer(HandlerWithSessions(mgr))
+	defer srv.Close()
+	defer mgr.CloseAll()
+	client := agentwebv1connect.NewHostServiceClient(srv.Client(), srv.URL)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Only the default is present up front.
+	if got := roster(t, ctx, client); len(got) != 1 || got[0] != DefaultSessionID {
+		t.Fatalf("initial roster = %v, want [%q]", got, DefaultSessionID)
+	}
+
+	id := mustCreate(t, ctx, client)
+	if id == "" || id == DefaultSessionID {
+		t.Fatalf("CreateSession minted a bad id: %q", id)
+	}
+
+	if got := roster(t, ctx, client); !equalSet(got, []string{DefaultSessionID, id}) {
+		t.Fatalf("roster after create = %v, want {%q, %q}", got, DefaultSessionID, id)
+	}
+
+	// The created session is a live, fresh App (its status reads back).
+	st, err := client.GetStatus(ctx, connect.NewRequest(&agentwebv1.GetStatusRequest{SessionId: id}))
+	if err != nil {
+		t.Fatalf("GetStatus on created session: %v", err)
+	}
+	if st.Msg.GetModelLabel() != "stub-model" {
+		t.Fatalf("created session model = %q, want stub-model", st.Msg.GetModelLabel())
+	}
+
+	// CloseSession removes it from the roster.
+	if _, err := client.CloseSession(ctx, connect.NewRequest(&agentwebv1.CloseSessionRequest{SessionId: id})); err != nil {
+		t.Fatalf("CloseSession: %v", err)
+	}
+	if got := roster(t, ctx, client); !equalSet(got, []string{DefaultSessionID}) {
+		t.Fatalf("roster after close = %v, want {%q}", got, DefaultSessionID)
+	}
+
+	// The closed session no longer routes (App closed and dropped).
+	if _, err := client.GetStatus(ctx, connect.NewRequest(&agentwebv1.GetStatusRequest{SessionId: id})); connect.CodeOf(err) != connect.CodeNotFound {
+		t.Fatalf("GetStatus on closed session code = %v, want NotFound", connect.CodeOf(err))
+	}
+
+	// Closing it again is a no-op miss.
+	if _, err := client.CloseSession(ctx, connect.NewRequest(&agentwebv1.CloseSessionRequest{SessionId: id})); connect.CodeOf(err) != connect.CodeNotFound {
+		t.Fatalf("second CloseSession code = %v, want NotFound", connect.CodeOf(err))
+	}
+}
+
+// TestBridge_UnknownSession asserts an unknown session_id is CodeNotFound across
+// the RPC surface.
+func TestBridge_UnknownSession(t *testing.T) {
+	mgr := NewSessionManager(nil)
+	mgr.SetDefault(stubApp(t))
+	srv := httptest.NewServer(HandlerWithSessions(mgr))
+	defer srv.Close()
+	defer mgr.CloseAll()
+	client := agentwebv1connect.NewHostServiceClient(srv.Client(), srv.URL)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if _, err := client.GetStatus(ctx, connect.NewRequest(&agentwebv1.GetStatusRequest{SessionId: "nope"})); connect.CodeOf(err) != connect.CodeNotFound {
+		t.Fatalf("GetStatus unknown code = %v, want NotFound", connect.CodeOf(err))
+	}
+	if _, err := client.Submit(ctx, connect.NewRequest(&agentwebv1.SubmitRequest{Input: "x", SessionId: "nope"})); connect.CodeOf(err) != connect.CodeNotFound {
+		t.Fatalf("Submit unknown code = %v, want NotFound", connect.CodeOf(err))
+	}
+
+	// Watch surfaces the not-found on the first Receive.
+	stream, err := client.Watch(ctx, connect.NewRequest(&agentwebv1.WatchRequest{SessionId: "nope"}))
+	if err == nil {
+		stream.Receive()
+		err = stream.Err()
+	}
+	if connect.CodeOf(err) != connect.CodeNotFound {
+		t.Fatalf("Watch unknown code = %v, want NotFound", connect.CodeOf(err))
+	}
+}
+
+// TestBridge_CreateSessionWithoutFactory asserts a default-only server (no
+// factory) refuses CreateSession with CodeFailedPrecondition.
+func TestBridge_CreateSessionWithoutFactory(t *testing.T) {
+	mgr := NewSessionManager(nil)
+	mgr.SetDefault(stubApp(t))
+	srv := httptest.NewServer(HandlerWithSessions(mgr))
+	defer srv.Close()
+	defer mgr.CloseAll()
+	client := agentwebv1connect.NewHostServiceClient(srv.Client(), srv.URL)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if _, err := client.CreateSession(ctx, connect.NewRequest(&agentwebv1.CreateSessionRequest{})); connect.CodeOf(err) != connect.CodeFailedPrecondition {
+		t.Fatalf("CreateSession without factory code = %v, want FailedPrecondition", connect.CodeOf(err))
+	}
+}
+
+func mustCreate(t *testing.T, ctx context.Context, client agentwebv1connect.HostServiceClient) string {
+	t.Helper()
+	res, err := client.CreateSession(ctx, connect.NewRequest(&agentwebv1.CreateSessionRequest{}))
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	return res.Msg.GetSessionId()
+}
+
+func roster(t *testing.T, ctx context.Context, client agentwebv1connect.HostServiceClient) []string {
+	t.Helper()
+	res, err := client.ListWebSessions(ctx, connect.NewRequest(&agentwebv1.ListWebSessionsRequest{}))
+	if err != nil {
+		t.Fatalf("ListWebSessions: %v", err)
+	}
+	return res.Msg.GetSessionIds()
+}
+
+func equalSet(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	a := append([]string(nil), got...)
+	b := append([]string(nil), want...)
+	sort.Strings(a)
+	sort.Strings(b)
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
Part of epic #1193.

Adds **multi-session support** to the `agent/web` Connect bridge so one `agentweb`
server can host many concurrent conversations, each routed to its own live
`host.App`. Backend + wire + tests only; a browser session-switcher UI is a
follow-up (see Out of scope).

## What changed

- **Proto** (`protos/mcpkit/agentweb/v1/host.proto`): a `session_id` routing
  field on `WatchRequest`, `SubmitRequest`, `DispatchRequest`,
  `RespondToAskRequest`, `ListSessionsRequest`, and `GetStatusRequest`, plus
  three lifecycle RPCs: `CreateSession` (mint a fresh App → its `session_id`),
  `ListWebSessions` (the roster of live conversation ids), and `CloseSession`.
  Regenerated Go via `buf generate` (protoc-gen-go + protoc-gen-connect-go), same
  as the original E3 generation.
- **`SessionManager`** (`sessions.go`, new): a thread-safe `map[string]*host.App`
  plus a `factory func(context.Context) (*host.App, error)` that builds a fresh
  App per new session. `Create` / `Get` / `List` / `Close` / `SetDefault` /
  `CloseAll`. Ids are 128-bit crypto/rand hex; the default session's id is the
  constant `"default"`.
- **Routing** (`hostservice.go`): `HostService` now holds a `*SessionManager`.
  Every RPC resolves `req.SessionId` via `appFor` and acts on that App; an unknown
  id returns Connect `CodeNotFound`. An **empty** `session_id` resolves to the
  default session, so the current single-surface flow (and the existing frontend,
  which sends no `session_id`) keeps working unchanged.
- **`cmd/agentweb`** (`main.go`): `buildApp` is now the `SessionManager` factory;
  the default session is created at startup. `--addr` / `--config` / `--demo`
  unchanged.

`session_id` is a routing field on the request envelope, never part of an event
payload — the `Frame` stays event-flat (agent/CONSTRAINTS A2).

## How a request routes to its session

```
Connect RPC (req.session_id)
        │
        ▼
HostService.appFor(session_id)
        │
        ▼
SessionManager.Get(session_id)     ""  ─► "default"  (backward-compat)
        │                          known ─► its *host.App
        │                          unknown ─► CodeNotFound
        ▼
   *host.App  ──►  App.RunTurn / Subscribe / Dispatch / RespondToAsk / …
```

`CreateSession` calls the factory to build a new App under a fresh id;
`CloseSession` closes that App and drops it; `ListWebSessions` returns the roster.

## Reviewer's guide

- [agent/web/protos/mcpkit/agentweb/v1/host.proto](https://github.com/panyam/mcpkit/pull/1214/files#diff-38b0ec8655206bc8fafc90c7e5a191e0c18e2f2205f265f1a884952859bc57ef) — the wire change: `session_id`
  fields and the three lifecycle RPCs. Start here.
- [agent/web/sessions.go](https://github.com/panyam/mcpkit/pull/1214/files#diff-dce0828b9e7d247560cb3e35031f8f2175199ba5bb6924d92672110b27d6448f) — `SessionManager`: the App registry + factory, id
  minting, and the empty-id → default `resolve` rule.
- [agent/web/hostservice.go](https://github.com/panyam/mcpkit/pull/1214/files#diff-437c49c3f077658cadeb9adb9d161917d93a64d70fba3da4b08c0362f9577964) — routing: `appFor` and the per-RPC `req.SessionId`
  resolution, plus `CreateSession` / `ListWebSessions` / `CloseSession`. Note
  `NewHostService(app)` still exists (single-App, default-only, no factory) and
  `NewHostServiceWithSessions(mgr)` is the multi-session constructor.
- [agent/web/serve.go](https://github.com/panyam/mcpkit/pull/1214/files#diff-b2a44337862bfe5df19cb9dfe7509f434878d10e61cb893d9a5a7492a9a8728f) — `HandlerWithSessions(mgr)` alongside the unchanged
  `Handler(app)`.
- [agent/web/cmd/agentweb/main.go](https://github.com/panyam/mcpkit/pull/1214/files#diff-0f5afbc921e60199eb1e3f7ca4b7b369ce57ad6486b25a0a2daa4888885e9663) — `buildApp` wired as the factory; default
  session created at startup.
- [agent/web/sessions_test.go](https://github.com/panyam/mcpkit/pull/1214/files#diff-1f3b6515fdd772b054e7254599f3cc56f0251d05e3d6d2a9c8f76e747e2a0a2d) — isolation (Submit/Watch/RespondToAsk per
  session), the create/list/close lifecycle, empty-session default routing, and
  unknown-session `CodeNotFound`. `host_bridge_test.go` (the E3 tests) is
  unchanged and still green.

## Naming note

The existing `ListSessions` RPC (pages an App's persisted RunStore runs) is left
as-is; it is already consumed by the frontend. The new roster RPC is
`ListWebSessions` to avoid the collision — the two are genuinely different
concepts (history inside one conversation vs the set of concurrent
conversations).

## Tests

`just test-agent`'s `agent/web` stage is green; `go test -race ./...` in
`agent/web` passes (E3 tests + the 6 new multi-session tests). No new module
dependencies (crypto/rand + encoding/hex are stdlib).

## Out of scope

- **Frontend session-switcher UI** (open / list / switch conversations in the
  browser) — a follow-up. The frontend still sends no `session_id` and rides the
  default session unchanged. Regenerating the TypeScript proto clients
  (`web/ npm run gen`) rides with that frontend work.

