### PR TITLE
feat(examples): standardize agent examples on shared config.json + web recipe

### DIFF
--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -4,13 +4,32 @@ Agent-focused examples grouped together, sharing a common demo harness.
 
 - **`agent-async`** — an agent managing async work (events + tasks) through chat.
 - **`multi-agent`** — Phase 3 composition: sub-agents-as-tools + handoff.
+- **`critic`** — a second model watches the primary agent's turns and injects graded steering notes.
+- **`deep-agent-supervisor`** — a supervisor over a server-advertised roster of specialist agents.
+- **`kitchen-sink`** — every agent feature wired at once.
 
-## Running
+## One config per example, shared across surfaces
 
-Each example is deterministic offline (`just agent` — scripted StubProviders,
-no LLM). To drive it with a live model, `just demo` resolves the model and
-endpoint from `llm.json` (or a gitignored `llm.local.json` override) when
-`MODEL` / `BASE_URL` aren't set.
+Every example runs off **one host config** that all its surfaces load:
+
+| Recipe | Surface | What it does |
+|---|---|---|
+| `just agent` | scripted | deterministic StubProviders, no LLM (the golden test) |
+| `just demo` | CLI (live) | a live model against the same server; resolves model/endpoint from `llm.json` |
+| `just serve` | server | boots the demo MCP server the live surfaces point at |
+| `just chat` | CLI (`agentchat`) | the terminal surface, `--config <config>.json` |
+| `just web` | browser (`agentweb`) | the browser surface, `--config <config>.json --addr :8090` |
+
+`chat` and `web` are shared recipes in `common.just`, parameterized by `CONFIG`
+(default `config.json`) and `ADDR`. The already-config-driven examples
+(`deep-agent-supervisor`, `kitchen-sink`, `examples/playground`) carry their own
+variable-driven justfiles and gained the same `web` surface.
+
+The three code-driven examples (`agent-async`, `multi-agent`, `critic`) each
+ship a `config.json` too. Their deterministic scenario loads that same
+`config.json` and keeps only the piece JSON cannot express in code — the
+scripted `StubProvider` (and, for `multi-agent`/`critic`, the hand-wired
+composition). Each example's README documents its own split.
 
 ## `llm.json` — providers, no secrets
 

--- a/examples/agents/agent-async/README.md
+++ b/examples/agents/agent-async/README.md
@@ -18,6 +18,24 @@ just test           # the golden-transcript test
 just demo qwen2.5-7b-instruct   # a live model improvising against the same server
 ```
 
+## One config, three surfaces
+
+`config.json` is the single host config both live surfaces load — the CLI
+(`agentchat`) and the browser (`agentweb`). Start the demo MCP server, then
+point either surface at it:
+
+```bash
+just serve   # the app-domain MCP server (events + tasks + send_email) on :8788
+just chat    # agentchat CLI against config.json (another terminal)
+just web     # agentweb browser surface against config.json (another terminal)
+```
+
+`config.json` carries the model connection, `metaTools`, and the server. The
+one piece it cannot hold is the scripted `StubProvider` that makes `just agent`
+deterministic, so `runScenario` loads the same `config.json` and only overrides
+the server URL to the in-process test server and injects the stub. The live
+surfaces use the config verbatim.
+
 ## What happens
 
 ```

--- a/examples/agents/agent-async/config.json
+++ b/examples/agents/agent-async/config.json
@@ -1,0 +1,13 @@
+{
+  "instructions": "You manage asynchronous work through chat. Subscribe to event streams, install standing triggers that fire when a chosen event occurs, and kick off long-running task tools. When an event you are watching fires, act on it.",
+  "connections": {
+    "active": "local",
+    "connections": {
+      "local": { "type": "lmstudio", "model": "qwen2.5-7b-instruct" }
+    }
+  },
+  "metaTools": true,
+  "servers": [
+    { "id": "app", "url": "http://localhost:8788/mcp" }
+  ]
+}

--- a/examples/agents/agent-async/justfile
+++ b/examples/agents/agent-async/justfile
@@ -1,6 +1,16 @@
 # agent-async — an agent managing async work (events + tasks) through chat.
+#
+# Surfaces (all off config.json):
+#   just agent   # deterministic scripted scenario, no LLM (the golden test)
+#   just serve   # the app-domain MCP server on :8788 (for chat / web)
+#   just chat    # agentchat CLI against config.json (needs just serve)
+#   just web     # agentweb browser surface against config.json (needs just serve)
 import '../common.just'
 
 # Show available recipes
 default:
     @just --list --unsorted
+
+# Serve the app-domain MCP server (events + tasks + send_email) on :8788.
+serve:
+    go run . --serve --addr :8788

