### PR TITLE
ci: repo-wide dependency sweep, consistency gate, Dependabot rescope

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,37 +1,21 @@
 version: 2
 
-# Coverage rule: if we tag and publish it, Dependabot monitors it.
+# Go modules are deliberately NOT listed here. Dependabot opens one PR per
+# directory and cannot touch modules outside its globs, but ~60 modules under
+# examples/ and tests/ depend on the published ones through `replace`
+# directives. So every grouped gomod PR left their go.mod stale and broke
+# test-agent and test-auth with "updates to go.mod needed" (PR 1225: a
+# 9-directory bump needed 57 further modules tidied in lock-step).
 #
-# The directory globs below track SUB_MODS_TO_TAG (justfile) plus the root
-# module. Everything under examples/ is deliberately excluded: those are demos,
-# not modules anyone imports, and ~60 of them would bury the signal. They are
-# swept by `just tidy-all` and scanned by `just vulncheck`'s published-module
-# loop instead.
+# DEPENDENCY_POLICY.md requires lock-step pins, which per-directory PRs cannot
+# deliver. Go updates are owned by .github/workflows/dep-sweep.yml, which
+# updates every module and reconciles the whole tree in one PR.
+#
+# Two things still cover the gap between monthly sweeps:
+#   - Dependabot SECURITY updates, a repository setting independent of this
+#     file, still open CVE PRs immediately.
+#   - .github/workflows/vulncheck.yml scans the published surface weekly.
 updates:
-  - package-ecosystem: gomod
-    directories:
-      - "/"
-      - "/agent"
-      - "/agent/host"
-      - "/agent/web"
-      - "/agent/store/*"
-      - "/cmd/*"
-      - "/ext/*"
-      - "/stores/*"
-      - "/experimental/ext/*"
-      - "/experimental/ext/*/clients/go"
-      - "/experimental/ext/*/stores/*"
-    schedule:
-      interval: weekly
-    # One grouped PR per module per week. With ~24 modules the default limit of
-    # 5 would stall the tail indefinitely; 10 keeps the queue draining without
-    # flooding the PR list.
-    open-pull-requests-limit: 10
-    groups:
-      go-deps:
-        patterns:
-          - "*"
-
   # The Bridge JS in ext/ui/assets ships into end users' browsers, so it is the
   # one dependency tree here with a direct client-side blast radius. agent/web's
   # frontend (dockview / solid / connect-web / esbuild) is served from the agent

--- a/.github/workflows/dep-sweep.yml
+++ b/.github/workflows/dep-sweep.yml
@@ -1,0 +1,117 @@
+name: Dependency Sweep
+
+# Monthly repo-wide dependency update, opened as ONE pull request.
+#
+# This replaces per-directory Dependabot gomod PRs. Dependabot cannot reach
+# examples/ or tests/, but those modules depend on the published ones through
+# `replace` directives, so every grouped Dependabot bump left their go.mod stale
+# and broke test-agent and test-auth with "updates to go.mod needed". PR 1225 is
+# the worked example: a 9-directory bump needed 57 further modules tidied in
+# lock-step. Only a sweep that sees the whole tree can do that.
+#
+# Monthly rather than weekly because a minor-level sweep across 88 modules
+# produces a PR that deserves real review attention. Security-driven updates do
+# not wait for this: Dependabot security updates (a repository setting, separate
+# from dependabot.yml) still open PRs immediately, and vulncheck.yml scans
+# weekly.
+on:
+  schedule:
+    # 1st of the month, 05:00 UTC.
+    - cron: '0 5 1 * *'
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'Update aggressiveness'
+        type: choice
+        default: minor
+        options: [minor, patch]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+
+      - uses: extractions/setup-just@v4
+
+      # MODE goes through env rather than being interpolated into the run: line.
+      # `choice` already constrains it to minor|patch, but keeping dispatch input
+      # out of the shell string is the cheap, unconditional habit.
+      - name: Sweep
+        id: sweep
+        env:
+          MODE: ${{ inputs.mode || 'minor' }}
+        run: bash scripts/dep-sweep.sh "$MODE"
+
+      - name: Check for changes
+        id: diff
+        run: |
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            git diff --stat | tail -1 >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      # The sweep runs the suites itself. A PR opened with GITHUB_TOKEN does not
+      # trigger workflows, so the sweep PR would otherwise carry no signal at
+      # all. Results are captured here and reported in the PR body. Non-fatal:
+      # a failing sweep is still worth surfacing, it just opens as a draft.
+      - name: Test
+        id: test
+        if: steps.diff.outputs.changed == 'true'
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          just check-dep-consistency 2>&1 | tee -a result.log
+          just test               2>&1 | tee -a result.log
+          just test-agent         2>&1 | tee -a result.log
+          just test-auth          2>&1 | tee -a result.log
+          just test-ui            2>&1 | tee -a result.log
+
+      - name: Open pull request
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MODE: ${{ inputs.mode || 'minor' }}
+          PASSED: ${{ steps.test.outcome == 'success' }}
+        run: |
+          branch="deps/sweep-$(date -u +%Y-%m)"
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
+          git add -A
+          git commit -m "build(deps): monthly dependency sweep ($MODE)"
+          git push -f origin "$branch"
+
+          if [ "$PASSED" = "true" ]; then
+            status="All suites passed in the sweep job."
+            draft=""
+          else
+            status="**Suites failed in the sweep job.** Opened as a draft; see the log tail below."
+            draft="--draft"
+          fi
+
+          {
+            echo "Automated monthly sweep (\`$MODE\`) across every Go module, reconciled with \`just tidy-all\`."
+            echo
+            echo "$status"
+            echo
+            echo "Checks are not attached: GitHub does not trigger workflows for pull requests opened with \`GITHUB_TOKEN\`, so the sweep job runs the suites itself. Push an empty commit to this branch to get normal CI."
+            echo
+            echo '```'
+            tail -c 6000 result.log 2>/dev/null || echo "(no test output)"
+            echo '```'
+          } > body.md
+
+          gh pr create --base main --head "$branch" $draft \
+            --title "build(deps): monthly dependency sweep ($MODE)" \
+            --body-file body.md

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,13 @@ jobs:
       - name: Vet
         run: go vet ./...
 
