### PR TITLE
fix(audit): scan the whole published module surface with govulncheck

### DIFF
--- a/DEPENDENCY_POLICY.md
+++ b/DEPENDENCY_POLICY.md
@@ -7,12 +7,13 @@ The root module (`core/`, `server/`, `client/`) stays dependency-light. Heavier 
 ## Update cadence
 
 - Dependabot (`.github/dependabot.yml`) opens weekly update PRs for the root module, the `ext/*` sub-modules, and GitHub Actions.
-- Sub-modules not covered by Dependabot are swept manually with `make tidy-all`, which runs whenever `core/` imports change and before every release.
+- Sub-modules not covered by Dependabot are swept manually with `just tidy-all`, which runs whenever `core/` imports change and before every release.
 - Cross-module pins are bumped in lock-step. For example, a `oneauth` bump touches all dependent modules in one PR so CI's module-resolution stays consistent.
 
 ## Security updates
 
-- `make audit` runs govulncheck, gosec, and gitleaks; it runs in CI and before every tagged release.
+- `just audit` runs govulncheck, gosec, and gitleaks. It is a pre-release gate, run before every tagged release, not a per-PR CI job.
+- `just vulncheck` scans the whole published module surface: the root module plus every module in `SUB_MODS_TO_TAG`. This matters because `govulncheck ./...` is module-scoped and does not descend into nested modules, so a root-only scan silently skips every sub-module. Examples are out of scope; they are demos, not modules anyone imports.
 - A vulnerability in a dependency with a fix available is treated at the severity of the vulnerability itself: critical (CVSS 7.0+) within 7 days, others in the next regular release. See `SECURITY.md`.
 
 ## Toolchain

--- a/Makefile
+++ b/Makefile
@@ -290,8 +290,26 @@ lint: ## Run staticcheck (install: go install honnef.co/go/tools/cmd/staticcheck
 # Security audit
 # =============================================================================
 
-vulncheck: ## Check dependencies for known vulnerabilities
-	govulncheck ./...
+# `govulncheck ./...` is module-scoped and does NOT descend into nested modules,
+# so the root scan alone left every published sub-module unscanned. Mirrors the
+# `just vulncheck` recipe; examples stay out of scope.
+vulncheck: ## Check dependencies for known vulnerabilities (root + published sub-modules)
+	@failed=""; \
+	echo "==> govulncheck root"; \
+	govulncheck ./... || failed="$$failed root"; \
+	for mod in $(SUB_MODS_TO_TAG); do \
+		if [ -f "$$mod/go.mod" ]; then \
+			echo ""; \
+			echo "==> govulncheck $$mod"; \
+			(cd $$mod && govulncheck ./...) || failed="$$failed $$mod"; \
+		fi; \
+	done; \
+	echo ""; \
+	if [ -n "$$failed" ]; then \
+		echo "=== govulncheck FAILED in:$$failed ==="; \
+		exit 1; \
+	fi; \
+	echo "=== govulncheck clean: root + published sub-modules ==="
 
 seccheck: ## Run gosec security scanner (install: go install github.com/securego/gosec/v2/cmd/gosec@latest)
 	gosec -quiet -severity=medium ./...

--- a/justfile
+++ b/justfile
@@ -379,9 +379,33 @@ lint:
 # Security audit
 # =============================================================================
 
-# Check dependencies for known vulnerabilities
+# Check dependencies for known vulnerabilities across the published module surface
+# (root + every module in SUB_MODS_TO_TAG).
+#
+# `govulncheck ./...` is module-scoped: `./...` matches packages in the current
+# module only and does NOT descend into nested modules. Scanning just the root
+# therefore left every published sub-module unscanned, ext/auth (the OAuth stack)
+# included. Examples are deliberately out of scope — they are demos, not modules
+# anyone imports.
 vulncheck:
-    govulncheck ./...
+    #!/usr/bin/env bash
+    set -u
+    failed=""
+    echo "==> govulncheck root"
+    govulncheck ./... || failed="$failed root"
+    for mod in {{SUB_MODS_TO_TAG}}; do
+        if [ -f "$mod/go.mod" ]; then
+            echo ""
+            echo "==> govulncheck $mod"
+            (cd "$mod" && govulncheck ./...) || failed="$failed $mod"
+        fi
+    done
+    echo ""
+    if [ -n "$failed" ]; then
+        echo "=== govulncheck FAILED in:$failed ==="
+        exit 1
+    fi
+    echo "=== govulncheck clean: root + $(echo {{SUB_MODS_TO_TAG}} | wc -w | tr -d ' ') sub-modules ==="
 
 # Run gosec security scanner (install: go install github.com/securego/gosec/v2/cmd/gosec@latest)
 seccheck:


### PR DESCRIPTION
## Summary

`govulncheck ./...` is module-scoped. In Go, `./...` matches packages in the current module only and does **not** descend into nested modules. Running it from the repo root therefore scanned the root module and nothing else, leaving all 24 published sub-modules unscanned, `ext/auth` (the OAuth stack) included.

`just vulncheck` / `make vulncheck` now loop over the root plus every module in `SUB_MODS_TO_TAG`, collect per-module failures, and exit non-zero listing them. Examples stay out of scope; they are demos, not modules anyone imports.

## What the fix immediately found

Four advisories reachable from our own code, across six modules, none of which the root-only scan could see:

| Advisory | Module | Found | Fixed in |
|---|---|---|---|
| GO-2025-3540 | `github.com/redis/go-redis/v9` | v9.7.0 | v9.7.3 |
| GO-2026-5970 | `golang.org/x/text` | v0.33.0, v0.37.0 | v0.39.0 |
| GO-2026-6061 | `google.golang.org/grpc` | v1.81.1 | v1.82.1 |
| GO-2026-5004 | `github.com/jackc/pgx/v5` | v5.6.0 | v5.9.2 |

Affected modules: `agent/store/gorm`, `stores/redis`, `experimental/ext/events/stores/gorm`, `experimental/ext/events/stores/redis`, `cmd/agentchat`, `examples/mcpskills-walkthrough`.

`stores/redis` is tagged and published, so v0.4.0 shipped with a reachable go-redis advisory. The dependency bumps are deliberately **not** in this PR: this one fixes the detector, the bumps follow separately so the two are reviewable apart.

## Doc corrections

`DEPENDENCY_POLICY.md` was wrong on two counts, both fixed here:

1. It referenced `make tidy-all` / `make audit` after the justfile migration.
2. It claimed the audit "runs in CI". No workflow in `.github/` invokes `audit`, `vulncheck`, `gosec`, or `gitleaks`. It is a pre-release gate, and the doc now says so.

A new bullet records the module-scoping behaviour so the next reader does not reintroduce a root-only scan.

## Test plan

- [x] `just vulncheck` runs across root + 24 sub-modules and exits 1 with the six failing modules named.
- [x] Clean modules report "No vulnerabilities found" and do not appear in the failure list.
- [x] Recipe is bash 3.2 compatible (macOS default); no bash-4 arrays, `set -u` safe on the empty-failure path.
- [x] `make vulncheck` mirrors the just recipe.

## Follow-ups

- Dependency bumps for the four advisories above.
- Dependabot coverage for the tagged modules and the npm trees (separate PR).
- Consider a scheduled (not per-PR) workflow running `just vulncheck`, so the gap this PR closes cannot silently reopen between releases.
