### PR TITLE
feat(client): validate elicitation responses against requestedSchema

### DIFF
--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -60,7 +60,7 @@ _Scenarios authored by this project, typically in the `panyam/mcpconformance` fo
 
 | Suite | Covers | Stage | Status | Source | Tracking |
 |---|---|:---:|:---:|---|---|
-| `testconf-file-inputs` | SEP-2356 File inputs | 8f | **PASS** | [`panyam/mcpconformance@pending`](https://github.com/panyam/mcpconformance/tree/pending) | — |
+| `testconf-file-inputs` | SEP-2356 File inputs (withdrawn upstream) | 8f | **PASS** | [`panyam/mcpconformance@pending`](https://github.com/panyam/mcpconformance/tree/pending) | mcpkit 827 |
 | `testconf-auth-server` | MCP authz 2025-11-25 | 8g | **PASS** | [`panyam/mcpconformance@pending`](https://github.com/panyam/mcpconformance/tree/pending) | — |
 | `testconf-skills` | SEP-2640 Skills | 8h | _INFO_<sup>3</sup> | [`panyam/mcpconformance@chore/sep-2640-yaml`](https://github.com/panyam/mcpconformance/tree/chore/sep-2640-yaml) | mcpkit 567 |
 

--- a/README.md
+++ b/README.md
@@ -96,11 +96,13 @@ mcpkit passes the [official MCP conformance suite](https://github.com/modelconte
 | MRTR | [SEP-2322](https://github.com/modelcontextprotocol/conformance) | **3/3** negative (upstream) |
 | Stateless wire | [SEP-2575](https://github.com/modelcontextprotocol/conformance) | **30/30** (upstream) |
 | List-TTL | SEP-2549 | **5/5** |
-| File-Inputs | SEP-2356 | **7/7** |
+| File-Inputs | SEP-2356 (withdrawn upstream, see below) | **7/7** |
 | Skills | SEP-2640 | fixture-driven |
 | Keycloak interop | — | **12/12** |
 
 Tasks v2, MRTR, and the SEP-2575 stateless wire all run against [`modelcontextprotocol/conformance`](https://github.com/modelcontextprotocol/conformance) `main` directly (merged upstream). The full per-SEP rollup is published at [panyam.github.io/mcpkit/conformance](https://panyam.github.io/mcpkit/conformance/).
+
+**On SEP-2356:** the working group closed it on 2026-06-26 in favour of SEP-2631 (File Objects and Transfer), which is still in draft. The file-input surface mcpkit ships and the scenarios above continue to work and are still exercised in CI; the row is kept so the behaviour stays covered, not as a claim of conformance to a live proposal. Migration to SEP-2631 is tracked in issue 827.
 
 Three artifacts describe mcpkit's conformance posture at increasing granularity:
 

--- a/agent/store/gorm/go.mod
+++ b/agent/store/gorm/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/panyam/goutils v0.1.8 // indirect
 	github.com/panyam/servicekit v0.1.4 // indirect
 	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.2 // indirect
 	golang.org/x/sync v0.21.0 // indirect

--- a/agent/store/gorm/go.sum
+++ b/agent/store/gorm/go.sum
@@ -5,6 +5,8 @@ github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx2
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/agent/store/redis/go.mod
+++ b/agent/store/redis/go.mod
@@ -23,11 +23,13 @@ require (
 	github.com/panyam/goutils v0.1.8 // indirect
 	github.com/panyam/servicekit v0.1.4 // indirect
 	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.2 // indirect
 	golang.org/x/sys v0.45.0 // indirect
+	golang.org/x/text v0.39.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/grpc v1.83.0 // indirect

--- a/agent/store/redis/go.sum
+++ b/agent/store/redis/go.sum
@@ -12,6 +12,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/agent/surfaces/go.mod
+++ b/agent/surfaces/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/panyam/servicekit v0.1.4 // indirect
 	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
 	github.com/pgvector/pgvector-go v0.4.1 // indirect
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.2 // indirect

--- a/agent/surfaces/go.sum
+++ b/agent/surfaces/go.sum
@@ -13,6 +13,8 @@ github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/agent/surfaces/web/go.mod
+++ b/agent/surfaces/web/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/panyam/mcpkit v0.4.0
 	github.com/panyam/mcpkit/agent v0.0.0
 	github.com/panyam/mcpkit/agent/host v0.0.0
-	github.com/panyam/servicekit v0.1.4
 	github.com/panyam/mcpkit/agent/surfaces v0.0.0
+	github.com/panyam/servicekit v0.1.4
 	google.golang.org/protobuf v1.36.11
 )
 

--- a/client/client.go
+++ b/client/client.go
@@ -119,6 +119,26 @@ func WithElicitationURLSupport() ClientOption {
 	return func(c *Client) { c.elicitationURLSupport = true }
 }
 
+// WithElicitationValidation controls whether accepted elicitation responses are
+// checked against the server's requestedSchema before being sent. Enabled by
+// default, mirroring the server, which validates inbound tool and prompt
+// arguments against their advertised schemas.
+//
+// The client is the only party that sees both the schema and the user's input,
+// so it is the only one that can catch a mismatch. When validation fails the
+// request is answered with -32602 and a structured error list rather than
+// forwarding content the server asked not to receive.
+//
+// A malformed or uncompilable schema is never an error: the defect is the
+// server's and the user answered in good faith, so validation is skipped.
+//
+// Pass false to send whatever the handler produced:
+//
+//	c := client.NewClient(url, info, client.WithElicitationValidation(false))
+func WithElicitationValidation(enabled bool) ClientOption {
+	return func(c *Client) { c.skipElicitationValidation = !enabled }
+}
+
 // WithElicitationCompleteHandler registers a handler for
 // notifications/elicitation/complete notifications (SEP-1036).
 func WithElicitationCompleteHandler(h ElicitationCompleteHandler) ClientOption {
@@ -418,6 +438,7 @@ type Client struct {
 	samplingHandler            SamplingHandler
 	elicitationHandler         ElicitationHandler
 	elicitationURLSupport      bool
+	skipElicitationValidation  bool
 	fileInputs                 bool
 	elicitationCompleteHandler ElicitationCompleteHandler
 	rootsHandler               RootsHandler
@@ -1027,6 +1048,17 @@ func (c *Client) dispatchServerRequest(ctx context.Context, req *core.Request) *
 		if result.Action == "accept" {
 			defaults := extractElicitationDefaults(params.RequestedSchema)
 			result.Content = mergeElicitationDefaults(result.Content, defaults)
+
+			// Validate what we are about to send against the schema the
+			// server asked for. Runs after the defaults merge because a
+			// schema-declared default can be what satisfies a `required`
+			// property. Opt out with WithElicitationValidation(false).
+			if !c.skipElicitationValidation {
+				if ve := validateElicitationContent(params.RequestedSchema, result.Content); ve != nil {
+					return core.NewErrorResponseWithData(req.ID, core.ErrCodeInvalidParams,
+						"elicitation response does not match requestedSchema", ve)
+				}
+			}
 		}
 		return core.NewResponse(req.ID, result)
 

--- a/client/elicitation_validation.go
+++ b/client/elicitation_validation.go
@@ -1,0 +1,55 @@
+package client
+
+import (
+	"encoding/json"
+
+	core "github.com/panyam/mcpkit/core"
+)
+
+// Elicitation response validation.
+//
+// A server sends elicitation/create with a RequestedSchema describing the
+// shape it needs. Nothing previously checked that what came back matched: a
+// handler that asked for an integer could hand the server a string, and one
+// that offered three enum values could receive a fourth. The server has no way
+// to tell a conforming answer from a malformed one, because the client is the
+// only party that saw both the schema and the user's input.
+//
+// Validation runs AFTER the SEP-1034 defaults merge, since a schema-declared
+// default can be what satisfies a `required` property.
+//
+// Symmetric with the server, which validates inbound tool and prompt arguments
+// against their advertised schemas and rejects with -32602. Both sides share
+// the compiler in core.
+
+// validateElicitationContent checks accepted elicitation content against the
+// schema the server asked for. Returns nil when the content conforms, when
+// there is no schema, or when the schema itself cannot be compiled.
+//
+// A malformed or uncompilable schema is deliberately NOT an error. The user
+// answered in good faith and the defect is on the server's side, so refusing
+// their input would punish the wrong party. This mirrors
+// extractElicitationDefaults, which also skips rather than fails on a schema
+// it cannot read.
+func validateElicitationContent(rawSchema json.RawMessage, content map[string]any) *core.ValidationErrors {
+	if len(rawSchema) == 0 {
+		return nil
+	}
+
+	var schema any
+	if err := json.Unmarshal(rawSchema, &schema); err != nil {
+		return nil
+	}
+
+	compiled, err := core.CompileSchema(schema)
+	if err != nil || compiled == nil {
+		return nil
+	}
+
+	// An accepted elicitation with no content is an empty object, not null;
+	// that distinction matters for a schema declaring `required`.
+	if content == nil {
+		content = map[string]any{}
+	}
+	return compiled.ValidateValue(content)
+}

--- a/client/elicitation_validation_test.go
+++ b/client/elicitation_validation_test.go
@@ -1,0 +1,213 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	core "github.com/panyam/mcpkit/core"
+)
+
+const validationSchema = `{
+  "type": "object",
+  "properties": {
+    "env":      {"type": "string", "enum": ["dev", "prod"]},
+    "replicas": {"type": "integer"}
+  },
+  "required": ["env"]
+}`
+
+func elicitCreateRequest(t *testing.T, schema string) *core.Request {
+	t.Helper()
+	params, err := json.Marshal(core.ElicitationRequest{
+		Message:         "configure",
+		RequestedSchema: json.RawMessage(schema),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &core.Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  "elicitation/create",
+		Params:  core.NewRawJSON(params),
+	}
+}
+
+func clientReturning(res core.ElicitationResult, opts ...ClientOption) *Client {
+	all := append([]ClientOption{
+		WithElicitationHandler(func(context.Context, core.ElicitationRequest) (core.ElicitationResult, error) {
+			return res, nil
+		}),
+	}, opts...)
+	return NewClient("http://example.invalid", core.ClientInfo{Name: "t", Version: "1"}, all...)
+}
+
+func TestElicitationValidationRejectsWrongType(t *testing.T) {
+	c := clientReturning(core.ElicitationResult{
+		Action:  "accept",
+		Content: map[string]any{"env": "dev", "replicas": "two"},
+	})
+
+	resp := c.HandleServerRequestWithContext(context.Background(), elicitCreateRequest(t, validationSchema))
+
+	if resp.Error == nil {
+		t.Fatal("expected an error response for a string in an integer property")
+	}
+	if resp.Error.Code != core.ErrCodeInvalidParams {
+		t.Errorf("code = %d, want %d", resp.Error.Code, core.ErrCodeInvalidParams)
+	}
+	raw, _ := json.Marshal(resp.Error.Data)
+	var ve core.ValidationErrors
+	if err := json.Unmarshal(raw, &ve); err != nil || len(ve.Errors) == 0 {
+		t.Fatalf("expected structured ValidationErrors in error.data, got %s", raw)
+	}
+	if ve.Errors[0].Path != "/replicas" {
+		t.Errorf("path = %q, want /replicas", ve.Errors[0].Path)
+	}
+}
+
+func TestElicitationValidationRejectsValueOutsideEnum(t *testing.T) {
+	c := clientReturning(core.ElicitationResult{
+		Action:  "accept",
+		Content: map[string]any{"env": "staging"},
+	})
+
+	resp := c.HandleServerRequestWithContext(context.Background(), elicitCreateRequest(t, validationSchema))
+
+	if resp.Error == nil {
+		t.Fatal("expected an error response for a value outside the declared enum")
+	}
+}
+
+func TestElicitationValidationRejectsMissingRequired(t *testing.T) {
+	c := clientReturning(core.ElicitationResult{
+		Action:  "accept",
+		Content: map[string]any{"replicas": 3},
+	})
+
+	resp := c.HandleServerRequestWithContext(context.Background(), elicitCreateRequest(t, validationSchema))
+
+	if resp.Error == nil {
+		t.Fatal("expected an error response when a required property is absent")
+	}
+}
+
+func TestElicitationValidationAcceptsConformingContent(t *testing.T) {
+	c := clientReturning(core.ElicitationResult{
+		Action:  "accept",
+		Content: map[string]any{"env": "prod", "replicas": 3},
+	})
+
+	resp := c.HandleServerRequestWithContext(context.Background(), elicitCreateRequest(t, validationSchema))
+
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %s", resp.Error.Message)
+	}
+}
+
+// A default supplied by SEP-1034 must be able to satisfy `required`, which only
+// works if validation runs after the merge rather than before it.
+func TestElicitationValidationRunsAfterDefaultsMerge(t *testing.T) {
+	const schema = `{
+      "type": "object",
+      "properties": {"env": {"type": "string", "default": "dev"}},
+      "required": ["env"]
+    }`
+
+	c := clientReturning(core.ElicitationResult{Action: "accept", Content: map[string]any{}})
+
+	resp := c.HandleServerRequestWithContext(context.Background(), elicitCreateRequest(t, schema))
+
+	if resp.Error != nil {
+		t.Fatalf("default should have satisfied required, got: %s", resp.Error.Message)
+	}
+	var out core.ElicitationResult
+	if err := resp.ResultAs(&out); err != nil {
+		t.Fatal(err)
+	}
+	if out.Content["env"] != "dev" {
+		t.Errorf("env = %v, want dev", out.Content["env"])
+	}
+}
+
+// Content is undefined for decline and cancel, so there is nothing to validate.
+func TestElicitationValidationSkippedWhenNotAccepted(t *testing.T) {
+	for _, action := range []string{"decline", "cancel"} {
+		c := clientReturning(core.ElicitationResult{
+			Action:  action,
+			Content: map[string]any{"replicas": "not-an-integer"},
+		})
+
+		resp := c.HandleServerRequestWithContext(context.Background(), elicitCreateRequest(t, validationSchema))
+
+		if resp.Error != nil {
+			t.Errorf("action %q: unexpected error: %s", action, resp.Error.Message)
+		}
+	}
+}
+
+// The defect is the server's, and the user answered in good faith, so a schema
+// that cannot be compiled must not block their input.
+func TestElicitationValidationSkippedOnUncompilableSchema(t *testing.T) {
+	// Valid JSON, invalid JSON Schema: `type` must be a string or array.
+	const badSchema = `{"type": "object", "properties": {"env": {"type": 42}}}`
+
+	c := clientReturning(core.ElicitationResult{
+		Action:  "accept",
+		Content: map[string]any{"anything": true},
+	})
+
+	resp := c.HandleServerRequestWithContext(context.Background(), elicitCreateRequest(t, badSchema))
+
+	if resp.Error != nil {
+		t.Errorf("expected pass-through, got: %s", resp.Error.Message)
+	}
+}
+
+// Schema bytes that are not valid JSON cannot arrive over the wire: they would
+// make the enclosing JSON-RPC message unparseable, so dispatch would reject it
+// long before the handler runs. The guard is exercised directly instead.
+func TestValidateElicitationContentGuardsUnparseableSchema(t *testing.T) {
+	got := validateElicitationContent(json.RawMessage(`{"type": "object", `), map[string]any{"a": 1})
+	if got != nil {
+		t.Errorf("expected nil for unparseable schema, got %+v", got)
+	}
+}
+
+func TestElicitationValidationOptOut(t *testing.T) {
+	c := clientReturning(
+		core.ElicitationResult{
+			Action:  "accept",
+			Content: map[string]any{"env": "dev", "replicas": "two"},
+		},
+		WithElicitationValidation(false),
+	)
+
+	resp := c.HandleServerRequestWithContext(context.Background(), elicitCreateRequest(t, validationSchema))
+
+	if resp.Error != nil {
+		t.Fatalf("validation should be off: %s", resp.Error.Message)
+	}
+	var out core.ElicitationResult
+	if err := resp.ResultAs(&out); err != nil {
+		t.Fatal(err)
+	}
+	if out.Content["replicas"] != "two" {
+		t.Errorf("replicas = %v, want the handler's value passed through", out.Content["replicas"])
+	}
+}
+
+// No schema means nothing to validate against.
+func TestElicitationValidationNoSchema(t *testing.T) {
+	c := clientReturning(core.ElicitationResult{
+		Action:  "accept",
+		Content: map[string]any{"free": "form"},
+	})
+
+	resp := c.HandleServerRequestWithContext(context.Background(), elicitCreateRequest(t, ""))
+
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %s", resp.Error.Message)
+	}
+}

--- a/conformance/local-suites.yaml
+++ b/conformance/local-suites.yaml
@@ -51,9 +51,10 @@ suites:
       default_path: ../conf-upstream-main
 
   - suite: testconf-file-inputs
-    sep: SEP-2356 File inputs
+    sep: SEP-2356 File inputs (withdrawn upstream)
     stage: 8f
     status: PASS
+    tracking: "mcpkit 827"
     source:
       repo: panyam/mcpconformance
       branch: pending

--- a/core/schema_validator.go
+++ b/core/schema_validator.go
@@ -1,0 +1,211 @@
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+// ValidationError is one violation reported by schema validation.
+// Path is a JSON Pointer to the offending value (e.g., "/age"),
+// Keyword is the JSON Schema keyword that failed (e.g., "type", "format"),
+// and Message is a human-readable description.
+type ValidationError struct {
+	Path    string `json:"path"`
+	Keyword string `json:"keyword"`
+	Message string `json:"message"`
+}
+
+// ValidationErrors is the payload returned in the error.data field of
+// JSON-RPC -32602 responses when argument validation fails.
+type ValidationErrors struct {
+	Errors []ValidationError `json:"errors"`
+}
+
+// CompiledSchema wraps a compiled JSON Schema for use at dispatch time.
+// Compiled once at registration; used to validate many incoming requests.
+// CompiledSchema wraps a compiled JSON Schema for repeated validation.
+// Compile once, validate many times.
+type CompiledSchema struct {
+	schema *jsonschema.Schema
+}
+
+// CompileSchema compiles a JSON Schema value (as stored on ToolDef.InputSchema
+// or PromptArgument.Schema) into a validator. The schema is expected to be
+// an `any` value that round-trips through JSON (map[string]any is typical).
+//
+// Network $ref resolution is disabled — all $refs must resolve within the
+// advertised schema via $defs or fragment pointers. This prevents servers
+// from unknowingly opening HTTP fetches to untrusted hosts at validation time.
+//
+// Returns a non-nil compiled schema on success, or an error if the schema
+// is malformed.
+func CompileSchema(schemaValue any) (*CompiledSchema, error) {
+	if schemaValue == nil {
+		return nil, nil
+	}
+
+	// Marshal to JSON bytes so we can re-parse through the jsonschema library.
+	// This normalizes the representation (map[string]any, json.RawMessage,
+	// user-defined structs, etc.) into a single canonical form.
+	raw, err := json.Marshal(schemaValue)
+	if err != nil {
+		return nil, fmt.Errorf("marshal schema: %w", err)
+	}
+
+	// Unmarshal into the loose form that jsonschema/v6 expects.
+	var loose any
+	if err := json.Unmarshal(raw, &loose); err != nil {
+		return nil, fmt.Errorf("unmarshal schema: %w", err)
+	}
+
+	// Use a compiler with a restrictive loader — refuses all remote fetches.
+	compiler := jsonschema.NewCompiler()
+	compiler.UseLoader(noNetworkLoader{})
+
+	// Register the schema under a synthetic URL so the compiler can reference it.
+	const schemaURL = "mem://schema.json"
+	if err := compiler.AddResource(schemaURL, loose); err != nil {
+		return nil, fmt.Errorf("add schema resource: %w", err)
+	}
+
+	sch, err := compiler.Compile(schemaURL)
+	if err != nil {
+		return nil, fmt.Errorf("compile schema: %w", err)
+	}
+	return &CompiledSchema{schema: sch}, nil
+}
+
+// validate checks a raw JSON value against the compiled schema. Returns nil
+// if the value conforms, or a ValidationErrors struct containing all
+// violations otherwise.
+//
+// The raw argument is typically envelope.Arguments (json.RawMessage) from
+// a tools/call request. nil/empty raw is treated as an empty object ({}).
+func (c *CompiledSchema) Validate(raw json.RawMessage) *ValidationErrors {
+	if c == nil || c.schema == nil {
+		return nil
+	}
+
+	var value any
+	// Treat missing, empty, or explicit null arguments as an empty object.
+	// This matches the spec-level intent: tools that declare `{"type":"object"}`
+	// but accept no arguments should pass validation when the client sends
+	// `"arguments": null`, `"arguments": {}`, or omits the field entirely.
+	if len(raw) == 0 || string(raw) == "null" {
+		value = map[string]any{}
+	} else if err := json.Unmarshal(raw, &value); err != nil {
+		return &ValidationErrors{
+			Errors: []ValidationError{{
+				Path:    "/",
+				Keyword: "parse",
+				Message: "invalid JSON: " + err.Error(),
+			}},
+		}
+	}
+
+	if err := c.schema.Validate(value); err != nil {
+		return convertValidationError(err)
+	}
+	return nil
+}
+
+// validateValue is like validate but takes a pre-decoded Go value.
+// Used for prompt arguments that have already been unmarshaled from the
+// request envelope into a map[string]any.
+func (c *CompiledSchema) ValidateValue(value any) *ValidationErrors {
+	if c == nil || c.schema == nil {
+		return nil
+	}
+	if err := c.schema.Validate(value); err != nil {
+		return convertValidationError(err)
+	}
+	return nil
+}
+
+// convertValidationError turns a jsonschema.ValidationError into our
+// ValidationErrors wire format. The jsonschema library reports nested
+// errors via .Causes — we walk the tree and flatten leaf-level errors.
+func convertValidationError(err error) *ValidationErrors {
+	ve, ok := err.(*jsonschema.ValidationError)
+	if !ok {
+		return &ValidationErrors{
+			Errors: []ValidationError{{
+				Path:    "/",
+				Keyword: "",
+				Message: err.Error(),
+			}},
+		}
+	}
+
+	var out []ValidationError
+	walkValidationErrors(ve, &out)
+	if len(out) == 0 {
+		// No leaf errors collected — fall back to the top-level message
+		out = append(out, ValidationError{
+			Path:    instanceLocationPath(ve),
+			Keyword: "",
+			Message: ve.Error(),
+		})
+	}
+	return &ValidationErrors{Errors: out}
+}
+
+// walkValidationErrors flattens nested validation errors into a slice,
+// collecting only leaf errors (those with no further causes). This gives
+// callers a flat list of specific violations rather than a tree.
+func walkValidationErrors(ve *jsonschema.ValidationError, out *[]ValidationError) {
+	if len(ve.Causes) == 0 {
+		// Leaf error — record it
+		kind := ""
+		if ve.ErrorKind != nil {
+			kind = kindKeyword(fmt.Sprintf("%T", ve.ErrorKind))
+		}
+		*out = append(*out, ValidationError{
+			Path:    instanceLocationPath(ve),
+			Keyword: kind,
+			Message: ve.Error(),
+		})
+		return
+	}
+	for _, cause := range ve.Causes {
+		walkValidationErrors(cause, out)
+	}
+}
+
+// instanceLocationPath converts a jsonschema InstanceLocation ([]string)
+// to a JSON Pointer string. Empty location becomes "/" (the root).
+func instanceLocationPath(ve *jsonschema.ValidationError) string {
+	if len(ve.InstanceLocation) == 0 {
+		return "/"
+	}
+	return "/" + strings.Join(ve.InstanceLocation, "/")
+}
+
+// kindKeyword extracts the JSON Schema keyword from a jsonschema ErrorKind
+// type name. The library uses types like "*jsonschema.kind.Type" — we strip
+// the package prefix and lowercase the result for a stable keyword string.
+func kindKeyword(typeName string) string {
+	// Examples: "*kind.Type" → "type", "*kind.Format" → "format"
+	if idx := strings.LastIndex(typeName, "."); idx >= 0 {
+		typeName = typeName[idx+1:]
+	}
+	return strings.ToLower(typeName)
+}
+
+// noNetworkLoader is a jsonschema Loader that refuses all remote fetches.
+// This is the default loader for mcpkit — callers who want network $refs
+// must opt in via a separate mechanism (not currently supported).
+type noNetworkLoader struct{}
+
+// Load implements the jsonschema.URLLoader interface. It always returns an
+// error, effectively forbidding any $ref that doesn't resolve within the
+// compiled schema's own $defs.
+func (noNetworkLoader) Load(url string) (any, error) {
+	return nil, fmt.Errorf("network schema loading is disabled (attempted %q)", url)
+}
+
+// Ensure noNetworkLoader satisfies the expected interface.
+var _ jsonschema.URLLoader = noNetworkLoader{}

--- a/docs/ELICITATION.md
+++ b/docs/ELICITATION.md
@@ -67,20 +67,26 @@ An `enum` makes the client render a fixed choice instead of a free-text field. `
 }}
 ```
 
-## mcpkit does not validate the response
+## The response is validated against your schema
 
-The schema tells the client what to collect. It is not enforced on the way back: mcpkit does not check `result.Content` against `requestedSchema` before handing it to your handler.
+An accepted response is checked against `requestedSchema` before it is sent. A handler that returns a string where you asked for an `integer`, omits a `required` property, or supplies a value outside a declared `enum` produces a `-32602` error with a structured list of violations, rather than handing you content you did not ask for.
 
-So a handler that asked for an `integer` can receive a string, and one that offered three enum values can receive a fourth. Validate anything you are going to act on:
+The client is the only party in a position to catch this. It is the one that saw both the schema and the user's input; by the time the response reaches you, the schema is just a memory of what you requested.
+
+Validation runs **after** the defaults merge, so a schema-declared default can be what satisfies `required`.
+
+Two things it deliberately does not do:
+
+- **A malformed or uncompilable schema is not an error.** If your schema cannot be compiled, validation is skipped and the user's answer goes through. The defect is on the server side and the user answered in good faith, so refusing their input would punish the wrong party.
+- **Only `accept` is validated.** Content is undefined for decline and cancel.
+
+Turn it off with `client.WithElicitationValidation(false)`, which sends whatever the handler produced. This mirrors the server, where `WithSchemaValidation(false)` opts out of validating inbound tool and prompt arguments. Both default to on.
+
+Content values are decoded JSON, so numbers arrive as `float64` and objects as `map[string]any`, the same as prompt arguments. Validation confirms the shape; it does not convert types for you:
 
 ```go
-env, ok := result.Content["env"].(string)
-if !ok || !slices.Contains([]string{"dev", "staging", "prod"}, env) {
-    return core.ErrorResult("invalid environment"), nil
-}
+replicas, ok := result.Content["replicas"].(float64)  // not int, even for "type": "integer"
 ```
-
-Content values are decoded JSON, so numbers arrive as `float64` and objects as `map[string]any`, the same as prompt arguments.
 
 ## URL mode
 

--- a/experimental/ext/protogen/go.mod
+++ b/experimental/ext/protogen/go.mod
@@ -18,9 +18,11 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.2 // indirect
 	golang.org/x/sys v0.45.0 // indirect
+	golang.org/x/text v0.39.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/experimental/ext/protogen/go.sum
+++ b/experimental/ext/protogen/go.sum
@@ -5,6 +5,8 @@ github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx2
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
@@ -23,6 +25,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=

--- a/server/dispatch.go
+++ b/server/dispatch.go
@@ -640,7 +640,7 @@ func (d *Dispatcher) handleToolsCall(ctx context.Context, id json.RawMessage, pa
 	// WithSchemaValidation(false) and perform validation in their own
 	// handler, returning whatever response shape they need.
 	if !d.skipSchemaValidation && entry.schema != nil {
-		if ve := entry.schema.validate(envelope.Arguments); ve != nil {
+		if ve := entry.schema.Validate(envelope.Arguments); ve != nil {
 			return core.NewResponse(id, toolValidationErrorResult(envelope.Name, ve))
 		}
 	}
@@ -936,7 +936,7 @@ func (d *Dispatcher) handlePromptsGet(ctx context.Context, id json.RawMessage, p
 	if !d.skipSchemaValidation && len(entry.argSchemas) > 0 {
 		var allErrors []ValidationError
 		for argName, sch := range entry.argSchemas {
-			ve := sch.validateValue(envelope.Arguments[argName])
+			ve := sch.ValidateValue(envelope.Arguments[argName])
 			if ve == nil {
 				continue
 			}

--- a/server/schema_validator.go
+++ b/server/schema_validator.go
@@ -1,214 +1,34 @@
 package server
 
 import (
-	"encoding/json"
-	"fmt"
 	"io"
-	"strings"
 
-	"github.com/santhosh-tekuri/jsonschema/v6"
+	core "github.com/panyam/mcpkit/core"
 )
 
+// Schema validation moved to core/ so both sides of the protocol can use it.
+// The server validates inbound tool and prompt arguments; the client validates
+// an elicitation response against the schema the server asked for. Duplicating
+// the compiler in client/ was the alternative, and client must not import
+// server (the dependency runs the other way).
+//
+// These aliases keep the existing server API and call sites unchanged.
+
 // ValidationError is one violation reported by schema validation.
-// Path is a JSON Pointer to the offending value (e.g., "/age"),
-// Keyword is the JSON Schema keyword that failed (e.g., "type", "format"),
-// and Message is a human-readable description.
-type ValidationError struct {
-	Path    string `json:"path"`
-	Keyword string `json:"keyword"`
-	Message string `json:"message"`
-}
+type ValidationError = core.ValidationError
 
 // ValidationErrors is the payload returned in the error.data field of
 // JSON-RPC -32602 responses when argument validation fails.
-type ValidationErrors struct {
-	Errors []ValidationError `json:"errors"`
-}
+type ValidationErrors = core.ValidationErrors
 
-// compiledSchema wraps a compiled JSON Schema for use at dispatch time.
-// Compiled once at registration; used to validate many incoming requests.
-type compiledSchema struct {
-	schema *jsonschema.Schema
-}
+// compiledSchema is the server-internal spelling of core.CompiledSchema.
+type compiledSchema = core.CompiledSchema
 
-// compileSchema compiles a JSON Schema value (as stored on ToolDef.InputSchema
-// or PromptArgument.Schema) into a validator. The schema is expected to be
-// an `any` value that round-trips through JSON (map[string]any is typical).
-//
-// Network $ref resolution is disabled — all $refs must resolve within the
-// advertised schema via $defs or fragment pointers. This prevents servers
-// from unknowingly opening HTTP fetches to untrusted hosts at validation time.
-//
-// Returns a non-nil compiled schema on success, or an error if the schema
-// is malformed.
+// compileSchema compiles a JSON Schema value into a validator.
+// See core.CompileSchema.
 func compileSchema(schemaValue any) (*compiledSchema, error) {
-	if schemaValue == nil {
-		return nil, nil
-	}
-
-	// Marshal to JSON bytes so we can re-parse through the jsonschema library.
-	// This normalizes the representation (map[string]any, json.RawMessage,
-	// user-defined structs, etc.) into a single canonical form.
-	raw, err := json.Marshal(schemaValue)
-	if err != nil {
-		return nil, fmt.Errorf("marshal schema: %w", err)
-	}
-
-	// Unmarshal into the loose form that jsonschema/v6 expects.
-	var loose any
-	if err := json.Unmarshal(raw, &loose); err != nil {
-		return nil, fmt.Errorf("unmarshal schema: %w", err)
-	}
-
-	// Use a compiler with a restrictive loader — refuses all remote fetches.
-	compiler := jsonschema.NewCompiler()
-	compiler.UseLoader(noNetworkLoader{})
-
-	// Register the schema under a synthetic URL so the compiler can reference it.
-	const schemaURL = "mem://schema.json"
-	if err := compiler.AddResource(schemaURL, loose); err != nil {
-		return nil, fmt.Errorf("add schema resource: %w", err)
-	}
-
-	sch, err := compiler.Compile(schemaURL)
-	if err != nil {
-		return nil, fmt.Errorf("compile schema: %w", err)
-	}
-	return &compiledSchema{schema: sch}, nil
+	return core.CompileSchema(schemaValue)
 }
 
-// validate checks a raw JSON value against the compiled schema. Returns nil
-// if the value conforms, or a ValidationErrors struct containing all
-// violations otherwise.
-//
-// The raw argument is typically envelope.Arguments (json.RawMessage) from
-// a tools/call request. nil/empty raw is treated as an empty object ({}).
-func (c *compiledSchema) validate(raw json.RawMessage) *ValidationErrors {
-	if c == nil || c.schema == nil {
-		return nil
-	}
-
-	var value any
-	// Treat missing, empty, or explicit null arguments as an empty object.
-	// This matches the spec-level intent: tools that declare `{"type":"object"}`
-	// but accept no arguments should pass validation when the client sends
-	// `"arguments": null`, `"arguments": {}`, or omits the field entirely.
-	if len(raw) == 0 || string(raw) == "null" {
-		value = map[string]any{}
-	} else if err := json.Unmarshal(raw, &value); err != nil {
-		return &ValidationErrors{
-			Errors: []ValidationError{{
-				Path:    "/",
-				Keyword: "parse",
-				Message: "invalid JSON: " + err.Error(),
-			}},
-		}
-	}
-
-	if err := c.schema.Validate(value); err != nil {
-		return convertValidationError(err)
-	}
-	return nil
-}
-
-// validateValue is like validate but takes a pre-decoded Go value.
-// Used for prompt arguments that have already been unmarshaled from the
-// request envelope into a map[string]any.
-func (c *compiledSchema) validateValue(value any) *ValidationErrors {
-	if c == nil || c.schema == nil {
-		return nil
-	}
-	if err := c.schema.Validate(value); err != nil {
-		return convertValidationError(err)
-	}
-	return nil
-}
-
-// convertValidationError turns a jsonschema.ValidationError into our
-// ValidationErrors wire format. The jsonschema library reports nested
-// errors via .Causes — we walk the tree and flatten leaf-level errors.
-func convertValidationError(err error) *ValidationErrors {
-	ve, ok := err.(*jsonschema.ValidationError)
-	if !ok {
-		return &ValidationErrors{
-			Errors: []ValidationError{{
-				Path:    "/",
-				Keyword: "",
-				Message: err.Error(),
-			}},
-		}
-	}
-
-	var out []ValidationError
-	walkValidationErrors(ve, &out)
-	if len(out) == 0 {
-		// No leaf errors collected — fall back to the top-level message
-		out = append(out, ValidationError{
-			Path:    instanceLocationPath(ve),
-			Keyword: "",
-			Message: ve.Error(),
-		})
-	}
-	return &ValidationErrors{Errors: out}
-}
-
-// walkValidationErrors flattens nested validation errors into a slice,
-// collecting only leaf errors (those with no further causes). This gives
-// callers a flat list of specific violations rather than a tree.
-func walkValidationErrors(ve *jsonschema.ValidationError, out *[]ValidationError) {
-	if len(ve.Causes) == 0 {
-		// Leaf error — record it
-		kind := ""
-		if ve.ErrorKind != nil {
-			kind = kindKeyword(fmt.Sprintf("%T", ve.ErrorKind))
-		}
-		*out = append(*out, ValidationError{
-			Path:    instanceLocationPath(ve),
-			Keyword: kind,
-			Message: ve.Error(),
-		})
-		return
-	}
-	for _, cause := range ve.Causes {
-		walkValidationErrors(cause, out)
-	}
-}
-
-// instanceLocationPath converts a jsonschema InstanceLocation ([]string)
-// to a JSON Pointer string. Empty location becomes "/" (the root).
-func instanceLocationPath(ve *jsonschema.ValidationError) string {
-	if len(ve.InstanceLocation) == 0 {
-		return "/"
-	}
-	return "/" + strings.Join(ve.InstanceLocation, "/")
-}
-
-// kindKeyword extracts the JSON Schema keyword from a jsonschema ErrorKind
-// type name. The library uses types like "*jsonschema.kind.Type" — we strip
-// the package prefix and lowercase the result for a stable keyword string.
-func kindKeyword(typeName string) string {
-	// Examples: "*kind.Type" → "type", "*kind.Format" → "format"
-	if idx := strings.LastIndex(typeName, "."); idx >= 0 {
-		typeName = typeName[idx+1:]
-	}
-	return strings.ToLower(typeName)
-}
-
-// noNetworkLoader is a jsonschema Loader that refuses all remote fetches.
-// This is the default loader for mcpkit — callers who want network $refs
-// must opt in via a separate mechanism (not currently supported).
-type noNetworkLoader struct{}
-
-// Load implements the jsonschema.URLLoader interface. It always returns an
-// error, effectively forbidding any $ref that doesn't resolve within the
-// compiled schema's own $defs.
-func (noNetworkLoader) Load(url string) (any, error) {
-	return nil, fmt.Errorf("network schema loading is disabled (attempted %q)", url)
-}
-
-// Ensure noNetworkLoader satisfies the expected interface.
-var _ jsonschema.URLLoader = noNetworkLoader{}
-
-// drain is a helper for tests that may need to exhaust a reader. Kept here
-// to avoid importing io in test files unnecessarily.
+// drain is a helper for tests that may need to exhaust a reader.
 func drain(r io.Reader) { _, _ = io.Copy(io.Discard, r) }

--- a/server/schema_validator_test.go
+++ b/server/schema_validator_test.go
@@ -79,7 +79,7 @@ func TestValidateTypeMismatch(t *testing.T) {
 	require.NoError(t, err)
 
 	raw := json.RawMessage(`{"age": "twenty"}`)
-	ve := c.validate(raw)
+	ve := c.Validate(raw)
 	require.NotNil(t, ve, "expected validation errors")
 	require.NotEmpty(t, ve.Errors)
 
@@ -110,7 +110,7 @@ func TestValidateMissingRequired(t *testing.T) {
 	require.NoError(t, err)
 
 	raw := json.RawMessage(`{"other": "value"}`)
-	ve := c.validate(raw)
+	ve := c.Validate(raw)
 	require.NotNil(t, ve)
 	require.NotEmpty(t, ve.Errors)
 }
@@ -129,7 +129,7 @@ func TestValidateSuccess(t *testing.T) {
 	require.NoError(t, err)
 
 	raw := json.RawMessage(`{"name": "alice", "age": 30}`)
-	ve := c.validate(raw)
+	ve := c.Validate(raw)
 	assert.Nil(t, ve)
 }
 
@@ -143,7 +143,7 @@ func TestValidateEmptyArgs(t *testing.T) {
 	c, err := compileSchema(schema)
 	require.NoError(t, err)
 
-	ve := c.validate(nil)
+	ve := c.Validate(nil)
 	assert.Nil(t, ve)
 }
 
@@ -179,12 +179,12 @@ func TestValidate2020_12Features(t *testing.T) {
 
 	// Valid input
 	raw := json.RawMessage(`{"contact":"alice@example.com","tags":["active",42]}`)
-	assert.Nil(t, c.validate(raw), "valid 2020-12 input should pass")
+	assert.Nil(t, c.Validate(raw), "valid 2020-12 input should pass")
 
 	// Invalid: contact is not an email (basic check — format assertions
 	// vary by library config, so we test a stronger invariant: type)
 	bad := json.RawMessage(`{"contact":42}`)
-	ve := c.validate(bad)
+	ve := c.Validate(bad)
 	require.NotNil(t, ve)
 	require.NotEmpty(t, ve.Errors)
 }


### PR DESCRIPTION
## What changes

A server sends `elicitation/create` with a `RequestedSchema` and, until now, got back whatever the handler produced. A string where it asked for an `integer`, a fourth value for a three-value `enum`, a missing `required` property: all forwarded silently. The server cannot detect any of it, because **the client is the only party that saw both the schema and the user's input**.

An accepted response is now validated before it is sent. A violation is answered with `-32602` and a structured `core.ValidationErrors` list, mirroring the server, which already validates inbound tool and prompt arguments the same way.

This closes audit row #26, the last SEP-1730 documentation row, by making the feature exist. Documentation alone could not close it.

## Reviewer's guide

1. [client/elicitation_validation.go](https://github.com/panyam/mcpkit/pull/1234/files#diff-8e92b1bc0f95211cc03f5714f3895bdb81ba28c371e73597226d79b8739d8cc4) — start here. The guard, and why an uncompilable schema is skipped rather than rejected.
2. [client/client.go](https://github.com/panyam/mcpkit/pull/1234/files#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09) — the dispatch site. Note the ordering against the defaults merge.
3. [client/elicitation_validation_test.go](https://github.com/panyam/mcpkit/pull/1234/files#diff-867266a30066077f84b83fd605a815e57efee9a74e355b3f442a5c3d88a2c222) — acceptance, 10 cases.
4. [core/schema_validator.go](https://github.com/panyam/mcpkit/pull/1234/files#diff-38d799e898043aa9f1cf27171c7930d5d20b3f728d9bf20046eb83df6ac9cd3c) — moved from `server/`, unchanged apart from exported names.
5. [server/schema_validator.go](https://github.com/panyam/mcpkit/pull/1234/files#diff-a89f65996ed18011523790f5e0794d745dac49ca85ca6463e48cb8bb6fb3caac) — aliases keeping the server API intact.
6. [README.md](https://github.com/panyam/mcpkit/pull/1234/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5), [conformance/local-suites.yaml](https://github.com/panyam/mcpkit/pull/1234/files#diff-743cc9d60b39db4b6e75f70916785f9a4f7b077efacec2db4befa87f84a09365), [CONFORMANCE.md](https://github.com/panyam/mcpkit/pull/1234/files#diff-d647b61d5d64e4801ec167193f4f207eb71d12b4ec92d5f08b2867673481b9de) — the SEP-2356 relabel.

Skim: the nine `go.mod` / `go.sum` files from `just tidy-all`.

## How it works

```
on elicitation/create:
    result = handler(request)
    if result.Action == "accept":
        result.Content = merge(result.Content, defaultsFrom(schema))   # SEP-1034
        if validationEnabled:
            if violations := validate(schema, result.Content); violations != nil:
                return error(-32602, violations)                        # do not forward
    return result
```

**Order is load-bearing.** Validation runs *after* the defaults merge, because a schema-declared default can be the thing that satisfies `required`. `TestElicitationValidationRunsAfterDefaultsMerge` pins it: an empty handler response passes only because the default filled the required property.

## Decision log

**Default on, opt out with `WithElicitationValidation(false)`.** Symmetric with `server.WithSchemaValidation(false)`, which also defaults on. Sending content the server explicitly said it could not accept is not a behaviour worth preserving by default, and this is pre-1.0.

**An uncompilable schema is skipped, not rejected.** If the server's schema cannot be compiled, validation is bypassed and the user's answer goes through. The defect is on the server's side and the user answered in good faith, so refusing their input punishes the wrong party. This matches `extractElicitationDefaults`, which already skips rather than fails on a schema it cannot read.

**The validator moved to `core/` rather than being duplicated.** The client cannot import `server` (the dependency runs the other way, verified), so the options were promote or duplicate. `server/schema_validator.go` now holds type aliases, so `server.ValidationErrors` and every call site keep working; the only edits are two dispatch sites picking up the exported method names.

## Red before green

`WithElicitationValidation(false)` reproduces the pre-change behaviour exactly, so it doubles as the red state:

```
=== with validation disabled (pre-change behaviour) ===
--- FAIL: TestElicitationValidationRejectsWrongType
--- FAIL: TestElicitationValidationRejectsValueOutsideEnum
--- FAIL: TestElicitationValidationRejectsMissingRequired

=== restored ===
ok  github.com/panyam/mcpkit/client  0.415s
```

## Two things caught during the work

**A test that was wrong, and what it revealed.** My first draft tested a malformed-JSON schema through the dispatch path. It failed with `json: error calling MarshalJSON for type json.RawMessage`, which is the harness pointing out something true: schema bytes that are not valid JSON cannot arrive over the wire at all, because they would make the enclosing JSON-RPC message unparseable and dispatch would reject it first. That case is now a direct unit test of the guard, and the dispatch-path test uses valid JSON that is an invalid schema (`{"type": 42}`), which is the realistic failure.

**The pre-push hook caught a real miss.** Moving the validator into `core/` means every sub-module importing `core` needs `santhosh-tekuri/jsonschema/v6` in its `go.sum`. `just tidy-all` adds it as an indirect dep to four sub-modules. Worth naming the consequence: the root module's dependency set is unchanged (`server` already pulled jsonschema), but a consumer importing only `core` now pulls it too. That is a small widening of `core`'s footprint, and the alternative was duplicating a JSON Schema compiler in `client/`.

## SEP-2356 relabel

Surfaced while closing PR 398. The WG closed SEP-2356 on 2026-06-26:

> Closing in favor of #2631 which will likely be the more durable solution.

SEP-2631 is still open. `README.md` and `CONFORMANCE.md` were advertising conformance to a withdrawn proposal, which is a spec-tracking accuracy problem a tier reviewer could reasonably flag. The suite still runs and still passes; the row now reads `SEP-2356 File inputs (withdrawn upstream)` and points at issue 827. `CONFORMANCE.md` is generated, so the source change is in `conformance/local-suites.yaml` and the file was regenerated.

## Risk / blast radius

- **Behaviour change:** a client whose elicitation handler returns non-conforming content now gets `-32602` instead of silently forwarding. That is the point, but it is the thing to pressure-test.
- The validator move touches `server/`, so the server suite is the regression surface. It passes unchanged.
- Elicitation is user-paced, so compiling the schema per request is not on any hot path.

## Test plan

- [x] `just test`, `just test-auth`, `just test-ui` green
- [x] `go vet ./...` clean
- [x] 10 new tests passing; 3 verified failing without the change
- [x] pre-push hook green (full suite across sub-modules)
- [x] `just check-local-suites-stale` green after the yaml edit
- [x] `CONFORMANCE.md` regenerated via `scripts/refresh-conformance.sh`
- [x] `just testconf-file-inputs` still passes
- [x] dependency-consistency gate green after `just tidy-all`

Assertions added: 10 test functions. Assertions removed or weakened: 0. The only edits to existing tests are 12 mechanical renames in `server/schema_validator_test.go` (`.validate` to `.Validate`).

## Out of scope

- Slice 5, the 15 walkthrough stubs. Tier-neutral.
- Migrating the file-input surface to SEP-2631, which is issue 827 and blocked on the draft.