+      # Catches a split third-party pin on the PR that introduces it. MVS
+      # resolves to the maximum required version, so divergence otherwise
+      # surfaces later as an unexplained failure in an unrelated module.
+      # Stdlib-only Python, so this needs no uv step in the repo's fastest job.
+      - name: Check dependency consistency
+        run: python3 scripts/check_dep_consistency.py
+
       - name: Start test server
         run: |
           STREAMABLE=1 PORT=18799 go run ./cmd/testserver &

--- a/DEPENDENCY_POLICY.md
+++ b/DEPENDENCY_POLICY.md
@@ -6,13 +6,20 @@ The root module (`core/`, `server/`, `client/`) stays dependency-light. Heavier 
 
 ## Update cadence
 
-- Dependabot (`.github/dependabot.yml`) opens weekly update PRs for the root module, every published library and binary sub-module (`agent/*`, `cmd/*`, `ext/*`, `stores/*`, `experimental/ext/*`), the two shipped npm trees (`ext/ui/assets`, `agent/web/web`), and GitHub Actions.
-- Two categories are deliberately outside Dependabot's scope: modules under `examples/`, which are demos rather than modules anyone imports (~60 of them would bury the signal), and the `tests/*` harnesses, which are tagged only to keep the release tag set consistent. Both are still swept by `just tidy-all` and, more importantly, still scanned by `just vulncheck`, which loops over the full `SUB_MODS_TO_TAG` set. Freshness PRs are scoped to what users consume; vulnerability scanning is not scoped at all.
-- Cross-module pins are bumped in lock-step. For example, a `oneauth` bump touches all dependent modules in one PR so CI's module-resolution stays consistent.
+**Go modules are updated by a repo-wide sweep, not per-directory.** `.github/workflows/dep-sweep.yml` runs monthly (and on demand), updates every module via `scripts/dep-sweep.sh`, reconciles the tree with `just tidy-all`, runs the suites, and opens one pull request. Run it locally with `just dep-sweep [patch|minor]`.
+
+The sweep exists because per-directory updates cannot satisfy the lock-step rule below. Dependabot opens one PR per directory and cannot touch modules outside its globs, but the ~60 modules under `examples/` and `tests/` depend on the published ones through `replace` directives. A grouped Dependabot bump therefore left their `go.mod` stale and broke `test-agent` and `test-auth` with `updates to go.mod needed`. The worked example is PR 1225, where a 9-directory bump required 57 further modules to be tidied in lock-step.
+
+- **Cross-module pins are bumped in lock-step.** A `oneauth` bump touches all dependent modules in one PR so module resolution stays consistent. This is enforced, not just documented: `just check-dep-consistency` fails CI when a third-party dependency is pinned at two or more versions across the published modules. Known-and-accepted divergence lives in `scripts/dep-baseline.json`; regenerate with `just update-dep-baseline`.
+- **Dependabot still owns the single-directory trees** where per-directory PRs are the correct shape: the two shipped npm trees (`ext/ui/assets`, `agent/web/web`) and GitHub Actions.
 
 ## Security updates
 
