### PR TITLE
docs: elicitation guide + SEP-1034 defaults examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ just/make test-apps-playwright  # ext-apps Playwright suite (needs Node.js)
 | [CLAUDE.md](CLAUDE.md) | Quick reference: commands, package structure, gotchas |
 | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | Transport design, type definitions, protocol details |
 | [docs/PROMPTS.md](docs/PROMPTS.md) | Prompts: arguments, content types, listing |
+| [docs/ELICITATION.md](docs/ELICITATION.md) | Elicitation: schemas, SEP-1034 defaults, enums, URL mode |
 | [docs/COMPLETIONS.md](docs/COMPLETIONS.md) | Argument completion for prompt arguments and resource URI templates |
 | [ext/auth/docs/DESIGN.md](ext/auth/docs/DESIGN.md) | Auth architecture, spec compliance (C1-C23, X1-X5) |
 | [docs/APPS_DESIGN.md](docs/APPS_DESIGN.md) | MCP Apps extension design, protocol flows, conformance strategy |

--- a/client/example_elicitation_test.go
+++ b/client/example_elicitation_test.go
@@ -1,0 +1,144 @@
+package client_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	core "github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/client"
+)
+
+func elicitRequest(schema string) *core.Request {
+	params, _ := json.Marshal(core.ElicitationRequest{
+		Message:         "Configure the deploy",
+		RequestedSchema: json.RawMessage(schema),
+	})
+	return &core.Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  "elicitation/create",
+		Params:  core.NewRawJSON(params),
+	}
+}
+
+func elicitContent(resp *core.Response) string {
+	var out core.ElicitationResult
+	_ = resp.ResultAs(&out)
+	keys := make([]string, 0, len(out.Content))
+	for k := range out.Content {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%v", k, out.Content[k]))
+	}
+	return fmt.Sprint(parts)
+}
+
+const deploySchema = `{
+  "type": "object",
+  "properties": {
+    "env":     {"type": "string",  "default": "dev"},
+    "replicas":{"type": "integer", "default": 2},
+    "verbose": {"type": "boolean", "default": false}
+  }
+}`
+
+// SEP-1034 defaults. A schema property may declare a default; the client fills
+// it in for any key the user left out, so a handler can return exactly what the
+// user typed and stay unaware of defaults entirely.
+//
+// The merge happens inside the elicitation/create dispatch path, after your
+// handler returns and before the response goes back to the server.
+func ExampleWithElicitationHandler_defaults() {
+	c := client.NewClient("http://example.invalid",
+		core.ClientInfo{Name: "example", Version: "1.0"},
+		client.WithElicitationHandler(
+			func(ctx context.Context, req core.ElicitationRequest) (core.ElicitationResult, error) {
+				// The user filled in one field and left the rest alone.
+				return core.ElicitationResult{
+					Action:  "accept",
+					Content: map[string]any{"env": "prod"},
+				}, nil
+			},
+		),
+	)
+
+	resp := c.HandleServerRequestWithContext(context.Background(), elicitRequest(deploySchema))
+
+	fmt.Println(elicitContent(resp))
+	// Output: [env=prod replicas=2 verbose=false]
+}
+
+// A value the user supplied always wins. Defaults only fill absent keys, so
+// this never overwrites input, including a value that happens to equal the
+// zero value of its type.
+func ExampleWithElicitationHandler_defaultsDoNotOverwrite() {
+	c := client.NewClient("http://example.invalid",
+		core.ClientInfo{Name: "example", Version: "1.0"},
+		client.WithElicitationHandler(
+			func(ctx context.Context, req core.ElicitationRequest) (core.ElicitationResult, error) {
+				return core.ElicitationResult{
+					Action:  "accept",
+					Content: map[string]any{"env": "staging", "replicas": 0},
+				}, nil
+			},
+		),
+	)
+
+	resp := c.HandleServerRequestWithContext(context.Background(), elicitRequest(deploySchema))
+
+	fmt.Println(elicitContent(resp))
+	// Output: [env=staging replicas=0 verbose=false]
+}
+
+// Defaults apply only when the user accepted. On decline or cancel the result's
+// content is undefined, so filling defaults would invent input the user never
+// gave.
+func ExampleWithElicitationHandler_defaultsSkippedOnDecline() {
+	c := client.NewClient("http://example.invalid",
+		core.ClientInfo{Name: "example", Version: "1.0"},
+		client.WithElicitationHandler(
+			func(ctx context.Context, req core.ElicitationRequest) (core.ElicitationResult, error) {
+				return core.ElicitationResult{Action: "decline"}, nil
+			},
+		),
+	)
+
+	resp := c.HandleServerRequestWithContext(context.Background(), elicitRequest(deploySchema))
+
+	var out core.ElicitationResult
+	_ = resp.ResultAs(&out)
+	fmt.Println(out.Action, len(out.Content))
+	// Output: decline 0
+}
+
+// A default whose type contradicts the schema is dropped rather than sent.
+// Forwarding it would put wire-invalid data in front of the server, so the key
+// is simply left absent and the server sees an omitted field.
+func ExampleWithElicitationHandler_defaultsTypeMismatch() {
+	const badSchema = `{
+      "type": "object",
+      "properties": {
+        "replicas": {"type": "integer", "default": "two"},
+        "env":      {"type": "string",  "default": "dev"}
+      }
+    }`
+
+	c := client.NewClient("http://example.invalid",
+		core.ClientInfo{Name: "example", Version: "1.0"},
+		client.WithElicitationHandler(
+			func(ctx context.Context, req core.ElicitationRequest) (core.ElicitationResult, error) {
+				return core.ElicitationResult{Action: "accept", Content: map[string]any{}}, nil
+			},
+		),
+	)
+
+	resp := c.HandleServerRequestWithContext(context.Background(), elicitRequest(badSchema))
+
+	fmt.Println(elicitContent(resp))
+	// Output: [env=dev]
+}

