### PR TITLE
docs: prompts guide + Example functions for prompt content types

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ just/make test-apps-playwright  # ext-apps Playwright suite (needs Node.js)
 | [CONTRIBUTING.md](CONTRIBUTING.md) | How to build, test, and contribute |
 | [CLAUDE.md](CLAUDE.md) | Quick reference: commands, package structure, gotchas |
 | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | Transport design, type definitions, protocol details |
+| [docs/PROMPTS.md](docs/PROMPTS.md) | Prompts: arguments, content types, listing |
 | [docs/COMPLETIONS.md](docs/COMPLETIONS.md) | Argument completion for prompt arguments and resource URI templates |
 | [ext/auth/docs/DESIGN.md](ext/auth/docs/DESIGN.md) | Auth architecture, spec compliance (C1-C23, X1-X5) |
 | [docs/APPS_DESIGN.md](docs/APPS_DESIGN.md) | MCP Apps extension design, protocol flows, conformance strategy |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -192,6 +192,8 @@ type TemplateHandler func(ctx context.Context, uri string, params map[string]str
 type PromptHandler func(ctx context.Context, req PromptRequest) (PromptResult, error)
 ```
 
+See [PROMPTS.md](PROMPTS.md) for the prompt handler contract, argument validation, and the content types a prompt message can carry.
+
 ### Content Cardinality Tolerance (#81)
 
 Several message types have a `content` field whose JSON cardinality varies in

--- a/docs/PROMPTS.md
+++ b/docs/PROMPTS.md
@@ -1,0 +1,99 @@
+# Prompts
+
+A prompt is a named, parameterised message template your server hands to a client. The client shows it in a picker, collects any arguments, and drops the resulting messages into a conversation with a model.
+
+That makes prompts the one primitive the user invokes directly. Tools are chosen by a model and resources are read on demand, but a prompt is something a person picks from a menu. Name and describe them accordingly.
+
+## Registering a prompt
+
+```go
+srv.RegisterPrompt(
+    core.PromptDef{Name: "changelog", Description: "Draft a changelog entry"},
+    func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResponse, error) {
+        return core.PromptResult{
+            Description: "Changelog draft",
+            Messages: []core.PromptMessage{{
+                Role:    "user",
+                Content: core.Content{Type: "text", Text: "Draft a changelog entry."},
+            }},
+        }, nil
+    },
+)
+```
+
+`Role` is `user` or `assistant`. Returning more than one message is how you supply a worked example: an assistant message showing the shape you want, followed by a user message with the real request.
+
+The handler returns `core.PromptResponse`, a sealed interface with two implementations. `core.PromptResult` is the sync answer and the one you write most of the time. `core.InputRequiredResult` is the MRTR variant: return it to ask the client for sampling, elicitation, or roots input mid-call, and the client re-sends the same `prompts/get` with the answers attached. See [MRTR_TUTORIAL.md](MRTR_TUTORIAL.md).
+
+The interface is sealed through an unexported marker method, so an external type cannot impersonate a response variant.
+
+Runnable versions of everything on this page are in [`server/example_prompts_test.go`](../server/example_prompts_test.go) and run with the test suite.
+
+## Arguments
+
+Declare arguments on the definition so a client can prompt for them, then read them back in the handler:
+
+```go
+core.PromptDef{
+    Name: "review",
+    Arguments: []core.PromptArgument{
+        {Name: "lang", Description: "Source language", Required: true,
+         Schema: map[string]any{"type": "string"}},
+    },
+}
+```
+
+```go
+lang, _ := req.Arguments["lang"].(string)
+```
+
+Two things to know.
+
+**Arguments are decoded JSON, not strings.** `req.Arguments` is a `map[string]any` holding already-decoded values, so a JSON number arrives as `float64` and an object as `map[string]any`. String arguments need a type assertion.
+
+**A `Schema` turns on server-side validation.** When an argument declares one, the dispatcher validates the incoming value before your handler runs and rejects a bad request with `-32602` and a structured error list. Arguments with no schema are passed through unchecked. Turn the call-time check off with `server.WithSchemaValidation(false)` if you would rather validate inside the handler.
+
+Marking an argument `Required` is advertisement, not enforcement. Give it a schema if you want the dispatcher to reject a missing value.
+
+## Content types
+
+`PromptMessage.Content` is the same `core.Content` type tool results use, so a prompt can carry anything a tool result can.
+
+Text:
+
+```go
+core.Content{Type: "text", Text: "Review this Go code."}
+```
+
+An image, base64 with a mime type:
+
+```go
+core.Content{Type: "image", Data: base64Data, MimeType: "image/png"}
+```
+
+An embedded resource:
+
+```go
+core.Content{
+    Type: "resource",
+    Resource: &core.ResourceContent{
+        URI:      "file:///etc/app.conf",
+        MimeType: "text/plain",
+        Text:     "debug = true",
+    },
+}
+```
+
+Prefer an embedded resource over inlined text when the content has a URI the client already knows about. It lets the client attribute the content, re-fetch it, or link to it, instead of treating it as anonymous prose. `Text` and `Blob` on the embedded resource are mutually exclusive; use `Blob` with base64 for binary.
+
+## Listing
+
+`prompts/list` returns every registered definition with its description and arguments, which is what a client renders in its picker. mcpkit returns all prompts in a single page: `nextCursor` is always empty because the server's page size is fixed at "no pagination". See [COMPLETIONS.md](COMPLETIONS.md) for suggesting values for a prompt argument once the user starts typing.
+
+Adding or removing a prompt at runtime through the registry broadcasts `notifications/prompts/list_changed`, so clients refresh without polling.
+
+## Related
+
+- [Argument completion](COMPLETIONS.md) for autocompleting prompt argument values
+- [Getting started](GETTING_STARTED.md) for a first server end to end
+- [Architecture](ARCHITECTURE.md) for where prompts sit in dispatch

--- a/docs/site/content/HeaderNavLinks.json
+++ b/docs/site/content/HeaderNavLinks.json
@@ -11,6 +11,7 @@
       { "name": "Auth",                "url": "guides/auth/" },
       { "name": "Long-running tasks",  "url": "guides/tasks/" },
       { "name": "MCP Apps",            "url": "guides/apps/" },
+      { "name": "Prompts",             "url": "guides/prompts/" },
       { "name": "Argument completion", "url": "guides/completions/" },
       { "name": "Observability",       "url": "guides/observability/" },
       { "name": "MRTR input-gathering","url": "guides/mrtr/" },

--- a/docs/site/content/guides/prompts/index.html
+++ b/docs/site/content/guides/prompts/index.html
@@ -1,0 +1,7 @@
+---
+title: "Prompts"
+description: "Named, parameterised message templates: arguments, content types, and listing."
+source: "docs/PROMPTS.md"
+---
+
+{{ renderMarkdownFile "docs/PROMPTS.md" }}

--- a/server/example_prompts_test.go
+++ b/server/example_prompts_test.go
@@ -1,0 +1,163 @@
+package server_test
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
+	core "github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/server"
+	"github.com/panyam/mcpkit/testutil"
+)
+
+func exampleGetPrompt(srv *server.Server, name string, args map[string]any) core.PromptResult {
+	params, _ := json.Marshal(map[string]any{"name": name, "arguments": args})
+	resp, _ := srv.Dispatch(context.Background(), &core.Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  "prompts/get",
+		Params:  core.NewRawJSON(params),
+	})
+	var out core.PromptResult
+	_ = resp.ResultAs(&out)
+	return out
+}
+
+// A prompt with no arguments. The handler returns messages the client will feed
+// to a model, so Role is "user" or "assistant" and the content is what you want
+// in the conversation.
+func ExampleServer_RegisterPrompt() {
+	srv := server.NewServer(core.ServerInfo{Name: "docs", Version: "1.0"})
+
+	srv.RegisterPrompt(
+		core.PromptDef{Name: "changelog", Description: "Draft a changelog entry"},
+		func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResponse, error) {
+			return core.PromptResult{
+				Description: "Changelog draft",
+				Messages: []core.PromptMessage{{
+					Role:    "user",
+					Content: core.Content{Type: "text", Text: "Draft a changelog entry."},
+				}},
+			}, nil
+		},
+	)
+	testutil.InitHandshake(srv)
+
+	res := exampleGetPrompt(srv, "changelog", nil)
+	fmt.Println(res.Messages[0].Role, res.Messages[0].Content.Text)
+	// Output: user Draft a changelog entry.
+}
+
+// A prompt with arguments. Declare them on PromptDef so a client can present
+// them, then read them from req.Arguments.
+//
+// Arguments arrive as decoded JSON values in a map[string]any, so a string
+// argument needs a type assertion. Give an argument a Schema and the dispatcher
+// validates it before your handler runs, rejecting bad input with -32602.
+func ExampleServer_RegisterPrompt_arguments() {
+	srv := server.NewServer(core.ServerInfo{Name: "docs", Version: "1.0"})
+
+	srv.RegisterPrompt(
+		core.PromptDef{
+			Name: "review",
+			Arguments: []core.PromptArgument{
+				{Name: "lang", Description: "Source language", Required: true,
+					Schema: map[string]any{"type": "string"}},
+			},
+		},
+		func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResponse, error) {
+			lang, _ := req.Arguments["lang"].(string)
+			return core.PromptResult{Messages: []core.PromptMessage{{
+				Role:    "user",
+				Content: core.Content{Type: "text", Text: "Review this " + lang + " code."},
+			}}}, nil
+		},
+	)
+	testutil.InitHandshake(srv)
+
+	res := exampleGetPrompt(srv, "review", map[string]any{"lang": "Go"})
+	fmt.Println(res.Messages[0].Content.Text)
+	// Output: Review this Go code.
+}
+
+// A prompt carrying an image. PromptMessage.Content is the same Content type
+// tool results use, so Type "image" plus base64 Data and a MimeType works
+// identically here.
+func ExampleServer_RegisterPrompt_image() {
+	srv := server.NewServer(core.ServerInfo{Name: "docs", Version: "1.0"})
+
+	srv.RegisterPrompt(
+		core.PromptDef{Name: "describe", Description: "Describe a screenshot"},
+		func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResponse, error) {
+			return core.PromptResult{Messages: []core.PromptMessage{{
+				Role: "user",
+				Content: core.Content{
+					Type:     "image",
+					Data:     base64.StdEncoding.EncodeToString([]byte{0x89, 'P', 'N', 'G'}),
+					MimeType: "image/png",
+				},
+			}}}, nil
+		},
+	)
+	testutil.InitHandshake(srv)
+
+	c := exampleGetPrompt(srv, "describe", nil).Messages[0].Content
+	fmt.Println(c.Type, c.MimeType, c.Data)
+	// Output: image image/png iVBORw==
+}
+
+// A prompt embedding a resource. Use this instead of inlining text when the
+// content has a URI the client already knows, so it can attribute or re-fetch
+// it rather than treating it as anonymous prose.
+func ExampleServer_RegisterPrompt_embeddedResource() {
+	srv := server.NewServer(core.ServerInfo{Name: "docs", Version: "1.0"})
+
+	srv.RegisterPrompt(
+		core.PromptDef{Name: "explain", Description: "Explain a config file"},
+		func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResponse, error) {
+			return core.PromptResult{Messages: []core.PromptMessage{{
+				Role: "user",
+				Content: core.Content{
+					Type: "resource",
+					Resource: &core.ResourceContent{
+						URI:      "file:///etc/app.conf",
+						MimeType: "text/plain",
+						Text:     "debug = true",
+					},
+				},
+			}}}, nil
+		},
+	)
+	testutil.InitHandshake(srv)
+
+	c := exampleGetPrompt(srv, "explain", nil).Messages[0].Content
+	fmt.Println(c.Type, c.Resource.URI, c.Resource.Text)
+	// Output: resource file:///etc/app.conf debug = true
+}
+
+// Listing prompts. Clients call this to populate a picker, so Description and
+// Arguments are what a user sees before choosing.
+func ExampleServer_Dispatch_promptsList() {
+	srv := server.NewServer(core.ServerInfo{Name: "docs", Version: "1.0"})
+
+	srv.RegisterPrompt(
+		core.PromptDef{
+			Name:        "review",
+			Description: "Review a diff",
+			Arguments:   []core.PromptArgument{{Name: "lang", Required: true}},
+		},
+		func(ctx core.PromptContext, req core.PromptRequest) (core.PromptResponse, error) {
+			return core.PromptResult{}, nil
+		},
+	)
+	testutil.InitHandshake(srv)
+
+	resp := exampleDispatch(srv, "prompts/list", map[string]any{})
+	var out core.PromptsListResult
+	_ = resp.ResultAs(&out)
+
+	p := out.Prompts[0]
+	fmt.Println(p.Name, p.Description, p.Arguments[0].Name, p.Arguments[0].Required)
+	// Output: review Review a diff lang true
+}


### PR DESCRIPTION
## What changes

Adds `docs/PROMPTS.md`, a primitive guide for prompts, backed by five runnable `Example*` functions.

Prompts was the only core primitive with no dedicated prose anywhere. Coverage was type listings in `ARCHITECTURE.md` plus a one-line pointer in the walkthrough, while tools and resources each had a full guide. The audit graded two prompt rows FAIL (embedded resources, image content) and three PARTIAL (listing, get-simple, get-with-arguments: examples existed, prose did not).

Slice 2 of issue 1219.

## Reviewer's guide

1. [server/example_prompts_test.go](https://github.com/panyam/mcpkit/pull/1232/files#diff-404c5cbbae3956b22711cc38d6950df29224b44e58c0daabda394478c672e218) — start here. Five examples with verified `Output`; they are the acceptance for the guide.
2. [docs/PROMPTS.md](https://github.com/panyam/mcpkit/pull/1232/files#diff-59a91baaaf76f5550a877fa88ad79816cc347ab6c38d9772cf6d7476e4a10c1d) — the guide. Each snippet maps to one example.
3. [docs/ARCHITECTURE.md](https://github.com/panyam/mcpkit/pull/1232/files#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1), [README.md](https://github.com/panyam/mcpkit/pull/1232/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5), `docs/site/content/` — cross-links and nav.

## Two things the guide makes explicit

Neither is visible from the type definitions, and both are easy to get wrong:

**`req.Arguments` holds decoded JSON, not strings.** It is a `map[string]any` of already-decoded values, so a JSON number arrives as `float64` and a string argument needs a type assertion. The inline comment in `ARCHITECTURE.md` says "handlers type-assert" without saying why.

**A `PromptArgument` with a `Schema` is validated by the dispatcher** before the handler runs, rejecting bad input with `-32602` and a structured error list. `Required` on its own is advertisement, not enforcement: it tells a client to collect the value but nothing rejects a request that omits it. Give the argument a schema if you want the dispatcher to enforce.

## A stale source comment, corrected

The doc comment on `core.PromptResponse` says:

> Today only [PromptResult] (the sync wire envelope) implements it; a future [InputRequiredResult] PromptResponse impl plugs in by adding a one-line promptResponse() method

That is out of date. `core/mrtr.go:117` already has `func (InputRequiredResult) promptResponse() {}`, so MRTR input-gathering works for prompts today. My first draft of the guide repeated the comment's claim; I caught it while verifying and the guide now documents both variants with a pointer to `MRTR_TUTORIAL.md`.

I left the source comment itself alone to keep this PR docs-only. Worth a one-line follow-up.

## Before / after

```
Go Example* functions:      16  ->  21

