### PR TITLE
docs: argument completion guide + the repo's first Example functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ just/make test-apps-playwright  # ext-apps Playwright suite (needs Node.js)
 | [CONTRIBUTING.md](CONTRIBUTING.md) | How to build, test, and contribute |
 | [CLAUDE.md](CLAUDE.md) | Quick reference: commands, package structure, gotchas |
 | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | Transport design, type definitions, protocol details |
+| [docs/COMPLETIONS.md](docs/COMPLETIONS.md) | Argument completion for prompt arguments and resource URI templates |
 | [ext/auth/docs/DESIGN.md](ext/auth/docs/DESIGN.md) | Auth architecture, spec compliance (C1-C23, X1-X5) |
 | [docs/APPS_DESIGN.md](docs/APPS_DESIGN.md) | MCP Apps extension design, protocol flows, conformance strategy |
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -258,6 +258,12 @@ Clients can subscribe to resource URIs and receive `notifications/resources/upda
 
 **Session cleanup:** All per-session teardown is centralized in `Dispatcher.Close()`. Transports call it in their disconnect path (SSE `OnClose`, Streamable `handleDelete`/`closeSession`, memory `close`). New per-session state should add its cleanup to `Close()` — not to each transport individually.
 
+## Argument Completion
+
+`completion/complete` resolves a handler by joining the ref type with the prompt name or resource URI template, so `ref/prompt` and `ref/resource` share a namespace without colliding. Two behaviors worth knowing at the dispatch level: an unregistered ref returns an empty result rather than an error, and a result over `core.MaxCompletionValues` (100) is truncated with `Total` and `HasMore` filled in by the dispatcher.
+
+See [COMPLETIONS.md](COMPLETIONS.md) for the handler API and worked examples.
+
 ## Notification Delivery Order Guarantees
 
 Notifications emitted during a tool call (logging, progress) are delivered to the client **before** the tool result. The ordering guarantee is per-transport:

--- a/docs/COMPLETIONS.md
+++ b/docs/COMPLETIONS.md
@@ -1,0 +1,109 @@
+# Argument completion
+
+A user typing a prompt argument in a client UI should get suggestions, the same way a shell completes a filename. MCP does this with `completion/complete`: the client sends the argument name and whatever the user has typed so far, and your server answers with the candidates that match.
+
+Completion is a server capability like tools or resources. It applies to two things: prompt arguments, and the variables in a resource URI template.
+
+## Registering a handler
+
+`RegisterCompletion` takes a reference type, the name of the thing being completed, and a handler.
+
+```go
+srv.RegisterCompletion("ref/prompt", "summarize",
+    func(ctx core.PromptContext, ref core.CompletionRef, arg core.CompletionArgument) (core.CompletionResult, error) {
+        styles := []string{"bullet", "brief", "detailed"}
+        var matched []string
+        for _, s := range styles {
+            if strings.HasPrefix(s, arg.Value) {
+                matched = append(matched, s)
+            }
+        }
+        return core.CompletionResult{Values: matched, Total: len(matched)}, nil
+    },
+)
+```
+
+`arg.Name` is the argument being completed and `arg.Value` is the partial input. Prefix matching is the common case, but nothing requires it. Fuzzy matching, a database lookup, or ignoring the partial value entirely are all fine.
+
+Runnable versions of every snippet on this page live in [`server/example_completion_test.go`](../server/example_completion_test.go) and run as part of the test suite.
+
+## The two reference types
+
+| Ref type | Second argument to `RegisterCompletion` | Completes |
+|---|---|---|
+| `ref/prompt` | the prompt name | an argument of that prompt |
+| `ref/resource` | the URI **template**, not a concrete URI | a variable in that template |
+
+The resource case trips people up. You register against the template string you passed to `RegisterResourceTemplate`, because that is what the client sends back:
+
+```go
+srv.RegisterCompletion("ref/resource", "file:///logs/{date}",
+    func(ctx core.PromptContext, ref core.CompletionRef, arg core.CompletionArgument) (core.CompletionResult, error) {
+        return core.CompletionResult{Values: []string{"2026-08-04", "2026-08-05"}, Total: 2}, nil
+    },
+)
+```
+
+Registering `file:///logs/2026-08-04` instead would never match, since the client completes the template, not an already-resolved URI.
+
+## An unregistered argument is not an error
+
+Ask for completion on something with no handler and the server returns an empty list with no error:
+
+```go
+resp, _ := srv.Dispatch(ctx, completionRequest("ref/prompt", "no-such-prompt", "style", "b"))
+// resp.Error == nil, values == []
+```
+
+This is deliberate. A client can offer completion on every argument without first discovering which ones support it, and an argument that gains a handler later starts working with no client change. Treat "no suggestions" and "no handler" as the same thing.
+
+## Returning more than 100 values
+
+The spec caps a completion response at 100 values. You do not have to enforce that yourself. Return everything you found and the server truncates, records the real count in `Total`, and sets `HasMore`:
+
+```go
+return core.CompletionResult{Values: values}, nil   // len(values) == 150
+// client sees: 100 values, Total 150, HasMore true
+```
+
+If you set `Total` yourself it is preserved. The automatic fill only happens when you leave it at zero, so a handler that knows the true size of a large result set (say, a count from a database that it only partially fetched) can report it accurately.
+
+`HasMore` tells the client there is more behind the current partial input. There is no cursor and no second page: the client narrows the search by sending a longer `arg.Value`, and your handler filters again.
+
+## Errors
+
+Returning an error produces a JSON-RPC error response with code `-31003` (`core.ErrCodeCompletionError`) and the ref key in the message. Prefer an empty result over an error for the ordinary "nothing matched" case. Reserve errors for a genuine failure, like the backing store being unreachable, so a client can tell the difference between "no suggestions" and "completion is broken right now".
+
+## Context
+
+The handler receives a `core.PromptContext`, the same typed context prompt handlers get. It embeds `context.Context`, so cancellation works directly through `ctx.Done()` and `ctx.Err()`, and `ctx.AuthClaims()` gives you the authenticated identity when the server runs behind `ext/auth`. A UI calls completion on every keystroke, so keep handlers fast and avoid unbounded work.
+
+## Wire shape
+
+Request:
+
+```json
+{
+  "jsonrpc": "2.0", "id": 1, "method": "completion/complete",
+  "params": {
+    "ref": {"type": "ref/prompt", "name": "summarize"},
+    "argument": {"name": "style", "value": "b"}
+  }
+}
+```
+
+Response:
+
+```json
+{
+  "jsonrpc": "2.0", "id": 1,
+  "result": {"completion": {"values": ["bullet", "brief"], "total": 2, "hasMore": false}}
+}
+```
+
+The server resolves the handler by joining the ref type and the name or URI, so `ref/prompt` and `ref/resource` never collide even if a prompt and a template share a string.
+
+## Related
+
+- [Getting started](GETTING_STARTED.md) for registering prompts and resource templates in the first place
+- [Architecture](ARCHITECTURE.md) for where completion sits in the dispatch path