--- a/examples/agents/agent-async/main.go
+++ b/examples/agents/agent-async/main.go
@@ -12,10 +12,22 @@ import (
 )
 
 func main() {
+	serveFlag := flag.Bool("serve", false, "run the demo MCP server (for the live chat/web surfaces) instead of the scripted scenario")
+	addr := flag.String("addr", ":8788", "listen address for --serve")
 	model := flag.String("model", "", "OpenAI-compatible model for a live run (default: deterministic stub)")
 	baseURL := flag.String("base-url", "http://localhost:1234/v1", "model endpoint for --model")
 	apiKeyEnv := flag.String("api-key-env", "", "env var holding the model API key (never the key itself)")
 	flag.Parse()
+
+	// --serve boots the app-domain MCP server the config.json surfaces point
+	// at (just chat / just web), so a live model has real tools to drive.
+	if *serveFlag {
+		if err := serve(*addr); err != nil {
+			fmt.Fprintln(os.Stderr, "agent-async:", err)
+			os.Exit(1)
+		}
+		return
+	}
 
 	out := &syncWriter{}
 	var provider agent.Provider

--- a/examples/agents/agent-async/scenario.go
+++ b/examples/agents/agent-async/scenario.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http/httptest"
 	"strings"
 	"time"
@@ -69,6 +70,15 @@ func buildServer() (*server.Server, func(context.Context, userData) error, *[]st
 	return srv, yield, &sent
 }
 
+// serve runs the app-domain server as a standalone streamable-HTTP MCP server
+// so the live chat/web surfaces (config.json points at it) have real tools to
+// drive. The scripted scenario uses the same buildServer over httptest instead.
+func serve(addr string) error {
+	srv, _, _ := buildServer()
+	log.Printf("agent-async demo server on http://localhost%s/mcp", addr)
+	return srv.Run(addr)
+}
+
 // stubScript is the model's scripted side of the conversation: the moves a
 // real model would make, pinned so the demo is deterministic.
 func stubScript() *agent.StubProvider {
@@ -98,11 +108,16 @@ func runScenario(out *syncWriter, provider agent.Provider) error {
 	ts := httptest.NewServer(srv.Handler(server.WithStreamableHTTP(true)))
 	defer ts.Close()
 
-	cfg := &host.Config{
-		Model:     host.ModelConfig{BaseURL: "http://stub", Model: "stub"},
-		MetaTools: true,
-		Servers:   []host.ServerConfig{{ID: "app", URL: ts.URL + "/mcp"}},
+	// Load the SAME config.json the live chat/web surfaces use (instructions,
+	// metaTools, the app server), then point its server at the in-process
+	// httptest instance for the deterministic run. The scripted StubProvider
+	// (below) is the one piece that cannot live in JSON; config.json's model is
+	// for a live model and is bypassed by WithProvider here.
+	cfg, err := host.LoadConfig("config.json")
+	if err != nil {
+		return err
 	}
+	cfg.Servers[0].URL = ts.URL + "/mcp"
 	opts := []host.AppOption{}
 	if provider != nil {
 		opts = append(opts, host.WithProvider(provider))

--- a/examples/agents/common.just
+++ b/examples/agents/common.just
@@ -1,7 +1,20 @@
 # Shared recipes for agent examples. Import from an example justfile:
 #   import '../common.just'
+#
+# One config per example drives every surface: `chat` (agentchat CLI) and
+# `web` (agentweb browser) both load CONFIG, and the deterministic `agent`
+# scenario loads the same file in code (see each example's README for the
+# split between JSON config and the in-code scripted StubProvider).
+#
 # `demo` resolves model/base-url from ../llm.json (or ../llm.local.json) when
 # MODEL/BASE_URL are unset — see ../demo.sh. Keys are never in the file.
+
+# Host config both surfaces load. Override in an example justfile if the file
+# is not named config.json.
+CONFIG := justfile_directory() / "config.json"
+
+# Address the agentweb browser surface listens on.
+ADDR := env_var_or_default("ADDR", ":8090")
 
 # Run the deterministic scripted scenario (no LLM)
 agent:
@@ -10,6 +23,23 @@ agent:
 # Run against a live model (MODEL=<name> BASE_URL=<url> override llm.json)
 demo:
     @../demo.sh
+
+# Chat with the CLI surface (agentchat) off CONFIG. Start the example's
+# server first (just serve) so the configured tools are reachable.
+chat:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cd "$(git rev-parse --show-toplevel)/cmd/agentchat"
+    exec go run . --config "{{CONFIG}}"
+
+# Serve the browser surface (agentweb) off CONFIG on ADDR. Start the example's
+# server first (just serve); a down server does not block boot, its tools wire
+# in once it is up.
+web:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cd "$(git rev-parse --show-toplevel)/agent/web"
+    exec go run ./cmd/agentweb --config "{{CONFIG}}" --addr "{{ADDR}}"
 
 # Run the golden-transcript test
 test:

--- a/examples/agents/common.just
+++ b/examples/agents/common.just
@@ -24,17 +24,14 @@ agent:
 demo:
     @../demo.sh
 
-# Chat with the CLI surface (agentchat) off CONFIG. Start the example's
-# server first (just serve) so the configured tools are reachable.
+# Chat with the CLI surface (agentchat) off CONFIG (start the server first: just serve).
 chat:
     #!/usr/bin/env bash
     set -euo pipefail
     cd "$(git rev-parse --show-toplevel)/cmd/agentchat"
     exec go run . --config "{{CONFIG}}"
 
-# Serve the browser surface (agentweb) off CONFIG on ADDR. Start the example's
-# server first (just serve); a down server does not block boot, its tools wire
-# in once it is up.
+# Serve the browser surface (agentweb) off CONFIG on ADDR (start the server first: just serve).
 web:
     #!/usr/bin/env bash
     set -euo pipefail

--- a/examples/agents/critic/README.md
+++ b/examples/agents/critic/README.md
@@ -41,6 +41,26 @@ Point real models at both roles independently:
 go run . --model qwen2.5 --critic-model llama3.2 --base-url http://localhost:1234/v1
 ```
 
+## One config, two surfaces (with a residual)
+
+`config.json` holds the **primary** agent's model connection, instructions, and
+the ops MCP server. Both live surfaces load it:
+
+```bash
+just serve   # the ops MCP server (run_shell) on :8786
+just chat    # agentchat CLI against config.json (another terminal)
+just web     # agentweb browser surface against config.json (another terminal)
+```
+
+The **critic loop itself is not config-expressible** — `host.Config` has no
+"observer model" seam; the second `Runner` + the anti-nag guard are code-level
+composition (that is the point of the example). So `config.json` drives the
+primary agent, and `just chat` / `just web` run it **without** the critic. The
+scripted `runScenario` loads the same `config.json` (overriding the server URL
+to the in-process test server, injecting the scripted providers) and adds the
+critic in code — the full watch-and-steer flow runs under `just agent` / `just
+demo`.
+
 ## The one rough edge: note delivery
 
 On top of `host.App` the pattern works, with a single gap. `App.RunTurn` accepts

--- a/examples/agents/critic/config.json
+++ b/examples/agents/critic/config.json
@@ -1,0 +1,12 @@
+{
+  "instructions": "You are an operations agent. Use the run_shell tool to carry out requests. When you are handed a note from a reviewer, weigh it rather than blindly obeying it.",
+  "connections": {
+    "active": "local",
+    "connections": {
+      "local": { "type": "lmstudio", "model": "qwen2.5-7b-instruct" }
+    }
+  },
+  "servers": [
+    { "id": "ops", "url": "http://localhost:8786/mcp" }
+  ]
+}

--- a/examples/agents/critic/justfile
+++ b/examples/agents/critic/justfile
@@ -1,7 +1,19 @@
 # critic — a second model watches the primary agent's turns and injects graded
 # steering notes, composed entirely from public primitives (issue 1148).
+#
+# Surfaces:
+#   just agent   # deterministic scripted scenario, no LLM (the golden test)
+#   just serve   # the ops MCP server on :8786 (for chat / web)
+#   just chat    # agentchat CLI against config.json (needs just serve)
+#   just web     # agentweb browser surface against config.json (needs just serve)
+# config.json drives the primary agent + server; the critic loop itself is
+# code-level composition (see README) and runs only under `just agent` / `just demo`.
 import '../common.just'
 
 # Show available recipes
 default:
     @just --list --unsorted
+
+# Serve the ops MCP server (run_shell) on :8786.
+serve:
+    go run . --serve --addr :8786

--- a/examples/agents/critic/main.go
+++ b/examples/agents/critic/main.go
@@ -10,11 +10,24 @@ import (
 )
 
 func main() {
+	serveFlag := flag.Bool("serve", false, "run the demo MCP server (for the live chat/web surfaces) instead of the scripted scenario")
+	addr := flag.String("addr", ":8786", "listen address for --serve")
 	model := flag.String("model", "", "OpenAI-compatible model for the PRIMARY agent (default: deterministic stub)")
 	criticModel := flag.String("critic-model", "", "OpenAI-compatible model for the CRITIC (default: deterministic stub)")
 	baseURL := flag.String("base-url", "http://localhost:1234/v1", "model endpoint for --model / --critic-model")
 	apiKeyEnv := flag.String("api-key-env", "", "env var holding the model API key (never the key itself)")
 	flag.Parse()
+
+	// --serve boots the ops MCP server the config.json surfaces point at
+	// (just chat / just web). The critic loop itself is code-level composition
+	// (see scenario.go / README): config.json drives the primary agent + server.
+	if *serveFlag {
+		if err := serve(*addr); err != nil {
+			fmt.Fprintln(os.Stderr, "critic:", err)
+			os.Exit(1)
+		}
+		return
+	}
 
 	newProvider := func(m string) agent.Provider {
 		if m == "" {

--- a/examples/agents/critic/scenario.go
+++ b/examples/agents/critic/scenario.go
@@ -21,6 +21,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"log"
 	"net/http/httptest"
 	"strings"
 
@@ -48,6 +49,14 @@ func buildServer() *server.Server {
 			return "ran: " + in.Cmd, nil
 		}))
 	return srv
+}
+
+// serve runs the ops server as a standalone streamable-HTTP MCP server so the
+// live chat/web surfaces (config.json points at it) have a real tool to drive.
+// The scripted scenario uses the same buildServer over httptest instead.
+func serve(addr string) error {
+	log.Printf("critic demo server on http://localhost%s/mcp", addr)
+	return buildServer().Run(addr)
 }
 
 // primaryScript is the primary model's scripted side: turn 1 runs an
@@ -96,10 +105,16 @@ func runScenario(out *syncWriter, primary, criticProvider agent.Provider) (*runR
 	}
 	primaryStub, _ := primary.(*agent.StubProvider)
 
-	cfg := &host.Config{
-		Model:   host.ModelConfig{BaseURL: "http://stub", Model: "stub"},
-		Servers: []host.ServerConfig{{ID: "ops", URL: ts.URL + "/mcp"}},
+	// Load the SAME config.json the live chat/web surfaces use (instructions,
+	// the ops server), then point its server at the in-process httptest
+	// instance for the deterministic run. config.json's model is bypassed by
+	// WithProvider (the scripted StubProvider) below; the critic loop itself is
+	// code-level composition and has no config.json representation (see README).
+	cfg, err := host.LoadConfig("config.json")
+	if err != nil {
+		return nil, err
 	}
+	cfg.Servers[0].URL = ts.URL + "/mcp"
 
 	// The observer hands us the primary's per-turn transcript delta. This is
 	// the whole "watch the turn stream" half — entirely public API.

--- a/examples/agents/deep-agent-supervisor/README.md
+++ b/examples/agents/deep-agent-supervisor/README.md
@@ -49,7 +49,8 @@ Two terminals:
 # Terminal 1 — the roster server on :8795
 just serve
 
-# Terminal 2 — the supervisor host
+# Terminal 2 — the supervisor host (CLI). `just web` serves the browser
+# surface (agentweb) off the same config instead.
 just demo
 ```
 

--- a/examples/agents/deep-agent-supervisor/justfile
+++ b/examples/agents/deep-agent-supervisor/justfile
@@ -32,6 +32,24 @@ demo:
 # Alias for demo.
 run: demo
 
+# Alias for demo (the agentchat CLI surface).
+chat: demo
+
+# agentweb uses the config's active connection (ACTIVE/EXPORTER are agentchat-only);
+# ADDR overrides the listen address (:8090). Needs `just serve`.
+# Launch the supervisor over the BROWSER surface (agentweb) against the config.
+web:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    DIR="{{justfile_directory()}}"
+    ROOT="$(cd "$DIR/../../.." && pwd)"
+    if ! (exec 3<>"/dev/tcp/localhost/8795") 2>/dev/null; then
+        echo "roster server not reachable on :8795 -> start it first: just serve" >&2
+        exit 1
+    fi
+    cd "$ROOT/agent/web"
+    exec go run ./cmd/agentweb --config "$DIR/deep-agent-supervisor.json" --addr "${ADDR:-:8090}"
+
 # Same as demo, but the alt-screen notebook UI (foldable cells make the
 # supervisor -> specialist delegation easy to follow).
 note:

--- a/examples/agents/kitchen-sink/README.md
+++ b/examples/agents/kitchen-sink/README.md
@@ -94,6 +94,7 @@ just servers-up-bg # the four MCP servers, detached (independent of the chat)
 just check        # probe backends; prints how to fix whatever is down
 just run          # preflight, verify servers are up, launch agentchat (inline TUI)
 just note         # same, but the alt-screen notebook UI (scrollable, foldable cells)
+just web          # the browser surface (agentweb) off kitchen-sink.json (config subset)
 # ... chat, quit, `just run` again — the servers are still up ...
 just servers-down  # stop the MCP servers
 just alldown       # tear the stacks back down

--- a/examples/agents/kitchen-sink/justfile
+++ b/examples/agents/kitchen-sink/justfile
@@ -45,6 +45,7 @@ export MAX_TREE_TOKENS := env_var_or_default("MAX_TREE_TOKENS", "")
 
 # --- misc ----------------------------------------------------------------
 export UI      := env_var_or_default("UI", "tui")
+export ADDR    := env_var_or_default("ADDR", ":8090")
 export PG_HOST := env_var_or_default("PG_HOST", "localhost")
 export PG_PORT := env_var_or_default("PG_PORT", "5432")
 export PG_DB   := env_var_or_default("PG_DB", "agent")
@@ -71,6 +72,14 @@ demo: run
 # Same as run, but the alt-screen notebook UI (scrollable, foldable cells).
 note:
     @UI=notebook bash run.sh
+
+# agentweb loads only what the config JSON expresses (connections, servers,
+# sub-agents) — the durable session / offload / semantic-memory / tree-budget
+# knobs are agentchat CLI flags (see run.sh); use `just run` for those. Start
+# the MCP servers first (just servers-up-bg). ADDR overrides the listen address.
+# Browser surface (agentweb) against kitchen-sink.json.
+web:
+    cd ../../../agent/web && go run ./cmd/agentweb --config "{{justfile_directory()}}/kitchen-sink.json" --addr "$ADDR"
 
 # Handoff-Team topology (kitchen-sink-team.json): a triage router transfers you
 # to a billing or technical specialist; the active agent persists across turns.

--- a/examples/agents/multi-agent/README.md
+++ b/examples/agents/multi-agent/README.md
@@ -13,9 +13,29 @@ mcpkit's Phase 3 multi-agent composition, both modes, in one runnable demo:
 ## Run
 
 ```bash
-go run .            # deterministic StubProviders (no LLM, no network)
+just agent          # deterministic StubProviders (no LLM, no network)
+just test           # the golden transcript
 go run . --model X  # drive the supervisor with a live OpenAI-compatible model
 ```
+
+## One config, two surfaces
+
+`config.json` is the **declarative host counterpart** to the hand-wired
+composition above: the two sub-agents become `subAgents` personas that share
+the main provider and a filtered view of a demo MCP server's tools. Both the
+CLI (`agentchat`) and browser (`agentweb`) surfaces load it:
+
+```bash
+just serve   # the demo MCP server (web_search + run_code) on :8785
+just chat    # agentchat CLI against config.json (another terminal)
+just web     # agentweb browser surface against config.json (another terminal)
+```
+
+The golden scenario stays hand-wired (each sub-agent gets its own scripted
+`StubProvider` + `FuncSource`, which JSON cannot express); `config.json` is the
+config-driven version of the same supervisor → researcher/coder shape. Handoff
+(`Team`) has no host-config surface in this example and runs only under `just
+agent` / `--model`.
 
 Sample output:
 

--- a/examples/agents/multi-agent/config.json
+++ b/examples/agents/multi-agent/config.json
@@ -1,0 +1,26 @@
+{
+  "instructions": "You are a supervisor. Delegate research to the researcher and coding to the coder, then synthesize their findings.",
+  "connections": {
+    "active": "local",
+    "connections": {
+      "local": { "type": "lmstudio", "model": "qwen2.5-7b-instruct" }
+    }
+  },
+  "servers": [
+    { "id": "demo", "url": "http://localhost:8785/mcp" }
+  ],
+  "subAgents": [
+    {
+      "name": "researcher",
+      "description": "researches a topic using the available server tools",
+      "instructions": "You are a researcher. Use the tools to look things up, then report concisely.",
+      "allow": ["web_search"]
+    },
+    {
+      "name": "coder",
+      "description": "writes and verifies code",
+      "instructions": "You are a coder. Write a snippet, verify it with run_code, then present it.",
+      "allow": ["run_code"]
+    }
+  ]
+}

--- a/examples/agents/multi-agent/go.mod
+++ b/examples/agents/multi-agent/go.mod
@@ -16,9 +16,11 @@ require (
 	github.com/panyam/goutils v0.1.8 // indirect
 	github.com/panyam/servicekit v0.1.3 // indirect
 	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.2 // indirect
 	golang.org/x/sys v0.43.0 // indirect
+	golang.org/x/text v0.33.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260120221211-b8f7ae30c516 // indirect
 	google.golang.org/grpc v1.80.0 // indirect

--- a/examples/agents/multi-agent/go.sum
+++ b/examples/agents/multi-agent/go.sum
@@ -4,6 +4,8 @@ github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJ
 github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/examples/agents/multi-agent/justfile
+++ b/examples/agents/multi-agent/justfile
@@ -1,6 +1,18 @@
 # multi-agent — Phase 3 composition: sub-agents-as-tools + handoff.
+#
+# Surfaces:
+#   just agent   # deterministic scripted scenario, no LLM (the golden test)
+#   just serve   # the demo MCP server (web_search + run_code) on :8785
+#   just chat    # agentchat CLI against config.json (needs just serve)
+#   just web     # agentweb browser surface against config.json (needs just serve)
+# config.json is the declarative host counterpart (subAgents personas) to the
+# hand-wired composition the golden scenario runs; see README.
 import '../common.just'
 
 # Show available recipes
 default:
     @just --list --unsorted
+
+# Serve the demo MCP server (web_search + run_code) on :8785.
+serve:
+    go run . --serve --addr :8785

--- a/examples/agents/multi-agent/main.go
+++ b/examples/agents/multi-agent/main.go
@@ -9,10 +9,22 @@ import (
 )
 
 func main() {
+	serveFlag := flag.Bool("serve", false, "run the demo MCP server (for the live chat/web surfaces) instead of the scripted scenario")
+	addr := flag.String("addr", ":8785", "listen address for --serve")
 	model := flag.String("model", "", "OpenAI-compatible model for a live supervisor (default: deterministic stub)")
 	baseURL := flag.String("base-url", "http://localhost:1234/v1", "model endpoint for --model")
 	apiKeyEnv := flag.String("api-key-env", "", "env var holding the model API key (never the key itself)")
 	flag.Parse()
+
+	// --serve boots the demo MCP server the config.json personas delegate over
+	// (just chat / just web). The scripted scenario below is the golden test.
+	if *serveFlag {
+		if err := serve(*addr); err != nil {
+			fmt.Fprintln(os.Stderr, "multi-agent:", err)
+			os.Exit(1)
+		}
+		return
+	}
 
 	var provider agent.Provider
 	if *model != "" {

--- a/examples/agents/multi-agent/serve.go
+++ b/examples/agents/multi-agent/serve.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"log"
+
+	"github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/server"
+)
+
+// searchInput / codeInput are the demo server's tool inputs.
+type searchInput struct {
+	Query string `json:"query"`
+}
+
+type codeInput struct {
+	Code string `json:"code"`
+}
+
+// buildServer is the demo MCP server the config.json personas delegate over:
+// web_search (the researcher's `allow`) and run_code (the coder's). It backs
+// the live chat/web surfaces (just chat / just web against config.json). The
+// deterministic golden scenario does NOT use this server — it wires each
+// sub-agent's own FuncSource tools in code (see scenario.go); config.json is
+// the declarative host counterpart to that hand-wired composition.
+func buildServer() *server.Server {
+	srv := server.NewServer(core.ServerInfo{Name: "multi-agent-demo", Version: "0.1.0"})
+	srv.Register(core.TextTool[searchInput]("web_search", "search the web for a query",
+		func(ctx core.ToolContext, in searchInput) (string, error) {
+			return "Go generics (added in 1.18) let functions and types take type parameters.", nil
+		}))
+	srv.Register(core.TextTool[codeInput]("run_code", "compile and run a Go snippet",
+		func(ctx core.ToolContext, in codeInput) (string, error) {
+			return "compiled and ran successfully", nil
+		}))
+	return srv
+}
+
+// serve runs the demo server as a standalone streamable-HTTP MCP server.
+func serve(addr string) error {
+	log.Printf("multi-agent demo server on http://localhost%s/mcp", addr)
+	return buildServer().Run(addr)
+}

--- a/examples/playground/README.md
+++ b/examples/playground/README.md
@@ -9,6 +9,16 @@ SQLite session store, and a filesystem offload dir.
 just pg
 ```
 
+`just pg` is the batteries-included wrapper (sqlite session store + offload
+dir). For the plain config-driven surfaces, this directory also has a justfile
+that runs both surfaces off `playground.json`:
+
+```bash
+just serve   # the demo MCP server (getting-started 'greet') on :8787
+just chat    # agentchat CLI against playground.json (another terminal)
+just web     # agentweb browser surface against playground.json (another terminal)
+```
+
 ## What you need
 
 A local OpenAI-compatible model endpoint. The bundled `playground.json`

--- a/examples/playground/justfile
+++ b/examples/playground/justfile
@@ -1,0 +1,30 @@
+# playground — the interactive agentchat / agentweb surface over playground.json.
+#
+#   just serve   # demo MCP server (getting-started 'greet') on :8787
+#   just chat    # agentchat CLI against playground.json (needs just serve)
+#   just web     # agentweb browser surface against playground.json (needs just serve)
+#
+# `just pg` at the repo root wraps chat with a sqlite session store + offload dir
+# (see scripts/playground.sh); the recipes here are the plain config-driven form.
+
+# Host config both surfaces load.
+CONFIG := justfile_directory() / "playground.json"
+
+# Address the agentweb browser surface listens on.
+ADDR := env_var_or_default("ADDR", ":8090")
+
+# Show available recipes.
+default:
+    @just --list --unsorted
+
+# Serve the demo MCP server (getting-started 'greet') on :8787.
+serve:
+    cd ../getting-started && go run ./server
+
+# Chat with the CLI surface (agentchat) off playground.json (needs just serve).
+chat:
+    cd ../../cmd/agentchat && go run . --config "{{CONFIG}}"
+
+# Serve the browser surface (agentweb) off playground.json (needs just serve).
+web:
+    cd ../../agent/web && go run ./cmd/agentweb --config "{{CONFIG}}" --addr "{{ADDR}}"


### PR DESCRIPTION
Standardizes the `examples/agents/*` (and `examples/playground`) examples on **one host config per example that every surface loads** — the `agentchat` CLI, the `agentweb` browser surface, and the deterministic scripted scenario. Part of epic #1193.

Before, the examples split two ways: `kitchen-sink` / `deep-agent-supervisor` / `playground` already ran `agentchat --config X.json`, while `agent-async` / `multi-agent` / `critic` were `go run .` programs that built a `host.Config` in code. Neither group had a browser surface. Now all of them share the same config file across both surfaces, and the code-driven ones load that file too.

## Recipe surface: before / after

| | before | after |
|---|---|---|
| scripted (no LLM) | `just agent` | `just agent` (now loads `config.json`) |
| live CLI | `just demo` / `agentchat --config` | `just chat` (+ `just demo`) |
| live browser | — | `just web` (agentweb) |
| demo server | ad hoc / separate `server/` | `just serve` (code-driven examples gained a `--serve` mode) |

`chat` + `web` are shared recipes in `common.just`, parameterized by `CONFIG` (default `config.json`) and `ADDR`.

## The config split (code-driven examples)

Each `go run .` example now ships a `config.json` and loads it via `host.LoadConfig`. The part JSON cannot express stays in code and is documented per example:

- **agent-async** — fully config-driven. `runScenario` loads `config.json`, overrides only the server URL to the in-process httptest server, and injects the scripted `StubProvider`. `--serve` boots the same events+tasks server for the live surfaces.
- **critic** — config drives the primary agent + ops server; the **critic loop itself has no `host.Config` seam** (it is code-level composition — the point of the example), so `just chat`/`web` run the primary without the critic. Documented residual.
- **multi-agent** — `config.json` is the **declarative `subAgents`-persona counterpart** to the hand-wired composition; the golden scenario stays hand-wired (per-child scripted stubs + `FuncSource`, not JSON-expressible). `--serve` exposes `web_search`/`run_code` the personas delegate over.

Config filenames for the already-config-driven examples are unchanged (`kitchen-sink.json` is referenced in `agent/host` docs/tests; `deep-agent-supervisor.json` / `playground.json` kept), so those just gained a `web` recipe.

## Verification

- `go build` + `go test` green for all converted examples; the 4 CI `test-agent` example tests pass (`agent-async`, `multi-agent`, `critic`, `deep-agent-supervisor/server`).
- `agentweb --config <example>/config.json` starts and serves for agent-async / critic / multi-agent / playground (TCP-probed the listen port; never `curl GET /mcp`), each with its `--serve` demo server up.
- No example dir added or renamed, so the hardcoded `.github/workflows/test.yml` `test-agent` steps need no change.

## Reviewer's guide

- [examples/agents/common.just](https://github.com/panyam/mcpkit/pull/1215/files#diff-5543bc708c3dba37272e242ee973ab467de19a92b853a751228e0a693f54545f) — the shared `CONFIG`/`ADDR` vars + `chat` (agentchat) and `web` (agentweb) recipes, git-root relative so nesting depth does not matter.
- [examples/agents/agent-async/config.json](https://github.com/panyam/mcpkit/pull/1215/files#diff-900557e345ff652e991c558b1cbfe2f87320619e60151d0ad39394284aa3bc5f) — extracted host config (model/metaTools/server).
- [examples/agents/agent-async/main.go](https://github.com/panyam/mcpkit/pull/1215/files#diff-9ad518f7cd18d865b4799b71cbeb6f84b471ec8065515119710264811136513b) — `--serve`/`--addr` flags to `serve()`.
- [examples/agents/agent-async/scenario.go](https://github.com/panyam/mcpkit/pull/1215/files#diff-70ed30479a0f87cf7827613ac8e2ecafd383a906f87a0bc31ed49c8e196ea829) — `serve()` (standalone MCP server) + `runScenario` now loads `config.json` and overrides the server URL.
- [examples/agents/agent-async/justfile](https://github.com/panyam/mcpkit/pull/1215/files#diff-65ff4d09b8153039e0de946393446ab6eaf225982805993099094fcb6bd938fa) — `serve` recipe.
- [examples/agents/critic/config.json](https://github.com/panyam/mcpkit/pull/1215/files#diff-f594d26f6f08fdafbdff7bb9de89256fb979c2832e19107f331a58d325b49e64) — primary agent + ops server config.
- [examples/agents/critic/main.go](https://github.com/panyam/mcpkit/pull/1215/files#diff-28120e668e54da1b05e3b9dd63b9dee18558330f90b740310a9020479fd1105e) — `--serve` dispatch.
- [examples/agents/critic/scenario.go](https://github.com/panyam/mcpkit/pull/1215/files#diff-8c00809b94e396cddb2f6b4c97193f17265339ed6a44ca0288f2020a5ebdd4af) — `serve()` + `runScenario` loads `config.json`.
- [examples/agents/critic/justfile](https://github.com/panyam/mcpkit/pull/1215/files#diff-c62b0d4b3dbdabb759443d450270775f73780de9b48c0c697973999b4c81c50f) — `serve` recipe.
- [examples/agents/multi-agent/config.json](https://github.com/panyam/mcpkit/pull/1215/files#diff-3705d77a6a2e1e965189b891d96415eea7d0872dbae87168ff78ce2d1c4dd887) — declarative `subAgents` personas.
- [examples/agents/multi-agent/serve.go](https://github.com/panyam/mcpkit/pull/1215/files#diff-3dc86d12d96d9af637c4bc0eb8cbae5e52024592541216941ed6ab7edc976f3c) — demo server (web_search + run_code) + `serve()`.
- [examples/agents/multi-agent/main.go](https://github.com/panyam/mcpkit/pull/1215/files#diff-95129c053b47b4fe7e991d9b8eda593c92ad1fe64e1b4675272edd69418b615f) — `--serve` dispatch.
- [examples/agents/multi-agent/justfile](https://github.com/panyam/mcpkit/pull/1215/files#diff-3c8e5dca7665e4dfd403cb971e450939f592c88e90da713d4e3d788c8aed28d0) — `serve` recipe.
- [examples/agents/multi-agent/go.mod](https://github.com/panyam/mcpkit/pull/1215/files#diff-634146b5ef61b99f9e6e35d8c3b08f9c24c0fea7291569825a5feda776ea0ae4) — `go mod tidy` after importing `server`.
- [examples/agents/deep-agent-supervisor/justfile](https://github.com/panyam/mcpkit/pull/1215/files#diff-2f68b02b74d4f25263697fc16ecdf0a7e04ddc942884170df334554ad09cd33c) — `web` recipe + `chat` alias.
- [examples/agents/kitchen-sink/justfile](https://github.com/panyam/mcpkit/pull/1215/files#diff-3a422c8318128efc4df647fe03696dc28bb009dd7aea7935cc0cfd2ab5d756ef) — `ADDR` var + `web` recipe (config-JSON subset).
- [examples/playground/justfile](https://github.com/panyam/mcpkit/pull/1215/files#diff-e69008167d1e6e611d519ba7670d6ef4a2933b0faf720af1154cc06f409f1c07) — new: `serve`/`chat`/`web` off `playground.json`.
- [examples/agents/README.md](https://github.com/panyam/mcpkit/pull/1215/files#diff-48aaf3162b7cbe4d63be7b22df6248775e24e2a8d7d1962aae148d448b4cb190) — the one-config / shared-surface table.
- [examples/agents/agent-async/README.md](https://github.com/panyam/mcpkit/pull/1215/files#diff-a06dc5909d80dcba2d49246e7ed952ccb6ba2f48abb8359b36ec73c7bf8dea98), [examples/agents/multi-agent/README.md](https://github.com/panyam/mcpkit/pull/1215/files#diff-2b136032ab9f8605a3085359a03423e16cd21961489e0589b4ff7ad4899e6aa8), [examples/agents/critic/README.md](https://github.com/panyam/mcpkit/pull/1215/files#diff-ea36ae16b8103b1197e4660de0af343a178c31d185e367150103b751a792d28a) — per-example config split.
- [examples/agents/deep-agent-supervisor/README.md](https://github.com/panyam/mcpkit/pull/1215/files#diff-0d17321223b8f4f478034db4dd4636000df26a149fe4942acda9b63a9abd787f), [examples/agents/kitchen-sink/README.md](https://github.com/panyam/mcpkit/pull/1215/files#diff-0cd2779408f292df1c83ceb77be3f10cf860d8ad3a06c76c7bce7deabd9cc4ba), [examples/playground/README.md](https://github.com/panyam/mcpkit/pull/1215/files#diff-0036a623f4327e869d5403d97a05b7e08b0b517419276e3cc2ca9b4b0fccb039) — `web` surface note.