--- a/docs/ELICITATION.md
+++ b/docs/ELICITATION.md
@@ -1,0 +1,122 @@
+# Elicitation
+
+A tool handler that needs a decision from the user, not from the model, asks for it with elicitation. The server sends `elicitation/create` with a JSON Schema describing what it wants; the client renders a form, collects the answer, and sends it back.
+
+This is a server-to-client request, the reverse of the usual direction. The client must have declared elicitation support at handshake time, so a handler cannot rely on it being available.
+
+## Asking for input
+
+```go
+result, err := ctx.Elicit(core.ElicitationRequest{
+    Message: "Which database should I connect to?",
+    RequestedSchema: json.RawMessage(`{
+        "type": "object",
+        "properties": {
+            "database": {"type": "string", "enum": ["prod", "staging", "dev"]}
+        }
+    }`),
+})
+```
+
+`result.Action` is `accept`, `decline`, or `cancel`. Check it before touching `result.Content`: on decline and cancel the content is undefined, and a user who cancelled has not given you a value to fall back on.
+
+Errors worth distinguishing:
+
+| Error | Means |
+|---|---|
+| `ErrElicitationNotSupported` | the client never declared the capability |
+| `ErrNoRequestFunc` | no push channel, see the stateless note below |
+| `context.DeadlineExceeded` | the user did not answer in time |
+
+Runnable examples of the defaults behavior described below are in [`client/example_elicitation_test.go`](../client/example_elicitation_test.go).
+
+## Defaults
+
+A schema property can declare a `default`. When the user accepts and leaves that field out, the client fills it in before the response goes back to the server:
+
+```json
+{"type": "object", "properties": {
+  "env":      {"type": "string",  "default": "dev"},
+  "replicas": {"type": "integer", "default": 2}
+}}
+```
+
+A handler that returns only `{"env": "prod"}` produces `{"env": "prod", "replicas": 2}` on the wire.
+
+The merge happens inside mcpkit's `elicitation/create` dispatch path, after your handler returns. Handler authors stay unaware of it: return what the user typed and the defaults land on their own.
+
+Four rules govern the merge:
+
+- **User input always wins.** Defaults fill absent keys only, so a supplied value is never overwritten, including one that equals its type's zero value.
+- **Defaults apply only on `accept`.** Filling them on decline or cancel would invent input the user never gave.
+- **A default whose type contradicts its schema is dropped.** An `integer` property declaring `"default": "two"` sends no value at all, because forwarding it would put wire-invalid data in front of the server.
+- **`integer` accepts a whole number.** JSON numbers all decode to `float64` in Go, so a default of `2` satisfies an `integer` property while `2.5` does not.
+
+This implements SEP-1034.
+
+## Enums
+
+An `enum` makes the client render a fixed choice instead of a free-text field. `enumNames` is optional and supplies display labels positionally; a client that does not understand it falls back to the raw values.
+
+```json
+{"env": {
+  "type": "string",
+  "enum": ["dev", "staging", "prod"],
+  "enumNames": ["Development", "Staging", "Production"],
+  "default": "dev"
+}}
+```
+
+## mcpkit does not validate the response
+
+The schema tells the client what to collect. It is not enforced on the way back: mcpkit does not check `result.Content` against `requestedSchema` before handing it to your handler.
+
+So a handler that asked for an `integer` can receive a string, and one that offered three enum values can receive a fourth. Validate anything you are going to act on:
+
+```go
+env, ok := result.Content["env"].(string)
+if !ok || !slices.Contains([]string{"dev", "staging", "prod"}, env) {
+    return core.ErrorResult("invalid environment"), nil
+}
+```
+
+Content values are decoded JSON, so numbers arrive as `float64` and objects as `map[string]any`, the same as prompt arguments.
+
+## URL mode
+
+Some flows cannot happen in a form: an OAuth consent screen, a payment step, a device pairing page. URL mode hands the user a link instead of a schema.
+
+```go
+core.ElicitURL(ctx, core.ElicitationRequest{
+    Message:       "Approve access in your browser",
+    Mode:          core.ElicitModeURL,
+    URL:           "https://example.com/consent/abc",
+    ElicitationID: "abc",
+})
+```
+
+Note the shape: form-mode elicitation has a context method (`ctx.Elicit`), while `ElicitURL` is a package function taking the context as its first argument. A handler context embeds `context.Context`, so passing `ctx` straight through works.
+
+`RequestedSchema` must not be set in URL mode, and the client must have opted in with `WithElicitationURLSupport`, separately from the form-mode handler. Without it the request is rejected as invalid params.
+
+The response only tells you the user acknowledged the link. When the out-of-band flow actually finishes, the server signals it with `NotifyElicitationComplete`, which sends `notifications/elicitation/complete` carrying the `elicitationId` so the client can correlate it with the original request and retry whatever was blocked. This is SEP-1036.
+
+## On the stateless wire
+
+`ctx.Elicit` needs a server-to-client push channel, which the SEP-2575 stateless wire does not have: the spec forbids independent JSON-RPC requests on a `tools/call` response stream. Calling it there returns `ErrNoRequestFunc`.
+
+Stateless handlers ask through MRTR instead, which carries the request in the tool result and gets the answer on a follow-up call:
+
+```go
+return ctx.RequestInput(core.InputRequests{
+    "which-db": core.NewElicitationInputRequest(req),
+})
+```
+
+See [MRTR_TUTORIAL.md](MRTR_TUTORIAL.md). The client side needs no extra work: `DefaultInputHandler` routes an MRTR elicitation request to the same handler a push-mode request would reach.
+
+## Related
+
+- [MRTR input-gathering](MRTR_TUTORIAL.md) for the stateless and multi-round path
+- [Prompts](PROMPTS.md) for the other place schemas describe user-supplied values
+- `examples/elicitation/` for a runnable two-terminal walkthrough including URL mode

