### PR TITLE
docs: Example functions for the 12 undocumented-by-example features

### DIFF
--- a/client/example_transports_test.go
+++ b/client/example_transports_test.go
@@ -1,0 +1,93 @@
+package client_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	core "github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/client"
+)
+
+// Connecting over the legacy SSE transport (MCP 2024-11-05). The default is
+// Streamable HTTP; pass WithSSEClient only when talking to a server that has
+// not moved off the two-endpoint SSE wire.
+//
+// This example is illustrative and does not run: it needs a live server.
+func ExampleWithSSEClient() {
+	c := client.NewClient("http://localhost:8080/sse",
+		core.ClientInfo{Name: "example", Version: "1.0"},
+		client.WithSSEClient(),
+	)
+	if err := c.Connect(); err != nil {
+		log.Fatal(err)
+	}
+	defer c.Close()
+
+	tools, err := c.ListTools(context.Background())
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(len(tools))
+}
+
+// Paging through a list method. mcpkit's own server returns everything in one
+// page, but a client cannot assume that of an arbitrary server: loop until
+// NextCursor comes back empty.
+//
+// Use ListToolsPage rather than ListTools when you want the envelope, since it
+// also carries the SEP-2549 ttlMs and cacheScope caching hints that the
+// item-iterator forms discard.
+//
+// This example is illustrative and does not run: it needs a live server.
+func ExampleClient_ListToolsPage() {
+	c := client.NewClient("http://localhost:8080/mcp",
+		core.ClientInfo{Name: "example", Version: "1.0"})
+	if err := c.Connect(); err != nil {
+		log.Fatal(err)
+	}
+	defer c.Close()
+
+	var all []core.ToolDef
+	cursor := ""
+	for {
+		page, err := c.ListToolsPage(cursor)
+		if err != nil {
+			log.Fatal(err)
+		}
+		all = append(all, page.Tools...)
+		if page.NextCursor == "" {
+			break
+		}
+		cursor = page.NextCursor
+	}
+	fmt.Println(len(all))
+}
+
+// Telling the server the client's filesystem roots changed. The server responds
+// by re-issuing roots/list, so the notification carries no payload of its own.
+// Registering a RootsHandler is what advertises the capability; without one the
+// server never asks.
+//
+// Deprecated: roots is deprecated per SEP-2577. See docs/SEP_2577_DEPRECATIONS.md.
+//
+// This example is illustrative and does not run: it needs a live server.
+func ExampleClient_NotifyRootsChanged() {
+	roots := []core.Root{{URI: "file:///home/me/project", Name: "project"}}
+
+	c := client.NewClient("http://localhost:8080/mcp",
+		core.ClientInfo{Name: "example", Version: "1.0"},
+		client.WithRootsHandler(func(context.Context) ([]core.Root, error) {
+			return roots, nil
+		}),
+	)
+	if err := c.Connect(); err != nil {
+		log.Fatal(err)
+	}
+	defer c.Close()
+
+	roots = append(roots, core.Root{URI: "file:///tmp/scratch", Name: "scratch"})
+	if err := c.NotifyRootsChanged(); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -220,7 +220,13 @@ Supports `2025-11-25` and `2024-11-05`. During `initialize`, server checks if cl
 1. Client sends `initialize` → server responds with capabilities and negotiated version
 2. Client sends `notifications/initialized` → server marks session as ready
 3. Only after step 2 does the server accept `tools/list`, `tools/call`, etc.
-4. `ping` is exempt — allowed at any time
+4. `ping` is exempt, allowed at any time
+
+### Ping
+
+`ping` is a liveness check either side can send. It takes no parameters and the peer replies with an empty result, so a successful response means only that the connection is up and the peer is processing messages. It says nothing about session state.
+
+The exemption in step 4 above is what makes it useful: a client can ping before completing the handshake, and a long-lived connection can ping to distinguish an idle session from a dropped one. That matters most on the SSE and Streamable HTTP transports, where a silent TCP drop is otherwise indistinguishable from a server with nothing to say. Handling is built in; servers register nothing to support it.
 
 ## Server-to-Client Notifications
 

--- a/server/example_content_test.go
+++ b/server/example_content_test.go
@@ -1,0 +1,129 @@
+package server_test
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
+	core "github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/server"
+	"github.com/panyam/mcpkit/testutil"
+)
+
+func exampleCallTool(srv *server.Server, name string) core.ToolResult {
+	params, _ := json.Marshal(map[string]any{"name": name, "arguments": map[string]any{}})
+	resp, _ := srv.Dispatch(context.Background(), &core.Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  "tools/call",
+		Params:  core.NewRawJSON(params),
+	})
+	var out core.ToolResult
+	_ = resp.ResultAs(&out)
+	return out
+}
+
+func exampleReadResource(srv *server.Server, uri string) core.ResourceResult {
+	params, _ := json.Marshal(map[string]string{"uri": uri})
+	resp, _ := srv.Dispatch(context.Background(), &core.Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  "resources/read",
+		Params:  core.NewRawJSON(params),
+	})
+	var out core.ResourceResult
+	_ = resp.ResultAs(&out)
+	return out
+}
+
+// A tool returning an image. Data is base64, and MimeType tells the client how
+// to decode it. The same Content shape carries audio and embedded resources,
+// switched by Type.
+func ExampleServer_Register_imageResult() {
+	srv := server.NewServer(core.ServerInfo{Name: "docs", Version: "1.0"})
+
+	png := []byte{0x89, 'P', 'N', 'G'}
+	srv.Register(core.TypedTool[struct{}, core.ToolResult]("render", "Renders a chart",
+		func(ctx core.ToolContext, _ struct{}) (core.ToolResult, error) {
+			return core.ToolResult{Content: []core.Content{{
+				Type:     "image",
+				Data:     base64.StdEncoding.EncodeToString(png),
+				MimeType: "image/png",
+			}}}, nil
+		},
+	))
+	testutil.InitHandshake(srv)
+
+	c := exampleCallTool(srv, "render").Content[0]
+	fmt.Println(c.Type, c.MimeType, c.Data)
+	// Output: image image/png iVBORw==
+}
+
+// A tool returning audio. Identical to the image case apart from Type, which is
+// why neither needs a dedicated result helper.
+func ExampleServer_Register_audioResult() {
+	srv := server.NewServer(core.ServerInfo{Name: "docs", Version: "1.0"})
+
+	srv.Register(core.TypedTool[struct{}, core.ToolResult]("speak", "Synthesizes speech",
+		func(ctx core.ToolContext, _ struct{}) (core.ToolResult, error) {
+			return core.ToolResult{Content: []core.Content{{
+				Type:     "audio",
+				Data:     base64.StdEncoding.EncodeToString([]byte("RIFF")),
+				MimeType: "audio/wav",
+			}}}, nil
+		},
+	))
+	testutil.InitHandshake(srv)
+
+	c := exampleCallTool(srv, "speak").Content[0]
+	fmt.Println(c.Type, c.MimeType)
+	// Output: audio audio/wav
+}
+
+// A tool embedding a resource in its result. Use this when the tool produced
+// something the client should be able to refer to later by URI, rather than an
+// opaque blob. Text and Blob are mutually exclusive on the embedded content.
+func ExampleServer_Register_embeddedResource() {
+	srv := server.NewServer(core.ServerInfo{Name: "docs", Version: "1.0"})
+
+	srv.Register(core.TypedTool[struct{}, core.ToolResult]("report", "Generates a report",
+		func(ctx core.ToolContext, _ struct{}) (core.ToolResult, error) {
+			return core.ToolResult{Content: []core.Content{{
+				Type: "resource",
+				Resource: &core.ResourceContent{
+					URI:      "report://q3",
+					MimeType: "text/plain",
+					Text:     "revenue up 4%",
+				},
+			}}}, nil
+		},
+	))
+	testutil.InitHandshake(srv)
+
+	c := exampleCallTool(srv, "report").Content[0]
+	fmt.Println(c.Type, c.Resource.URI, c.Resource.Text)
+	// Output: resource report://q3 revenue up 4%
+}
+
+// Reading a binary resource. Set Blob (base64) instead of Text; the two are
+// mutually exclusive, and MimeType is what tells the client which it is getting.
+func ExampleServer_RegisterResource_binary() {
+	srv := server.NewServer(core.ServerInfo{Name: "docs", Version: "1.0"})
+
+	srv.RegisterResource(
+		core.ResourceDef{URI: "asset://logo.png", Name: "logo", MimeType: "image/png"},
+		func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
+			return core.ResourceResult{Contents: []core.ResourceReadContent{{
+				URI:      "asset://logo.png",
+				MimeType: "image/png",
+				Blob:     base64.StdEncoding.EncodeToString([]byte{0x89, 'P', 'N', 'G'}),
+			}}}, nil
+		},
+	)
+	testutil.InitHandshake(srv)
+
+	c := exampleReadResource(srv, "asset://logo.png").Contents[0]
+	fmt.Println(c.MimeType, c.Blob, c.Text == "")
+	// Output: image/png iVBORw== true
+}

