### PR TITLE
chore(deps): extend Dependabot to the published module surface and npm trees

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,54 @@
 version: 2
+
+# Coverage rule: if we tag and publish it, Dependabot monitors it.
+#
+# The directory globs below track SUB_MODS_TO_TAG (justfile) plus the root
+# module. Everything under examples/ is deliberately excluded: those are demos,
+# not modules anyone imports, and ~60 of them would bury the signal. They are
+# swept by `just tidy-all` and scanned by `just vulncheck`'s published-module
+# loop instead.
 updates:
   - package-ecosystem: gomod
     directories:
       - "/"
-      - "/ext/auth"
-      - "/ext/tasks"
-      - "/ext/ui"
-      - "/ext/otel"
+      - "/agent"
+      - "/agent/host"
+      - "/agent/web"
+      - "/agent/store/*"
+      - "/cmd/*"
+      - "/ext/*"
+      - "/stores/*"
+      - "/experimental/ext/*"
+      - "/experimental/ext/*/clients/go"
+      - "/experimental/ext/*/stores/*"
     schedule:
       interval: weekly
+    # One grouped PR per module per week. With ~24 modules the default limit of
+    # 5 would stall the tail indefinitely; 10 keeps the queue draining without
+    # flooding the PR list.
+    open-pull-requests-limit: 10
     groups:
       go-deps:
         patterns:
           - "*"
+
+  # The Bridge JS in ext/ui/assets ships into end users' browsers, so it is the
+  # one dependency tree here with a direct client-side blast radius. agent/web's
+  # frontend (dockview / solid / connect-web / esbuild) is served from the agent
+  # web surface. Dev-only trees (conformance/, tools/*, ext/ui/tests/playwright,
+  # the example apps) are left out on the same demos-are-not-artifacts rule.
+  - package-ecosystem: npm
+    directories:
+      - "/ext/ui/assets"
+      - "/agent/web/web"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      npm-deps:
+        patterns:
+          - "*"
+
   - package-ecosystem: github-actions
     directory: "/"
     schedule:

--- a/DEPENDENCY_POLICY.md
+++ b/DEPENDENCY_POLICY.md
@@ -6,8 +6,8 @@ The root module (`core/`, `server/`, `client/`) stays dependency-light. Heavier 
 
 ## Update cadence
 
-- Dependabot (`.github/dependabot.yml`) opens weekly update PRs for the root module, the `ext/*` sub-modules, and GitHub Actions.
-- Sub-modules not covered by Dependabot are swept manually with `just tidy-all`, which runs whenever `core/` imports change and before every release.
+- Dependabot (`.github/dependabot.yml`) opens weekly update PRs for the root module, every published library and binary sub-module (`agent/*`, `cmd/*`, `ext/*`, `stores/*`, `experimental/ext/*`), the two shipped npm trees (`ext/ui/assets`, `agent/web/web`), and GitHub Actions.
+- Two categories are deliberately outside Dependabot's scope: modules under `examples/`, which are demos rather than modules anyone imports (~60 of them would bury the signal), and the `tests/*` harnesses, which are tagged only to keep the release tag set consistent. Both are still swept by `just tidy-all` and, more importantly, still scanned by `just vulncheck`, which loops over the full `SUB_MODS_TO_TAG` set. Freshness PRs are scoped to what users consume; vulnerability scanning is not scoped at all.
 - Cross-module pins are bumped in lock-step. For example, a `oneauth` bump touches all dependent modules in one PR so CI's module-resolution stays consistent.
 
 ## Security updates


### PR DESCRIPTION
## Summary

Dependabot covered **5 of 86** Go modules (root plus four `ext/*`), and the line was not drawn where you would expect: `ext/skills` and `stores/redis` are tagged and published but sat outside, while their `ext/*` siblings were inside. That reads as drift rather than a decision. The npm side had **no** coverage at all.

Coverage rule applied here: **if we tag and publish it, Dependabot monitors it.**

Companion to PR 1216, which fixed `govulncheck` to scan the same surface.

## Go coverage

Directory globs now track the published library and binary surface. Resolutions below are the actual expansion against the tree, not the intent:

| Glob | Resolves to |
|---|---|
| `/agent`, `/agent/host`, `/agent/web` | 3 modules |
| `/agent/store/*` | `gorm`, `redis` |
| `/cmd/*` | `agentchat`, `common`, `mcpskills`, `testclient` |
| `/ext/*` | `auth`, `otel`, `skills`, `tasks`, `ui` |
| `/stores/*` | `redis` |
| `/experimental/ext/*` | `agents`, `events`, `protogen` |
| `/experimental/ext/*/clients/go` | `agents`, `events` |
| `/experimental/ext/*/stores/*` | `events/stores/{gorm,memory,redis}` |

22 of the 25 modules in `SUB_MODS_TO_TAG` are covered. The three that are not (`examples/mcpskills-walkthrough`, `tests/e2e`, `tests/keycloak`) are a demo and two test harnesses, tagged to keep the release tag set consistent rather than because anyone imports them.

Everything under `examples/` stays out. Those are demos, and ~60 of them would bury the signal.

**The exclusions are freshness-only.** `just vulncheck` (PR 1216) loops the full `SUB_MODS_TO_TAG` set, so every tagged module is still scanned for known vulnerabilities. Freshness PRs are scoped to what users consume; vulnerability scanning is not scoped at all.

## npm coverage

Two trees added:

- **`ext/ui/assets`** — the Bridge JS that ships into end users' browsers, the only dependency tree in the repo with a direct client-side blast radius.
- **`agent/web/web`** — dockview / solid / connect-web / esbuild, served from the agent web surface.

Dev-only trees (`conformance/`, `tools/*`, `ext/ui/tests/playwright`, the example apps) are left out on the same demos-are-not-artifacts rule.

## Noise control

`open-pull-requests-limit: 10` for gomod. Each directory produces one grouped PR per week; with ~22 directories the default limit of 5 would stall the tail indefinitely.

## Test plan

- [x] Every glob resolved against the tree; the table above is the actual resolution.
- [x] Both npm directories confirmed to contain a `package.json`.
- [x] Coverage diffed programmatically against `SUB_MODS_TO_TAG`; the three uncovered modules are named above rather than glossed.
- [x] YAML is tab-free and structurally valid.

Supersedes PR 1217, which GitHub auto-closed when its base branch was deleted on 1216's merge; this branch is the same work rebased onto `main`.