-- `just audit` runs govulncheck, gosec, and gitleaks. It is a pre-release gate, run before every tagged release, not a per-PR CI job.
+Security fixes do not wait for the monthly sweep:
+
+- **Dependabot security updates** are a repository setting, independent of `.github/dependabot.yml`, and still open CVE pull requests immediately.
+- **`.github/workflows/vulncheck.yml`** scans the published surface weekly, plus on every release tag. It is time-triggered rather than tied to pushes because the advisory database moves independently of this repository: a CVE published after your last commit affects code that has not changed.
+- `just audit` runs govulncheck, gosec, and gitleaks. It is a pre-release gate, not a per-PR CI job.
 - `just vulncheck` scans the whole published module surface: the root module plus every module in `SUB_MODS_TO_TAG`. This matters because `govulncheck ./...` is module-scoped and does not descend into nested modules, so a root-only scan silently skips every sub-module. Examples are out of scope; they are demos, not modules anyone imports.
 - A vulnerability in a dependency with a fix available is treated at the severity of the vulnerability itself: critical (CVSS 7.0+) within 7 days, others in the next regular release. See `SECURITY.md`.
 

--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,15 @@ check-conformance-stale: check-local-suites-stale ## Fail if CONFORMANCE.md is s
 check-local-suites-stale: ## CI gate — fail if conformance/local-suites.yaml drifts from the Makefile (cases A/B/C)
 	uv run scripts/check_local_suites.py
 
+check-dep-consistency: ## CI gate — fail if a third-party dep is pinned at 2+ versions across published modules
+	python3 scripts/check_dep_consistency.py
+
+update-dep-baseline: ## Accept the current dependency divergence as the new baseline
+	python3 scripts/check_dep_consistency.py --update-baseline
+
+dep-sweep: ## Repo-wide dependency sweep (usage: make dep-sweep MODE=patch|minor); see scripts/dep-sweep.sh
+	bash scripts/dep-sweep.sh $(or $(MODE),minor)
+
 check-snippets: ## CI gate — fail if docs/GETTING_STARTED.md Go snippets drift from examples/getting-started/ (issue 853)
 	go run ./tools/check-snippets
 