--- a/docs/site/content/HeaderNavLinks.json
+++ b/docs/site/content/HeaderNavLinks.json
@@ -12,6 +12,7 @@
       { "name": "Long-running tasks",  "url": "guides/tasks/" },
       { "name": "MCP Apps",            "url": "guides/apps/" },
       { "name": "Prompts",             "url": "guides/prompts/" },
+      { "name": "Elicitation",         "url": "guides/elicitation/" },
       { "name": "Argument completion", "url": "guides/completions/" },
       { "name": "Observability",       "url": "guides/observability/" },
       { "name": "MRTR input-gathering","url": "guides/mrtr/" },

--- a/docs/site/content/guides/elicitation/index.html
+++ b/docs/site/content/guides/elicitation/index.html
@@ -1,0 +1,7 @@
+---
+title: "Elicitation"
+description: "Ask the user for structured input: schemas, SEP-1034 defaults, enums, URL mode."
+source: "docs/ELICITATION.md"
+---
+
+{{ renderMarkdownFile "docs/ELICITATION.md" }}


### PR DESCRIPTION
## What changes

Adds `docs/ELICITATION.md` and four runnable `Example*` functions covering SEP-1034 defaults.

Defaults are fully implemented in `client/elicitation_defaults.go` but were documented only in Go doc comments, which the audit rubric excludes. So the row graded FAIL despite the code working correctly.