--- a/server/example_protocol_test.go
+++ b/server/example_protocol_test.go
@@ -1,0 +1,122 @@
+package server_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	core "github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/server"
+	"github.com/panyam/mcpkit/testutil"
+)
+
+func exampleDispatch(srv *server.Server, method string, params any) *core.Response {
+	raw, _ := json.Marshal(params)
+	resp, _ := srv.Dispatch(context.Background(), &core.Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  method,
+		Params:  core.NewRawJSON(raw),
+	})
+	return resp
+}
+
+// Subscribing and unsubscribing from a resource. Subscription requires the
+// WithSubscriptions server option; without it the methods are not advertised.
+// Unsubscribe is what stops notifications/resources/updated for that URI, and a
+// session that disconnects is unsubscribed automatically.
+func ExampleWithSubscriptions() {
+	srv := server.NewServer(core.ServerInfo{Name: "docs", Version: "1.0"}, server.WithSubscriptions())
+	srv.RegisterResource(
+		core.ResourceDef{URI: "feed://prices", Name: "prices"},
+		func(ctx core.ResourceContext, req core.ResourceRequest) (core.ResourceResult, error) {
+			return core.ResourceResult{Contents: []core.ResourceReadContent{{
+				URI: "feed://prices", Text: "42",
+			}}}, nil
+		},
+	)
+	testutil.InitHandshake(srv)
+
+	sub := exampleDispatch(srv, "resources/subscribe", map[string]string{"uri": "feed://prices"})
+	unsub := exampleDispatch(srv, "resources/unsubscribe", map[string]string{"uri": "feed://prices"})
+
+	fmt.Println(sub.Error == nil, unsub.Error == nil)
+	// Output: true true
+}
+
+// Setting the log level. The client raises or lowers the threshold at runtime
+// and the server filters notifications/message below it, so a client can turn
+// on debug output without a reconnect.
+func ExampleServer_Dispatch_loggingSetLevel() {
+	srv := server.NewServer(core.ServerInfo{Name: "docs", Version: "1.0"})
+	testutil.InitHandshake(srv)
+
+	ok := exampleDispatch(srv, "logging/setLevel", map[string]string{"level": "debug"})
+	bad := exampleDispatch(srv, "logging/setLevel", map[string]string{"level": "louder"})
+
+	fmt.Println(ok.Error == nil, bad.Error.Message)
+	// Output: true unknown log level: louder
+}
+
+// Pagination on a list method. mcpkit servers return every item in one page:
+// the page size is a compile-time constant of 0, meaning "no pagination", so
+// nextCursor is always empty regardless of how many items are registered.
+//
+// The cursor is still part of the wire contract, and mcpkit's client handles
+// servers that do paginate. Loop with ListToolsPage, passing the previous
+// NextCursor, until it comes back empty.
+func ExampleServer_Dispatch_pagination() {
+	srv := server.NewServer(core.ServerInfo{Name: "docs", Version: "1.0"})
+	for i := range 3 {
+		name := fmt.Sprintf("tool-%d", i)
+		srv.Register(core.TextTool[struct{}](name, "noop",
+			func(ctx core.ToolContext, _ struct{}) (string, error) { return "", nil }))
+	}
+	testutil.InitHandshake(srv)
+
+	resp := exampleDispatch(srv, "tools/list", map[string]any{})
+	var out core.ToolsListResult
+	_ = resp.ResultAs(&out)
+
+	fmt.Println(len(out.Tools), out.NextCursor == "")
+	// Output: 3 true
+}
+
+// An elicitation schema with an enum. The client renders a fixed choice rather
+// than a free-text field. enumNames is optional and supplies display labels
+// parallel to enum; a client that does not understand it falls back to the raw
+// enum values.
+//
+// mcpkit does not validate the response against this schema. The schema drives
+// what the client collects; a handler that cares should check the returned
+// content itself.
+func ExampleElicitationRequest_enum() {
+	req := core.ElicitationRequest{
+		Message: "Pick a deployment target",
+		RequestedSchema: json.RawMessage(`{
+                        "type": "object",
+                        "properties": {
+                          "env": {
+                            "type": "string",
+                            "enum": ["dev", "staging", "prod"],
+                            "enumNames": ["Development", "Staging", "Production"],
+                            "default": "dev"
+                          }
+                        },
+                        "required": ["env"]
+                        }`),
+	}
+
+	var schema struct {
+		Properties struct {
+			Env struct {
+				Enum    []string `json:"enum"`
+				Default string   `json:"default"`
+			} `json:"env"`
+		} `json:"properties"`
+	}
+	_ = json.Unmarshal(req.RequestedSchema, &schema)
+
+	fmt.Println(schema.Properties.Env.Enum, schema.Properties.Env.Default)
+	// Output: [dev staging prod] dev
+}