SEP-1730 audit rows:
  #20 Prompts - embedded resources   FAIL     ->  PASS
  #21 Prompts - image content        FAIL     ->  PASS
  #17 Prompts - listing              PARTIAL  ->  PASS
  #18 Prompts - getting simple       PARTIAL  ->  PASS
  #19 Prompts - getting with args    PARTIAL  ->  PASS

Issue 1219 undocumented features:    4  ->  2
Issue 1219 PARTIAL rows:             3  ->  0
```

Examples running:

```
--- PASS: ExampleServer_RegisterPrompt (0.00s)
--- PASS: ExampleServer_RegisterPrompt_arguments (0.00s)
--- PASS: ExampleServer_RegisterPrompt_image (0.00s)
--- PASS: ExampleServer_RegisterPrompt_embeddedResource (0.00s)
--- PASS: ExampleServer_Dispatch_promptsList (0.00s)
ok  github.com/panyam/mcpkit/server  0.736s
```

## Risk / blast radius

- Docs and one test file. No production code is touched.
- All five examples run in the existing `test` job, so the guide's claims cannot drift.
- `HeaderNavLinks.json` edited surgically to preserve its hand-aligned formatting.

Assertions added: 5 `Output` blocks. Assertions removed or weakened: 0. No existing test is modified.

## Out of scope

- Fixing the stale `core.PromptResponse` doc comment. Source change, not docs.
- Slice 5 (the 12 stub pages under `tutorials/walkthrough/`).
- Slice 3 (elicitation) still needs the schema-validation decision: that row cannot be closed with prose, since nothing validates a response against `requestedSchema` today.