--- a/docs/site/content/HeaderNavLinks.json
+++ b/docs/site/content/HeaderNavLinks.json
@@ -11,6 +11,7 @@
       { "name": "Auth",                "url": "guides/auth/" },
       { "name": "Long-running tasks",  "url": "guides/tasks/" },
       { "name": "MCP Apps",            "url": "guides/apps/" },
+      { "name": "Argument completion", "url": "guides/completions/" },
       { "name": "Observability",       "url": "guides/observability/" },
       { "name": "MRTR input-gathering","url": "guides/mrtr/" },
       { "name": "Deployment",          "url": "guides/deployment/" }

--- a/docs/site/content/guides/completions/index.html
+++ b/docs/site/content/guides/completions/index.html
@@ -1,0 +1,7 @@
+---
+title: "Argument completion"
+description: "Suggest values for prompt arguments and resource URI template variables (completion/complete)."
+source: "docs/COMPLETIONS.md"
+---
+
+{{ renderMarkdownFile "docs/COMPLETIONS.md" }}

--- a/server/example_completion_test.go
+++ b/server/example_completion_test.go
@@ -1,0 +1,122 @@
+package server_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	core "github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/server"
+	"github.com/panyam/mcpkit/testutil"
+)
+
+func completionRequest(refType, name, argName, partial string) *core.Request {
+	params, _ := json.Marshal(map[string]any{
+		"ref":      map[string]string{"type": refType, "name": name},
+		"argument": map[string]string{"name": argName, "value": partial},
+	})
+	return &core.Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  "completion/complete",
+		Params:  core.NewRawJSON(params),
+	}
+}
+
+func completionValues(resp *core.Response) core.CompletionResult {
+	var out struct {
+		Completion core.CompletionResult `json:"completion"`
+	}
+	_ = resp.ResultAs(&out)
+	return out.Completion
+}
+
+// Completion suggestions for a prompt argument. The client sends the partial
+// value the user has typed; the handler returns the matching candidates.
+func ExampleServer_RegisterCompletion() {
+	srv := server.NewServer(core.ServerInfo{Name: "docs", Version: "1.0"})
+
+	srv.RegisterCompletion("ref/prompt", "summarize",
+		func(ctx core.PromptContext, ref core.CompletionRef, arg core.CompletionArgument) (core.CompletionResult, error) {
+			styles := []string{"bullet", "brief", "detailed"}
+			var matched []string
+			for _, s := range styles {
+				if strings.HasPrefix(s, arg.Value) {
+					matched = append(matched, s)
+				}
+			}
+			return core.CompletionResult{Values: matched, Total: len(matched)}, nil
+		},
+	)
+	testutil.InitHandshake(srv)
+
+	resp, _ := srv.Dispatch(context.Background(),
+		completionRequest("ref/prompt", "summarize", "style", "b"))
+
+	fmt.Println(completionValues(resp).Values)
+	// Output: [bullet brief]
+}
+
+// Completion for a resource URI template argument. The ref type is
+// "ref/resource" and the registered name is the URI template itself, not a
+// prompt name.
+func ExampleServer_RegisterCompletion_resource() {
+	srv := server.NewServer(core.ServerInfo{Name: "docs", Version: "1.0"})
+
+	srv.RegisterCompletion("ref/resource", "file:///logs/{date}",
+		func(ctx core.PromptContext, ref core.CompletionRef, arg core.CompletionArgument) (core.CompletionResult, error) {
+			return core.CompletionResult{
+				Values: []string{"2026-08-04", "2026-08-05"},
+				Total:  2,
+			}, nil
+		},
+	)
+	testutil.InitHandshake(srv)
+
+	resp, _ := srv.Dispatch(context.Background(),
+		completionRequest("ref/resource", "file:///logs/{date}", "date", "2026-08"))
+
+	fmt.Println(completionValues(resp).Values)
+	// Output: [2026-08-04 2026-08-05]
+}
+
+// An unregistered ref is not an error. The server answers with an empty list so
+// a client can offer completion everywhere without first checking which
+// arguments support it.
+func ExampleServer_RegisterCompletion_unregistered() {
+	srv := server.NewServer(core.ServerInfo{Name: "docs", Version: "1.0"})
+	testutil.InitHandshake(srv)
+
+	resp, _ := srv.Dispatch(context.Background(),
+		completionRequest("ref/prompt", "no-such-prompt", "style", "b"))
+
+	result := completionValues(resp)
+	fmt.Println(resp.Error == nil, len(result.Values))
+	// Output: true 0
+}
+
+// The spec caps a completion response at 100 values. Returning more is allowed:
+// the server truncates, sets Total to the full count, and flips HasMore, so a
+// handler can stay simple and return everything it found.
+func ExampleServer_RegisterCompletion_truncation() {
+	srv := server.NewServer(core.ServerInfo{Name: "docs", Version: "1.0"})
+
+	srv.RegisterCompletion("ref/prompt", "pick",
+		func(ctx core.PromptContext, ref core.CompletionRef, arg core.CompletionArgument) (core.CompletionResult, error) {
+			values := make([]string, 150)
+			for i := range values {
+				values[i] = fmt.Sprintf("item-%d", i)
+			}
+			return core.CompletionResult{Values: values}, nil
+		},
+	)
+	testutil.InitHandshake(srv)
+
+	resp, _ := srv.Dispatch(context.Background(),
+		completionRequest("ref/prompt", "pick", "item", ""))
+
+	result := completionValues(resp)
+	fmt.Println(len(result.Values), result.Total, result.HasMore)
+	// Output: 100 150 true
+}