@@ -444,5 +453,5 @@ setup: setup-tools setup-hooks ## Full development setup
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-18s\033[0m %s\n", $$1, $$2}'
 
-.PHONY: build test test-examples test-race test-v cover cover-html cover-func cover-all test-auth test-ui test-skills test-mcpskills build-mcpskills test-mcpskills-walkthrough test-protogen test-e2e test-experimental test-apps-playwright test-apps-playwright-docker test-apps-playwright-all test-apps-playwright-docker-all refresh-visual-gallery release-audit-apps demo-app demo-upstream testkcl testkcl-auto testall test-report smoke smoke-wire verify-dual testconfall testconf testconfauth testconf-client testconf-tasks testconf-tasks-v2 testconf-mrtr testconf-file-inputs testconf-auth-server testconf-elicitation testconf-skills testconf-external-checker refresh-conformance check-conformance-stale check-local-suites-stale check-snippets check-auth-markers refresh-apps-compat-report check-apps-compat-stale vet lint vulncheck seccheck secrets verify-submodule-deps audit ci ci-full serve serve-streamable serve-both tidy tidy-all bump-root collect-walkthroughs ghbuild ghserve ghdeploy tag tag-push setup-tools setup-hooks setup upkcl downkcl kcllogs build-bridge help
+.PHONY: build test test-examples test-race test-v cover cover-html cover-func cover-all test-auth test-ui test-skills test-mcpskills build-mcpskills test-mcpskills-walkthrough test-protogen test-e2e test-experimental test-apps-playwright test-apps-playwright-docker test-apps-playwright-all test-apps-playwright-docker-all refresh-visual-gallery release-audit-apps demo-app demo-upstream testkcl testkcl-auto testall test-report smoke smoke-wire verify-dual testconfall testconf testconfauth testconf-client testconf-tasks testconf-tasks-v2 testconf-mrtr testconf-file-inputs testconf-auth-server testconf-elicitation testconf-skills testconf-external-checker refresh-conformance check-conformance-stale check-local-suites-stale check-snippets check-dep-consistency update-dep-baseline dep-sweep check-auth-markers refresh-apps-compat-report check-apps-compat-stale vet lint vulncheck seccheck secrets verify-submodule-deps audit ci ci-full serve serve-streamable serve-both tidy tidy-all bump-root collect-walkthroughs ghbuild ghserve ghdeploy tag tag-push setup-tools setup-hooks setup upkcl downkcl kcllogs build-bridge help
 .DEFAULT_GOAL := help

--- a/justfile
+++ b/justfile
@@ -170,6 +170,18 @@ check-conformance-stale: check-local-suites-stale
 check-local-suites-stale:
     uv run scripts/check_local_suites.py
 
+# CI gate — fail if a third-party dep is pinned at 2+ versions across published modules
+check-dep-consistency:
+    python3 scripts/check_dep_consistency.py
+
+# Accept the current dependency divergence as the new baseline
+update-dep-baseline:
+    python3 scripts/check_dep_consistency.py --update-baseline
+
+# Repo-wide dependency sweep (usage: just dep-sweep [patch|minor]); see scripts/dep-sweep.sh
+dep-sweep MODE="minor":
+    bash scripts/dep-sweep.sh {{MODE}}
+
 # CI gate — fail if docs/GETTING_STARTED.md Go snippets drift from examples/getting-started/ (issue 853)
 check-snippets:
     go run ./tools/check-snippets

--- a/scripts/check_dep_consistency.py
+++ b/scripts/check_dep_consistency.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Fail when a third-party dependency is pinned at more than one version across
+the published Go modules (root + SUB_MODS_TO_TAG).
+
+Why this exists
+---------------
+The repo requires lock-step pins (DEPENDENCY_POLICY.md). Divergence is not a
+style problem: 81 of 88 modules use local `replace` directives, so intra-repo
+deps resolve locally while third-party ones resolve through MVS. MVS takes the
+*maximum* required version across the graph, so a bump in one module silently
+raises the version its siblings build against. If that bump is API-breaking, the
+sibling's code breaks without its go.mod ever changing.
+
+This runs in per-PR CI so divergence is caught on the PR that introduces it,
+rather than weeks later as an unexplained failure in an unrelated module.
+
+Scope
+-----
+Published modules only. `examples/` and `tests/` are excluded on the same rule
+as .github/dependabot.yml: they are demos and harnesses, not modules anyone
+imports. They are still swept by `just tidy-all` and scanned by `just vulncheck`.
+
+mcpkit's own modules are skipped: they resolve via `replace`, so their recorded
+versions are v0.0.0 pseudo-versions that differ legitimately.
+
+Stdlib only, on purpose. This runs in the `test` job, which is the fastest job
+in the matrix and has no Python tooling set up; keeping it dependency-free means
+it needs no uv step.
+
+Usage
+-----
+    python3 scripts/check_dep_consistency.py
+    python3 scripts/check_dep_consistency.py --update-baseline
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import os
+import re
+import subprocess
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BASELINE = os.path.join(REPO_ROOT, "scripts", "dep-baseline.json")
+INTERNAL_PREFIX = "github.com/panyam/mcpkit"
+
+REQUIRE_RE = re.compile(r"^\s+(\S+)\s+(v\S+)")
+SUB_MODS_RE = re.compile(r'SUB_MODS_TO_TAG := "([^"]+)"')
+
+
+def published_modules() -> list[str]:
+    """Root plus every module in the justfile's SUB_MODS_TO_TAG.
+
+    Sourced from the justfile rather than duplicated here so the release tag set
+    and the consistency gate cannot drift apart.
+    """
+    with open(os.path.join(REPO_ROOT, "justfile")) as fh:
+        match = SUB_MODS_RE.search(fh.read())
+    if not match:
+        sys.exit("check_dep_consistency: SUB_MODS_TO_TAG not found in justfile")
+    mods = ["."] + match.group(1).split()
+    return [m for m in mods if os.path.exists(os.path.join(REPO_ROOT, m, "go.mod"))]
+
+
+def collect(mods: list[str]) -> dict[str, dict[str, list[str]]]:
+    versions: dict[str, dict[str, list[str]]] = collections.defaultdict(
+        lambda: collections.defaultdict(list)
+    )
+    for mod in mods:
+        with open(os.path.join(REPO_ROOT, mod, "go.mod")) as fh:
+            for line in fh:
+                stripped = line.strip()
+                if stripped.startswith("//"):
+                    continue
+                match = REQUIRE_RE.match(line)
+                if not match:
+                    continue
+                dep, ver = match.group(1), match.group(2)
+                if dep.startswith(INTERNAL_PREFIX):
+                    continue
+                versions[dep][ver].append(mod)
+    return versions
+
+
+def divergent(versions) -> dict[str, dict[str, list[str]]]:
+    return {d: dict(v) for d, v in versions.items() if len(v) > 1}
+
+
+def all_modules() -> list[str]:
+    """Every module in the tree, published or not.
+
+    Unification runs over all of them: an example left on an older pin still
+    gets silently upgraded by MVS, which is the surprise we are removing.
+    """
+    mods = []
+    for root, dirs, files in os.walk(REPO_ROOT):
+        dirs[:] = [d for d in dirs if d not in ("node_modules", ".git", ".claude")]
+        if "go.mod" in files:
+            mods.append(os.path.relpath(root, REPO_ROOT))
+    return sorted(mods)
+
+
+def semver_key(ver: str):
+    """Ordering key for a Go module version.
+
+    Handles releases, prereleases, and pseudo-versions. A release sorts above a
+    prerelease of the same M.m.p, which is what semver requires and what makes
+    `max()` pick the version MVS would actually resolve to.
+    """
+    body = ver.lstrip("v")
+    pre = ""
+    if "-" in body:
+        body, pre = body.split("-", 1)
+    nums = [int(x) for x in re.findall(r"\d+", body)[:3]]
+    while len(nums) < 3:
+        nums.append(0)
+    return (nums[0], nums[1], nums[2], 0 if pre else 1, pre)
+
+
+def unify(baseline: dict[str, list[str]]) -> int:
+    """Raise every lagging module to the maximum version already in the tree.
+
+    This is the lock-step half of the sweep. `go get -u` runs per module against
+    that module's own graph, so it routinely lands modules on different patch
+    levels and *introduces* divergence. Unification is what turns a pile of
+    independent updates into one consistent tree.
+
+    Baselined deps are skipped: their divergence is deliberate.
+    """
+    mods = all_modules()
+    versions = collect(mods)
+    fixed = 0
+
+    for dep, vers in sorted(versions.items()):
+        if len(vers) < 2 or dep in baseline:
+            continue
+        target = max(vers, key=semver_key)
+        for ver, owners in sorted(vers.items()):
+            if ver == target:
+                continue
+            for mod in sorted(owners):
+                print(f"==> {mod}: {dep} {ver} -> {target}")
+                proc = subprocess.run(
+                    ["go", "get", f"{dep}@{target}"],
+                    cwd=os.path.join(REPO_ROOT, mod),
+                    capture_output=True,
+                    text=True,
+                )
+                if proc.returncode != 0:
+                    print(f"    FAILED: {proc.stderr.strip()[:300]}")
+                else:
+                    fixed += 1
+
+    print(f"\nunified {fixed} module/dependency pairs across {len(mods)} modules")
+    return 0
+
+
+def load_baseline() -> dict[str, list[str]]:
+    if not os.path.exists(BASELINE):
+        return {}
+    with open(BASELINE) as fh:
+        return json.load(fh).get("allowed", {})
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--update-baseline",
+        action="store_true",
+        help="rewrite the baseline to accept current divergence",
+    )
+    parser.add_argument(
+        "--unify",
+        action="store_true",
+        help="raise every lagging module to the max version already in the tree",
+    )
+    parser.add_argument(
+        "--prune-baseline",
+        action="store_true",
+        help="drop baseline entries that are no longer divergent (never adds)",
+    )
+    args = parser.parse_args()
+
+    if args.unify:
+        return unify(load_baseline())
+
+    mods = published_modules()
+    found = divergent(collect(mods))
+
+    # A one-way ratchet for the sweep: entries whose divergence is gone are
+    # removed, but nothing new is ever accepted. Auto-accepting would let the
+    # sweep silently baseline divergence it failed to unify, which is exactly
+    # the thing the gate exists to surface.
+    if args.prune_baseline:
+        baseline = load_baseline()
+        kept = {d: v for d, v in baseline.items() if d in found}
+        dropped = sorted(set(baseline) - set(kept))
+        payload = {
+            "_comment": (
+                "Known dependency-version divergence across published modules. "
+                "This should shrink to empty as the monthly sweep unifies pins; "
+                "regenerate with: just update-dep-baseline"
+            ),
+            "allowed": {d: sorted(v) for d, v in sorted(kept.items())},
+        }
+        with open(BASELINE, "w") as fh:
+            json.dump(payload, fh, indent=2)
+            fh.write("\n")
+        print(f"baseline pruned: dropped {len(dropped)}, {len(kept)} remain")
+        for dep in dropped:
+            print(f"  dropped {dep}")
+        return 0
+
+    if args.update_baseline:
+        payload = {
+            "_comment": (
+                "Known dependency-version divergence across published modules. "
+                "This should shrink to empty as the monthly sweep unifies pins; "
+                "regenerate with: just update-dep-baseline"
+            ),
+            "allowed": {d: sorted(v) for d, v in sorted(found.items())},
+        }
+        with open(BASELINE, "w") as fh:
+            json.dump(payload, fh, indent=2)
+            fh.write("\n")
+        print(f"baseline updated: {len(found)} accepted divergences")
+        return 0
+
+    baseline = load_baseline()
+    new, stale = {}, []
+
+    for dep, vers in found.items():
+        if sorted(vers) != sorted(baseline.get(dep, [])):
+            new[dep] = vers
+    for dep in baseline:
+        if dep not in found:
+            stale.append(dep)
+
+    print(f"scanned {len(mods)} published modules")
+    print(f"divergent third-party deps: {len(found)} ({len(baseline)} baselined)")
+
+    if new:
+        print("\nFAIL: dependency versions diverge across published modules.\n")
+        for dep, vers in sorted(new.items()):
+            print(f"  {dep}")
+            for ver, owners in sorted(vers.items()):
+                shown = ", ".join(sorted(owners)[:4])
+                more = f" (+{len(owners) - 4} more)" if len(owners) > 4 else ""
+                print(f"      {ver}: {shown}{more}")
+        print(
+            "\nMVS resolves third-party deps to the maximum required version, so a\n"
+            "split pin means some modules silently build against a version their\n"
+            "go.mod does not name. Unify them, or run `just update-dep-baseline`\n"
+            "if the divergence is deliberate."
+        )
+        return 1
+
+    if stale:
+        print("\nFAIL: baseline lists divergence that no longer exists:")
+        for dep in sorted(stale):
+            print(f"  {dep}")
+        print("\nRun `just update-dep-baseline` to drop the stale entries.")
+        return 1
+
+    print("OK: no unexpected divergence.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dep-baseline.json
+++ b/scripts/dep-baseline.json
@@ -1,0 +1,25 @@
+{
+  "_comment": "Known dependency-version divergence across published modules. This should shrink to empty as the monthly sweep unifies pins; regenerate with: just update-dep-baseline",
+  "allowed": {
+    "github.com/charmbracelet/lipgloss": [
+      "v1.1.0",
+      "v1.1.1-0.20250404203927-76690c660834"
+    ],
+    "github.com/panyam/gocurrent": [
+      "v0.1.1",
+      "v0.1.2"
+    ],
+    "github.com/panyam/goutils": [
+      "v0.1.13",
+      "v0.1.8"
+    ],
+    "github.com/spf13/pflag": [
+      "v1.0.10",
+      "v1.0.9"
+    ],
+    "golang.org/x/sys": [
+      "v0.45.0",
+      "v0.47.0"
+    ]
+  }
+}

--- a/scripts/dep-sweep.sh
+++ b/scripts/dep-sweep.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Repo-wide dependency sweep: update every Go module, then reconcile the whole
+# tree in one commit.
+#
+# Why this exists rather than per-directory Dependabot PRs
+# --------------------------------------------------------
+# Dependabot opens one PR per directory and cannot touch modules outside its
+# configured globs. This repo excludes examples/ and tests/ from that config,
+# but those modules depend on the published ones through `replace` directives,
+# so a Dependabot bump leaves their go.mod stale and CI fails with
+# "updates to go.mod needed". Observed on PR 1225: a 9-directory bump required
+# 57 further modules to be tidied in lock-step.
+#
+# DEPENDENCY_POLICY.md requires lock-step pins for exactly this reason. Only a
+# sweep that sees every module at once can deliver that.
+#
+# Usage:
+#   scripts/dep-sweep.sh [patch|minor]
+#
+#   patch  — go get -u=patch, low risk, no minor-version churn
+#   minor  — go get -u, the real sweep (default)
+set -euo pipefail
+
+MODE="${1:-minor}"
+case "$MODE" in
+    patch) FLAG="-u=patch" ;;
+    minor) FLAG="-u" ;;
+    *) echo "dep-sweep: mode must be 'patch' or 'minor', got '$MODE'" >&2; exit 2 ;;
+esac
+
+cd "$(dirname "$0")/.."
+
+# Every module, not just the published surface: the whole point is that the
+# excluded ones are what go stale.
+mods="$(find . -name go.mod -not -path '*/node_modules/*' -not -path '*/.claude/*' \
+    | sed 's|^\./||;s|/go.mod$||' | sort)"
+
+failed=""
+count=0
+for mod in $mods; do
+    [ "$mod" = "go.mod" ] && mod="."
+    count=$((count + 1))
+    echo "==> go get $FLAG $mod"
+    # A module that cannot resolve is recorded and the sweep continues; one bad
+    # module should not hide updates for the other 87.
+    (cd "$mod" && go get $FLAG ./...) || failed="$failed $mod"
+done
+
+# `go get -u` runs per module against that module's own graph, so it routinely
+# lands modules on different patch levels and INTRODUCES divergence. Unification
+# is what turns a pile of independent updates into one consistent tree, and it
+# is the whole reason this is a sweep rather than N per-directory bumps.
+echo ""
+echo "==> unify divergent pins to the maximum already in the tree"
+python3 scripts/check_dep_consistency.py --unify
+
+echo ""
+echo "==> tidy-all (reconciles every module, including the ones Dependabot cannot reach)"
+just tidy-all
+
+# One-way ratchet: drop baseline entries the sweep just resolved, never add.
+echo ""
+echo "==> prune the divergence baseline"
+python3 scripts/check_dep_consistency.py --prune-baseline
+
+echo ""
+if [ -n "$failed" ]; then
+    echo "=== sweep completed with failures in:$failed ==="
+    echo "The tree is still tidied; review the listed modules by hand."
+    exit 1
+fi
+echo "=== sweep clean across $count modules (mode: $MODE) ==="