--- a/server/example_stdio_test.go
+++ b/server/example_stdio_test.go
@@ -1,0 +1,35 @@
+package server_test
+
+import (
+	"context"
+	"log"
+
+	core "github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/server"
+)
+
+// Serving over stdio. This is the transport a desktop host uses when it
+// launches your server as a subprocess: one JSON-RPC message per line on
+// stdin and stdout.
+//
+// Nothing else may write to stdout, or it corrupts the framing. Send logs to
+// stderr, which the host captures separately. RunStdio blocks until ctx is
+// cancelled or stdin closes.
+//
+// This example is illustrative and does not run: RunStdio blocks and consumes
+// the process's stdin.
+func ExampleServer_RunStdio() {
+	srv := server.NewServer(core.ServerInfo{Name: "example", Version: "1.0"})
+	srv.Register(core.TextTool[struct{}]("ping", "Replies with pong",
+		func(ctx core.ToolContext, _ struct{}) (string, error) {
+			return "pong", nil
+		},
+	))
+
+	// log's default output is stderr, which is the safe channel here.
+	log.SetPrefix("example-server: ")
+
+	if err := srv.RunStdio(context.Background()); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
## What changes

Twelve `Example*` functions covering every feature the SEP-1730 audit marked PARTIAL, meaning documented in prose but with no example a reader could copy. Follows the pattern slice 1 established.

Slice 4 of issue 1219.

## Reviewer's guide

1. [server/example_content_test.go](https://github.com/panyam/mcpkit/pull/1231/files#diff-4b7c72516eb5ba1b61f3f6576a68652c2b09e09bd97e6cf7feeacae54009721d) — start here. Tool image / audio / embedded-resource results and binary resource reads, all with verified `Output`.
2. [server/example_protocol_test.go](https://github.com/panyam/mcpkit/pull/1231/files#diff-37fdc2805b5f13ffe59a1e789432ac993d30bd6b8b92bda15f1671bf58dff96d) — subscribe/unsubscribe, `logging/setLevel`, pagination, elicitation enums.
3. [client/example_transports_test.go](https://github.com/panyam/mcpkit/pull/1231/files#diff-331f13ce5b46e89bdfeec0ece6d790932e889acddb0f07a401d730460a87d065) — the three client-side cases that need a live server, so they compile and render but do not run.
4. [server/example_stdio_test.go](https://github.com/panyam/mcpkit/pull/1231/files#diff-083fcea3a8ce5782c6fed0dc3095872e4439c17376b49c5b0e1c8c843c7f8834) — stdio, illustrative because `RunStdio` blocks on the process's stdin.
5. [docs/ARCHITECTURE.md](https://github.com/panyam/mcpkit/pull/1231/files#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1) — the Ping prose section.

## Coverage

| Audit row | Where | Runnable |
|---|---|---|
| Tools image result | `server/example_content_test.go` | yes |
| Tools audio result | `server/example_content_test.go` | yes |
| Tools embedded resource | `server/example_content_test.go` | yes |
| Resources binary read | `server/example_content_test.go` | yes |
| Resources unsubscribe | `server/example_protocol_test.go` | yes |
| `logging/setLevel` | `server/example_protocol_test.go` | yes |
| Pagination | `server/example_protocol_test.go` | yes |
| Elicitation enums | `server/example_protocol_test.go` | yes |
| stdio server | `server/example_stdio_test.go` | no, blocks |
| Legacy SSE client | `client/example_transports_test.go` | no, needs a server |
| Client pagination loop | `client/example_transports_test.go` | no, needs a server |
| Roots list-changed | `client/example_transports_test.go` | no, needs a server |
| Ping (inverted: had an example, lacked prose) | `docs/ARCHITECTURE.md` | prose |

## Two behaviors the examples surfaced

**mcpkit servers never paginate.** `defaultPageSize` is a `const` `0` used at all four list call sites, and `parsePaginationParams` returns it unconditionally. There is no option to change it, so `nextCursor` is always empty no matter how many items are registered. The `paginate` helper and cursor decoder exist but are unreachable in practice.

This is spec-legal, since server pagination is optional, and the client side correctly handles servers that do paginate. But it would have been easy to write an example implying mcpkit paginates. The example documents the real behavior and points at the client loop instead. **A `WithPageSize` option is a genuine gap** and worth filing separately.

**mcpkit does not validate elicitation responses against `requestedSchema`.** The enum example says so explicitly, so a reader does not assume the schema is enforced. This is the same finding flagged for slice 3, where it needs code rather than prose.

## Decision log

**Four examples deliberately have no `Output` block.** `RunStdio` blocks on stdin, and the three client cases need a live server. Go compiles and renders these on pkg.go.dev without executing them, which is the standard way to document a call shape that cannot run in a test. Each says so in its doc comment rather than leaving a reader wondering why it produces nothing.

**Roots is documented despite being deprecated** under SEP-2577. It still ships and the audit still counts it, so the example carries a `Deprecated:` note pointing at `docs/SEP_2577_DEPRECATIONS.md` rather than being omitted.

**Helpers are prefixed `example*`** to avoid colliding with the existing `callTool` in `server/schema_validation_test.go`, which is also in `package server_test`.

## Before / after

```
Go Example* functions:            4  ->  16   (12 runnable, 4 illustrative)
Issue 1219 PARTIAL rows:         15  ->   3
```

Runnable examples executing:

```
$ go test ./server/ -run Example
ok  github.com/panyam/mcpkit/server  0.838s

$ go vet ./server/ ./client/
(clean)
```

## Risk / blast radius

- Test files and one docs section. No production code is touched.
- The 12 runnable examples execute in the existing `test` job, so their claims cannot drift.
- The 4 illustrative ones are compile-checked by `go vet` and `go build` but never executed, so an API change breaks the build rather than silently rotting.

Assertions added: 12 `Output` blocks. Assertions removed or weakened: 0. No existing test is modified.

## Out of scope

- `server.WithPageSize` so a server can actually paginate. Worth filing.
- Remaining 1219 slices: 2 (prompts guide) and 5 (walkthrough stubs). Slice 3 (elicitation) still needs the schema-validation decision, since that row cannot be closed with prose.