Slice 3 of issue 1219, docs half. The remaining row (#26, schema validation) needs code and is deliberately left open; see below.

## Reviewer's guide

1. [client/example_elicitation_test.go](https://github.com/panyam/mcpkit/pull/1233/files#diff-d1268f3cff3c8de29b8dac8904136936f2b2a7fd95167e7be0b1ae4482621013) — start here. Four examples pinning the four merge rules.
2. [docs/ELICITATION.md](https://github.com/panyam/mcpkit/pull/1233/files#diff-df73c2db41be81870fd7a9dbfba1dbe24d7d308a47ef4bd2035e1fd3688eaad8) — the guide.
3. [README.md](https://github.com/panyam/mcpkit/pull/1233/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5), `docs/site/content/` — link and nav wiring.

## The four merge rules, each with an example

The merge runs inside the `elicitation/create` dispatch path after your handler returns, so handler authors can stay SEP-1034-unaware and return exactly what the user typed:

- **User input wins.** Defaults fill absent keys only, so a supplied value is never overwritten, including one equal to its type's zero value. The `replicas: 0` case pins this.
- **Only on `accept`.** Filling on decline or cancel would invent input the user never gave.
- **Type-mismatched defaults are dropped.** An `integer` property declaring `"default": "two"` sends nothing, because forwarding it would put wire-invalid data in front of the server.
- **`integer` accepts a whole number.** JSON numbers decode to `float64`, so `2` satisfies `integer` and `2.5` does not.

`Client.HandleServerRequestWithContext` is public, so all four run with no live server: construct a client with an elicitation handler, hand it an `elicitation/create` request, inspect the merged result.

## The validation gap is documented, not papered over

The guide states plainly that **mcpkit does not validate a response against `requestedSchema`**. A handler that asked for an `integer` can receive a string; one that offered three enum values can receive a fourth. The guide shows the handler-side check rather than implying the schema is enforced.

That is audit row #26. It cannot be closed with prose, so it stays FAIL pending a decision on whether to implement validation. Flagged on issue 1219.

## An error caught before shipping

`ElicitURL` is a **package function** taking `ctx` as its first argument, not a `BaseContext` method. My first draft wrote `ctx.ElicitURL(...)`, which does not compile. The guide now uses `core.ElicitURL(ctx, ...)` and calls out the asymmetry with form-mode's `ctx.Elicit`, since that inconsistency is exactly what would trip a reader.

Fourth such catch across this slice sequence, after the `-31003` error code, `defaultPageSize` being permanently `0`, and the stale `PromptResponse` comment.

## Before / after

```
Go Example* functions:      21  ->  25

SEP-1730 audit rows:
  #27 Elicitation - default values     FAIL  ->  PASS
  #26 Elicitation - schema validation  FAIL (unchanged, needs code)

Issue 1219 undocumented features:    2  ->  1
Audit total:                     46/48  ->  47/48
```

Examples running:

```
--- PASS: ExampleWithElicitationHandler_defaults (0.00s)
--- PASS: ExampleWithElicitationHandler_defaultsDoNotOverwrite (0.00s)
--- PASS: ExampleWithElicitationHandler_defaultsSkippedOnDecline (0.00s)
--- PASS: ExampleWithElicitationHandler_defaultsTypeMismatch (0.00s)
ok  github.com/panyam/mcpkit/client  0.917s
```

## Risk / blast radius

- Docs and one test file. No production code is touched.
- All four examples run in the existing `test` job.
- Every API name in the guide was checked against the source: `Elicit`, `ElicitURL`, `ErrElicitationNotSupported`, `ErrNoRequestFunc`, `NewElicitationInputRequest`, `ErrorResult`, `ElicitModeURL`, `NotifyElicitationComplete`, `WithElicitationURLSupport`.

Assertions added: 4 `Output` blocks. Assertions removed or weakened: 0. No existing test is modified.

## Out of scope

- **Implementing response validation (#26).** The last remaining audit row and a correctness question in its own right: a server currently asks for a schema and gets back whatever the handler produced, unchecked.
- Slice 5, the 15 stub pages under `tutorials/walkthrough/`. Tier-neutral and a project in itself.