### PR DESCRIPTION
## What changes

Replaces per-directory Dependabot gomod PRs with a monthly repo-wide sweep that updates every module and reconciles the whole tree in one PR, plus a per-PR gate that catches split pins the day they appear.

## Why

Dependabot opens one PR per directory and cannot touch modules outside its globs. But ~60 modules under `examples/` and `tests/` depend on the published ones through `replace` directives, so every grouped gomod PR left their `go.mod` stale and failed `test-agent` and `test-auth` with `updates to go.mod needed`.

PR 1225 is the worked case: a **9-directory bump required 57 further modules** to be tidied in lock-step. `DEPENDENCY_POLICY.md` has always required lock-step pins. Per-directory PRs structurally cannot deliver that.

## Reviewer's guide

1. [scripts/check_dep_consistency.py](https://github.com/panyam/mcpkit/pull/1227/files#diff-ce26e261d9b42135df2b60793d89002389f2189722774acdbbf79d7067d9397d) — start here. The gate, plus `--unify` and `--prune-baseline`. The module docstring carries the MVS rationale.
2. [scripts/dep-sweep.sh](https://github.com/panyam/mcpkit/pull/1227/files#diff-cb4f9e18610b053b1917e44073ed7067d09ab673a942102be67e04f4dcdee5c5) — update, unify, tidy, prune. The ordering is the design.
3. [.github/workflows/dep-sweep.yml](https://github.com/panyam/mcpkit/pull/1227/files#diff-90ac1c17baa508d2a7e331ceb7b9b67abf8bf7d197a42c01bfe9edacd0015e33) — monthly schedule and the PR-opening step.
4. [.github/dependabot.yml](https://github.com/panyam/mcpkit/pull/1227/files#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28) — gomod block removed, npm and actions retained.
5. [.github/workflows/test.yml](https://github.com/panyam/mcpkit/pull/1227/files#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88) — one step added to the `test` job.
6. [DEPENDENCY_POLICY.md](https://github.com/panyam/mcpkit/pull/1227/files#diff-74eb2623aa815edb7cd6f6b685c634d16fcf5ccef9658eed6a0ff33b4fc66d3c) — the policy now describes what the tooling does.

Skim: [justfile](https://github.com/panyam/mcpkit/pull/1227/files#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1), [Makefile](https://github.com/panyam/mcpkit/pull/1227/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52) (recipe parity), [scripts/dep-baseline.json](https://github.com/panyam/mcpkit/pull/1227/files#diff-290a8606b11d5405cfc5bc8f351c191998a0ad2cef3662b2a1ab553a22487d82) (generated).

## How it works

```
sweep(mode):
  for each of 88 modules:  go get -u[=patch] ./...     # per-module, independent
  unify():                                             # <- the load-bearing step
      for each third-party dep pinned at 2+ versions, not baselined:
          target = max(versions)                       # semver-aware, release > prerelease
          for each lagging module: go get dep@target
  just tidy-all                                        # reconciles all 88, incl. Dependabot's blind spot
  prune_baseline()                                     # drop resolved entries; never add
```

## Decision log

**The unify pass is load-bearing, and testing is what found it.** `go get -u` runs per module against that module's own graph, so it lands modules on different patch levels and *introduces* divergence. My first version had no unify step and **failed its own consistency gate**:

```
FAIL: dependency versions diverge across published modules.
  github.com/go-logr/logr      v1.4.3: ext/auth   v1.4.4: cmd/agentchat, ext/otel
  github.com/mattn/go-sqlite3  v1.14.22: agent/store/gorm   v1.14.49: cmd/agentchat
  github.com/yuin/gopher-lua   v1.1.1: agent/store/redis    v1.1.2: stores/redis
  golang.org/x/sync            v0.21.0: agent/store/gorm    v0.22.0: examples/...
```

A sweep without unification is just N independent bumps in one commit.

**Baseline pruning is a one-way ratchet.** The sweep drops entries whose divergence it resolved but never accepts new ones. Auto-accepting would let the sweep silently baseline divergence it failed to unify, which is precisely what the gate exists to surface.

**Stdlib-only Python.** The gate runs in the `test` job, the fastest in the matrix. No `uv` step needed.

**Gate scope is published modules only**, matching the line drawn in 1218. `examples/` and `tests/` are still unified and tidied by the sweep; they just do not gate PRs.

**Dependabot keeps npm and github-actions.** Single-directory trees are exactly where per-directory PRs are the right shape. Security updates are a repository setting, unaffected by this file, so CVE PRs still arrive immediately, and `vulncheck.yml` still scans weekly.

## Before / after

Baseline divergence across the 26 published modules, as the sweep ratchets it down:

```
main today                    5 divergent deps  (baselined)
after a real patch sweep      4 NEW divergences introduced by per-module go get -u
after unify (10 pairs fixed)  2 divergent deps
```

Gate behaviour, verified both directions:

```
$ python3 scripts/check_dep_consistency.py          # clean tree
scanned 26 published modules
divergent third-party deps: 5 (5 baselined)
OK: no unexpected divergence.                        exit 0

$ # after pinning x/text to v0.30.0 in ext/skills
FAIL: dependency versions diverge across published modules.
  golang.org/x/text
      v0.30.0: ext/skills
      v0.39.0: ., agent, agent/host, agent/store/gorm (+19 more)
                                                     exit 1
```

## Risk / blast radius

- The gate runs on every PR. A false positive blocks merges, so it ships with a baseline of the 5 divergences that exist today, and `just update-dep-baseline` is the escape hatch.
- The sweep workflow has never run on schedule. It was exercised end to end locally (`just dep-sweep patch` across all 88 modules), but the PR-opening step is only reachable in CI. Trigger it once via `workflow_dispatch` after merge to confirm.
- `MODE` reaches the sweep through `env:`, not interpolated into the `run:` line. `choice` already constrains it; this is defence in depth.
- **PRs opened with `GITHUB_TOKEN` do not trigger workflows**, so the sweep runs the suites itself and reports results in the PR body. A failing sweep opens as a draft rather than not opening at all.

## Test plan

- [x] `just dep-sweep patch` across all 88 modules, exit 0
- [x] Unify resolved 10 module/dependency pairs on the tree the sweep produced
- [x] Gate green after unify + tidy + prune
- [x] Gate fails on introduced divergence (exit 1) and passes when reverted (exit 0)
- [x] Stale-baseline detection fires and `--prune-baseline` clears it
- [x] `just test` green with the new CI step
- [x] All three YAML files tab-free and structurally valid; `bash -n` on the sweep script
- [x] `just` and `make` recipe parity

Assertions added: 0. Assertions removed or weakened: 0. No existing test files are touched.

## Out of scope

- Clearing the remaining 5 baselined divergences. The first real sweep should shrink it; forcing them now bundles dependency risk into a tooling PR.
- Pre-push hook module coverage (noted in PR 1224).