### PR DESCRIPTION
## What changes

Documents argument completion, the only core MCP capability slot with zero user-facing docs, and adds the repo's first Go `Example*` functions as its executable backing.

`server.RegisterCompletion` is public API, the capability is advertised, and upstream conformance exercises it. But nothing outside `cmd/testserver` and a unit test showed a caller how to use it, so the SEP-1730 tier audit graded both completion rows FAIL.

First of five slices for issue 1219.

## Reviewer's guide

1. [server/example_completion_test.go](https://github.com/panyam/mcpkit/pull/1229/files#diff-82325b73c5730ab702ec8f7a923c7237b0cda4627d9470157e080f6ae7e00c81) — start here. Four runnable examples; they are the acceptance for everything the guide claims.
2. [docs/COMPLETIONS.md](https://github.com/panyam/mcpkit/pull/1229/files#diff-5db784792f5a90af47854146cbb5155c733c228da734870cc4a04fda33e35f02) — the guide. Each snippet corresponds to one of the examples above.
3. [docs/ARCHITECTURE.md](https://github.com/panyam/mcpkit/pull/1229/files#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1) — dispatch-level behavior plus a pointer to the guide.
4. [README.md](https://github.com/panyam/mcpkit/pull/1229/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5), `docs/site/content/` — one-line link and nav wiring.

## Decision log

**Go `Example*` functions rather than a new `examples/completions/` directory.** `examples/CONVENTIONS.md` is 1018 lines and a compliant example needs `main.go`, `walkthrough.go`, `WALKTHROUGH.md`, `README.md`, a justfile, a new `go.mod`, and CI wiring. The audit rubric explicitly counts Go `Example*` functions as examples because they render on pkg.go.dev. **The repo had zero of them**, which is itself one of the audit's structural findings, so this establishes the pattern that slice 4 (12 more rows) will reuse. A full runnable example can follow if completions warrants one.

**External `server_test` package.** Lets the examples use `testutil.InitHandshake` and only public API, so they are copy-pasteable. The existing `server/completion_integration_test.go` uses the unexported `initDispatcher`, which would render as an undefined symbol on pkg.go.dev.

**Documented three dispatch behaviors the type definitions do not reveal**, each with a matching example:

- an unregistered ref returns an empty result, not an error, so a client can offer completion everywhere without probing capabilities first
- past 100 values the dispatcher truncates and fills `Total`/`HasMore`, but a caller-set `Total` is preserved
- the handler key joins ref type with name-or-URI, so a prompt and a URI template sharing a string do not collide

**Prose style** follows the `mcp_at_scale` STYLE_GUIDE tone now in effect for mcpkit docs.

## Two errors caught while writing

Both were in my first draft and are fixed. Worth flagging because they are the kind of thing prose gets wrong when it is not executable:

| Claim in draft | Reality |
|---|---|
| completion errors return `-32603` | `core.ErrCodeCompletionError` is **`-31003`** |
| cancellation via `ctx.Context()` | `BaseContext` embeds `context.Context`; it is `ctx.Done()` / `ctx.Err()` directly |

This is the argument for `Example*` over hand-written snippets: the examples cannot drift, because `go test` runs them.

## Before / after

```
Go Example* functions in the repo:   0  ->  4

SEP-1730 audit rows:
  #34 Completions - resource argument   FAIL  ->  PASS
  #35 Completions - prompt argument     FAIL  ->  PASS

Issue 1219 undocumented features:      6  ->  4
```

Examples running:

```
=== RUN   ExampleServer_RegisterCompletion
--- PASS: ExampleServer_RegisterCompletion (0.00s)
=== RUN   ExampleServer_RegisterCompletion_resource
--- PASS: ExampleServer_RegisterCompletion_resource (0.00s)
=== RUN   ExampleServer_RegisterCompletion_unregistered
--- PASS: ExampleServer_RegisterCompletion_unregistered (0.00s)
=== RUN   ExampleServer_RegisterCompletion_truncation
--- PASS: ExampleServer_RegisterCompletion_truncation (0.00s)
ok  github.com/panyam/mcpkit/server  0.312s
```

## Risk / blast radius

- Docs and a new test file. No production code is touched.
- The examples run in the existing `test` job, so they cannot silently rot.
- `HeaderNavLinks.json` is edited surgically to preserve its hand-aligned formatting; a `json.dump` round trip reflowed 172 lines for a one-line addition, so that was reverted.

Assertions added: 4 Example functions with `// Output:` blocks. Assertions removed or weakened: 0. No existing test is modified.

## Out of scope

Remaining 1219 slices, to follow sequentially:

2. Prompts primitive guide (2 FAILs + the 3 prose-less rows)
3. Elicitation. **Note: schema validation is not implemented anywhere in the codebase**, so that row needs code, not prose. Flagged on the issue.
4. `Example*` sweep for the 12 documented-but-no-example rows
5. The 12 stub pages under `tutorials/walkthrough/`

