### PR TITLE
ci: run everything through make, drop just from the pipeline

### DIFF
--- a/.github/workflows/dep-sweep.yml
+++ b/.github/workflows/dep-sweep.yml
@@ -40,8 +40,6 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - uses: extractions/setup-just@v4
-
       # MODE goes through env rather than being interpolated into the run: line.
       # `choice` already constrains it to minor|patch, but keeping dispatch input
       # out of the shell string is the cheap, unconditional habit.
@@ -71,11 +69,11 @@ jobs:
         continue-on-error: true
         run: |
           set -o pipefail
-          just check-dep-consistency 2>&1 | tee -a result.log
-          just test               2>&1 | tee -a result.log
-          just test-agent         2>&1 | tee -a result.log
-          just test-auth          2>&1 | tee -a result.log
-          just test-ui            2>&1 | tee -a result.log
+          make check-dep-consistency 2>&1 | tee -a result.log
+          make test               2>&1 | tee -a result.log
+          make test-agent         2>&1 | tee -a result.log
+          make test-auth          2>&1 | tee -a result.log
+          make test-ui            2>&1 | tee -a result.log
 
       - name: Open pull request
         if: steps.diff.outputs.changed == 'true'
@@ -101,7 +99,7 @@ jobs:
           fi
 
           {
-            echo "Automated monthly sweep (\`$MODE\`) across every Go module, reconciled with \`just tidy-all\`."
+            echo "Automated monthly sweep (\`$MODE\`) across every Go module, reconciled with \`make tidy-all\`."
             echo
             echo "$status"
             echo

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -38,6 +38,10 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # A starved queue should fail fast and be retried, not block a merge for
+    # hours. This job was cancelled after 1h45m on PR 1234 without ever being
+    # assigned a runner (zero steps recorded).
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
 
@@ -54,19 +58,17 @@ jobs:
         with:
           enable-cache: true
 
-      - uses: extractions/setup-just@v4
-
       - name: Sync Python tooling env
         run: uv sync
 
       - name: Build site
         working-directory: docs/site
-        run: just build
+        run: make build
 
       # Self-hosted shields endpoint badge: root-module coverage computed
       # here and shipped inside the site output at /coverage/badge.json,
       # same pattern as the conformance badge (which is committed under
-      # docs/site/static/ by refresh-conformance and rides `just build`).
+      # docs/site/static/ by refresh-conformance and rides `make build`).
       # Relies on docs/site/go.mod sharing the root module's go directive:
       # setup-go@v7 pins GOTOOLCHAIN=local, so the one installed toolchain
       # must satisfy both modules.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: '22'
 
       # Enforces what scripts/pre-commit-hook.sh checks locally. The hook is
-      # opt-in (just setup-hooks) and bypassable with --no-verify, so this is
+      # opt-in (make setup-hooks) and bypassable with --no-verify, so this is
       # the gate that actually keeps binaries off main. Runs before the tests
       # because it is ~1s and its failure is unambiguous.
       - name: No committed binaries
@@ -128,10 +128,10 @@ jobs:
     #
     # Why pin instead of tracking upstream/main: upstream advances daily, so
     # tracking main would make this gate fail on every PR until a maintainer
-    # ran `just refresh-conformance` locally. Pinning to the stamp lets the
+    # ran `make refresh-conformance` locally. Pinning to the stamp lets the
     # gate verify "the committed file is reproducible from its declared
     # inputs" — bumping upstream becomes an explicit, reviewable change
-    # (run `just refresh-conformance` + commit the diff).
+    # (run `make refresh-conformance` + commit the diff).
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -153,7 +153,7 @@ jobs:
           SHA="$(sed -n 's/.*upstream-conformance@\([a-f0-9]\{40\}\).*/\1/p' CONFORMANCE.md | head -1)"
           if [ -z "$SHA" ]; then
             echo "::error::Could not extract upstream-conformance SHA from CONFORMANCE.md stamp line."
-            echo "::error::Run 'just refresh-conformance' locally to regenerate the file."
+            echo "::error::Run 'make refresh-conformance' locally to regenerate the file."
             exit 1
           fi
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
@@ -179,8 +179,6 @@ jobs:
           enable-cache: true
           working-directory: mcpkit
 
-      - uses: extractions/setup-just@v4
-
       - name: Sync Python tooling env
         working-directory: mcpkit
         run: uv sync
@@ -200,11 +198,11 @@ jobs:
           # from bailing during data collection.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MCPCONFORMANCE_BASE_PATH: ${{ github.workspace }}/conf-upstream-main
-        run: just check-conformance-stale
+        run: make check-conformance-stale
 
       - name: Check Get Started snippets match the example
         working-directory: mcpkit
-        run: just check-snippets
+        run: make check-snippets
 
   apps-compat-report:
     # Mirrors conformance-report: regenerates conformance/apps/COMPAT.md
@@ -222,8 +220,6 @@ jobs:
         with:
           node-version: '22'
 
-      - uses: extractions/setup-just@v4
-
       - name: Run apps-compat renderer unit tests
         working-directory: tools/compat-reports
         run: |
@@ -235,4 +231,4 @@ jobs:
           # GH_TOKEN is enough — the umbrella body is read via gh CLI
           # which inherits this from the env.
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: just check-apps-compat-stale
+        run: make check-apps-compat-stale

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,30 +4,33 @@ Go library for building production-grade MCP servers and clients.
 
 ## Quick Commands
 
+`make` is the supported runner and the only one CI uses. Justfiles mirroring
+these names exist but are an experiment; `make` is authoritative.
+
 ```bash
-just test              # Core tests (core/server/client/testutil)
-just test-agent        # agent/ sub-module (host layer)
-just test-auth         # ext/auth sub-module
-just test-ui           # ext/ui sub-module
-just test-e2e          # E2E tests (auth + apps)
-just testconf          # MCP conformance suite (needs Node.js)
-just testconfauth      # Auth conformance (client OAuth)
-just testconf-client   # Full client conformance (core + auth + extensions) — same set tier-check --client-cmd runs
-just testconf-tasks    # Tasks v1 conformance (27 scenarios, local; 26 pass + 1 skip — v1 sampling push vs 2.0 SDK client)
-just testconf-tasks-v2 # SEP-2663 — upstream @ MCPCONFORMANCE_TASKS_V2_PATH + mcpkit-local stricter sentinel
-just testconf-mrtr     # SEP-2322 — upstream @ MCPCONFORMANCE_MRTR_PATH + mcpkit-local stricter sentinel
-just testconf-file-inputs # SEP-2356 — fork @ MCPCONFORMANCE_FILE_INPUTS_PATH (7 checks)
-just testconf-auth-server # MCP authz 2025-11-25 — fork @ MCPCONFORMANCE_AUTH_PATH (6 scenarios, 23 checks: 18 active, 5 SKIPPED gaps for unsupported features)
-just testconf-stateless # SEP-2575 — upstream @ MCPCONFORMANCE_STATELESS_PATH; drives examples/stateless fixture (25 pass / 1 known upstream-test fail)
-just testconf-skills   # SEP-2640 — fork @ MCPCONFORMANCE_SKILLS_PATH; drives examples/skills fixture
-just testconf-upstream-audit # Audit mcpkit against modelcontextprotocol/conformance@main → conformance/UPSTREAM_AUDIT.md (informational scenario-level pass/fail; runs in the conformance umbrella but exits 0 by design)
-just refresh-conformance # Regenerate CONFORMANCE.md from upstream tier-check + traceability (issue #498). Driver: scripts/refresh-conformance.sh, renderer: tools/conformance-report.
-just check-conformance-stale # CI gate — refresh + git diff --exit-code CONFORMANCE.md (issue #498). Wired into .github/workflows/test.yml on every PR.
-just testall           # Everything (9 stages, 21 sub-stages) + Keycloak + HTML report
+make test              # Core tests (core/server/client/testutil)
+make test-agent        # agent/ sub-module (host layer)
+make test-auth         # ext/auth sub-module
+make test-ui           # ext/ui sub-module
+make test-e2e          # E2E tests (auth + apps)
+make testconf          # MCP conformance suite (needs Node.js)
+make testconfauth      # Auth conformance (client OAuth)
+make testconf-client   # Full client conformance (core + auth + extensions) — same set tier-check --client-cmd runs
+make testconf-tasks    # Tasks v1 conformance (27 scenarios, local; 26 pass + 1 skip — v1 sampling push vs 2.0 SDK client)
+make testconf-tasks-v2 # SEP-2663 — upstream @ MCPCONFORMANCE_TASKS_V2_PATH + mcpkit-local stricter sentinel
+make testconf-mrtr     # SEP-2322 — upstream @ MCPCONFORMANCE_MRTR_PATH + mcpkit-local stricter sentinel
+make testconf-file-inputs # SEP-2356 — fork @ MCPCONFORMANCE_FILE_INPUTS_PATH (7 checks)
+make testconf-auth-server # MCP authz 2025-11-25 — fork @ MCPCONFORMANCE_AUTH_PATH (6 scenarios, 23 checks: 18 active, 5 SKIPPED gaps for unsupported features)
+make testconf-stateless # SEP-2575 — upstream @ MCPCONFORMANCE_STATELESS_PATH; drives examples/stateless fixture (25 pass / 1 known upstream-test fail)
+make testconf-skills   # SEP-2640 — fork @ MCPCONFORMANCE_SKILLS_PATH; drives examples/skills fixture
+make testconf-upstream-audit # Audit mcpkit against modelcontextprotocol/conformance@main → conformance/UPSTREAM_AUDIT.md (informational scenario-level pass/fail; runs in the conformance umbrella but exits 0 by design)
+make refresh-conformance # Regenerate CONFORMANCE.md from upstream tier-check + traceability (issue #498). Driver: scripts/refresh-conformance.sh, renderer: tools/conformance-report.
+make check-conformance-stale # CI gate — refresh + git diff --exit-code CONFORMANCE.md (issue #498). Wired into .github/workflows/test.yml on every PR.
+make testall           # Everything (9 stages, 21 sub-stages) + Keycloak + HTML report
                        # stage 5a/5b cover ext/otel + examples/otel/stdout (issue 634 wiring)
                        # stage 7d covers experimental/ext/events/stores/redis (issue 634 wiring)
-just audit             # govulncheck + gosec + gitleaks + race
-just tag-push vX.Y.Z # Tag root + all sub-modules and push (see RELEASING.md; pre-release form is vX.Y.Z-bN)
+make audit             # govulncheck + gosec + gitleaks + race
+make tag-push vX.Y.Z # Tag root + all sub-modules and push (see RELEASING.md; pre-release form is vX.Y.Z-bN)
 ```
 
 ## Package Layout
@@ -92,7 +95,7 @@ Project-wide: `CONSTRAINTS.md`. Per-package: `core/CONSTRAINTS.md`, `server/CONS
   - **Session scoping (1140)**: `MemoryConfig.SessionScoped` (opt-in) makes `registerMemory` pass `WithMemoryNamespaceFunc(a.currentRunID)`, so each RunStore run gets its own scratchpad. **The deadlock trap**: the namespace func runs *inside a turn while `turnMu` is held* (both the memory tools and the summary/recall injection), so `App.RunID()` (takes `turnMu`) would re-enter and deadlock. Fix: a **lock-free `currentRunID()` backed by an `atomic.Value` mirror** of `runID`; all four writers (`AttachRun`, `resumeLocked`, `Fork`, `ensureRunLocked`) route through one **`setRunID`** so the mirror never drifts. agentchat: `--memory-session-scoped` (default off — cross-session shared memory is often the point; a no-op + warning without a `--session-store`). `App` gained a `log *slog.Logger` field for the warning.
   - **Sub-agent memory model = injection over shared store — ENFORCED (issue 1151; PR 1153)**: sub-agents have **no** working memory (the source is on the main `multi`, personas get a filtered `serverTools` view + `AgentSource.Call` bypasses the injection). Now a hard invariant: **`agent/CONSTRAINTS.md` A7** ("no ambient parent state") + the **`TestSubAgentCannotReachParentMemory`** guard (a persona's `remember` hits an unknown tool, the parent store stays empty; proven to fail if personas are handed `multi`). The principle: a child's location is not guaranteed (in-process `AgentSource` is the degenerate co-located case), so shared parent memory assumes co-location that A2 wire-serializability already forbids. If a child needs memory it **owns its own setup entirely** (its store/namespace, configured by whoever builds the child — same encapsulation as a stateful MCP tool owning its DB), never a `WithMemoryNamespaceFunc(a.currentRunID)` into the *parent's* namespace (the trap). Parent→child transfer is params + injection. **`AgentSource` stays; colocation is contained, not removed** — it is the in-process impl of a location-independent `ToolSource` contract; a remote sub-agent is a *sibling* impl (largely "a sub-agent published as an MCP server, reached via the existing server-tools `ToolSource`"), and what it adds is carrying the composition metadata ctx threads for free in-process (depth/budget, cancellation, nested event stream) over the wire = the surface of async sub-agents (1035) / upward signals (1036) / dynamic composition (1038). Hierarchy (parent recall across children) is deferred behind a prefix/hierarchical namespace query the seam lacks (exact-match today). Lifecycle is **decomposed, not centralized** (no `SubagentManager`); a real lifecycle owner emerges only in the async/Task form (1035). Full rationale: `docs/AGENT_COMPOSITION.md` § Sub-agents and memory.
 - **Agent Runner OTel metrics SHIPPED (issue 1023; PR 1141)** — the metrics sibling of the SEP-414 spans, through the existing `core.MeterProvider` seam (no new seam). `RunnerConfig.MeterProvider` opts in (nil = `NoopMeterProvider`, branch-free zero overhead); instruments built once in `NewRunner` (`agent/metrics.go`), recorded at the same points as the spans: **turn end** (`agent.turns` by `agent.finish_reason`, `agent.turn.duration`, `agent.steps`, `agent.tokens` by `direction`) and **each tool call** (`agent.tool.calls` by `tool`+`status`, `agent.tool.duration` by `tool`). `status` ∈ {ok, error, tool_error, denied, cancelled, unavailable}, set on each outcome path and emitted by a **single `defer` in `callTool`** so no path double-counts or misses. Host threads it via `host.WithMeterProvider` (main Runner + every sub-agent persona); agentchat builds it from the same `--exporter`/`--otlp-endpoint` decision as the tracer/logger via **`SetupMeter`** (the meter sibling of `SetupTelemetry`/`SetupLogs`, `cmd/agentchat/telemetry_setup_meter.go`; new deps `otlpmetricgrpc`+`stdoutmetric`). The **`mcpkit — agent`** Grafana dashboard (`docker/observability/grafana/provisioning/dashboards/files/mcpkit-agent.json`, uid `mcpkit-agent`) charts turn rate, latency, token throughput, and tool failure ratio off Mimir (OTel Prometheus rename: dots→underscores, `_total` on counters, unit suffix on histograms → `agent_turn_duration_seconds_bucket`). Deferred: a memory-tracks metrics seam (embed/recall/compaction counters) + exemplars on the agent instruments.
-- **`CAPABILITIES.md` was retired (commit `ebc41058`)** — checkpoint/start_pr must NOT sync or recreate it; fold learnings into CLAUDE.md + the design docs (`docs/AGENT_*.md`) + the roadmap. **Makefile → justfile migration landed (PR 1009)** but the `Makefile` still exists, so `make test-agent` etc. still work.
+- **`CAPABILITIES.md` was retired (commit `ebc41058`)** — checkpoint/start_pr must NOT sync or recreate it; fold learnings into CLAUDE.md + the design docs (`docs/AGENT_*.md`) + the roadmap. **`make` is the supported runner and the only one CI uses** (the justfiles from PR 1009 remain as an experiment; `make` is authoritative when they disagree). CI installs no task runner.
 - **`experimental/ext/agents` — server-declared agent discovery wire primitive SHIPPED (epic 1142; issue 1143, PR 1181)**. Pre-SEP research surface (agents-wg#20) under `experimental/ext/` (own go.mod, mirrors `experimental/ext/events`); promote to `ext/agents` only when a SEP merges. Load-bearing facts:
   - **What it is**: a server that hosts a fleet of specialist agents advertises them as a small roster of tuples for routing, so a supervisor host never eager-loads a flat `tools/list` of every specialist's schemas. **Three-level progressive disclosure** (same shape as two-tier skills #910): (1) `capabilities.extensions["io.modelcontextprotocol/agents"]` advertised via the `core.ExtensionProvider` mechanism, (2) `agents/list` → roster of `AgentSummary` (agentId/description/capabilities/exampleTasks/delegateTool/tasksEnabled/skillUri, **no tool schemas**), (3) `agents/get {agentId}` → `AgentDetail` (summary **embedded** + instructions + scoped `tools[]`). **Only discovery is new wire surface** — invocation rides on the existing `tools/call` via each agent's advertised `delegateTool`.
   - **Advertised via the extension mechanism, NOT a new `core.ServerCapabilities.Agents` field** — matches skills/tasks/ui, reuses `ServerSupportsExtension`, keeps a churning pre-SEP surface out of `core/`. The issue title's "capabilities.agents" is the conceptual capability, realized as the advertised extension entry.

--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,12 @@ testconf-elicitation: ## Run SEP-1036 elicitation conformance (delegates to conf
 testconf-skills: ## Run SEP-2640 skills conformance — fork-based (delegates to conformance/Makefile)
 	$(MAKE) -C conformance testconf-skills
 
+testconf-stateless: ## Run SEP-2575 stateless conformance — drives examples/stateless (delegates to conformance/Makefile)
+	$(MAKE) -C conformance testconf-stateless
+
+testconf-upstream-audit: ## Audit mcpkit against modelcontextprotocol/conformance@main → conformance/UPSTREAM_AUDIT.md (informational; delegates to conformance/Makefile)
+	$(MAKE) -C conformance testconf-upstream-audit
+
 testconf-external-checker: ## Grade the mcpkit CLIENT against the external stateless-draft checker (live network, not a CI gate; delegates to conformance/Makefile)
 	$(MAKE) -C conformance testconf-external-checker
 
@@ -460,5 +466,5 @@ setup: setup-tools setup-hooks ## Full development setup
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-18s\033[0m %s\n", $$1, $$2}'
 
-.PHONY: build test test-examples test-race test-v cover cover-html cover-func cover-all test-auth test-ui test-skills test-mcpskills build-mcpskills test-mcpskills-walkthrough test-protogen test-e2e test-experimental test-apps-playwright test-apps-playwright-docker test-apps-playwright-all test-apps-playwright-docker-all refresh-visual-gallery release-audit-apps demo-app demo-upstream testkcl testkcl-auto testall test-report smoke smoke-wire verify-dual testconfall testconf testconfauth testconf-client testconf-tasks testconf-tasks-v2 testconf-mrtr testconf-file-inputs testconf-auth-server testconf-elicitation testconf-skills testconf-external-checker refresh-conformance check-conformance-stale check-local-suites-stale check-snippets check-dep-consistency update-dep-baseline dep-sweep check-auth-markers refresh-apps-compat-report check-apps-compat-stale vet lint vulncheck seccheck secrets verify-submodule-deps audit ci ci-full serve serve-streamable serve-both tidy tidy-all bump-root collect-walkthroughs ghbuild ghserve ghdeploy tag tag-push setup-tools setup-hooks setup upkcl downkcl kcllogs build-bridge help
+.PHONY: build test test-examples test-race test-v cover cover-html cover-func cover-all test-auth test-ui test-skills test-mcpskills build-mcpskills test-mcpskills-walkthrough test-protogen test-e2e test-experimental test-apps-playwright test-apps-playwright-docker test-apps-playwright-all test-apps-playwright-docker-all refresh-visual-gallery release-audit-apps demo-app demo-upstream testkcl testkcl-auto testall test-report smoke smoke-wire verify-dual testconfall testconf testconfauth testconf-client testconf-tasks testconf-tasks-v2 testconf-mrtr testconf-file-inputs testconf-auth-server testconf-elicitation testconf-skills testconf-stateless testconf-upstream-audit testconf-external-checker refresh-conformance check-conformance-stale check-local-suites-stale check-snippets check-dep-consistency update-dep-baseline dep-sweep check-auth-markers refresh-apps-compat-report check-apps-compat-stale vet lint vulncheck seccheck secrets verify-submodule-deps audit ci ci-full serve serve-streamable serve-both tidy tidy-all bump-root collect-walkthroughs ghbuild ghserve ghdeploy tag tag-push setup-tools setup-hooks setup upkcl downkcl kcllogs build-bridge help
 .DEFAULT_GOAL := help

--- a/README.md
+++ b/README.md
@@ -110,18 +110,21 @@ Three artifacts describe mcpkit's conformance posture at increasing granularity:
 
 ## Testing
 
-The task runner is moving to [`just`](https://github.com/casey/just); during
-the transition the original Makefiles remain alongside the justfiles with the
-same target names, so both `just <target>` and `make <target>` work.
+`make` is the supported task runner and the only one CI uses, so `make` is
+preinstalled everywhere and needs no setup step.
 
 ```bash
-just/make test          # Unit tests (200+ across core/server/client)
-just/make testall       # ALL tests + Keycloak + conformance + HTML report
-just/make testconf      # MCP conformance suite
-just/make testconfauth  # Auth conformance
-just/make test-e2e      # E2E tests (auth + apps)
-just/make test-apps-playwright  # ext-apps Playwright suite (needs Node.js)
+make test          # Unit tests (200+ across core/server/client)
+make testall       # ALL tests + Keycloak + conformance + HTML report
+make testconf      # MCP conformance suite
+make testconfauth  # Auth conformance
+make test-e2e      # E2E tests (auth + apps)
+make test-apps-playwright  # ext-apps Playwright suite (needs Node.js)
 ```
+
+Justfiles mirroring the same target names also exist and are kept as an
+experiment. They are not used by CI, and `make` is authoritative when the two
+disagree.
 
 ## Documentation
 

--- a/scripts/dep-sweep.sh
+++ b/scripts/dep-sweep.sh
@@ -56,7 +56,7 @@ python3 scripts/check_dep_consistency.py --unify
 
 echo ""
 echo "==> tidy-all (reconciles every module, including the ones Dependabot cannot reach)"
-just tidy-all
+make tidy-all
 
 # One-way ratchet: drop baseline entries the sweep just resolved, never add.
 echo ""


### PR DESCRIPTION
## What changes

CI installed `extractions/setup-just` in three workflows to run six recipes. `make` is preinstalled on every runner and the Makefile already mirrors the justfile, so the dependency bought nothing. This removes it.

Also fixes real drift the README was papering over, and adds a timeout to the job that hung for 1h45m on PR 1234.

## Reviewer's guide

1. [.github/workflows/test.yml](https://github.com/panyam/mcpkit/pull/1235/files#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88) — start here. Three `just` calls become `make`; two `setup-just` steps removed.
2. [.github/workflows/pages.yml](https://github.com/panyam/mcpkit/pull/1235/files#diff-267452bb53d388a7b14551d9fc53a797edc124dc9085ecc79f5339277a1e53b5) — same, plus `timeout-minutes: 20`.
3. [.github/workflows/dep-sweep.yml](https://github.com/panyam/mcpkit/pull/1235/files#diff-90ac1c17baa508d2a7e331ceb7b9b67abf8bf7d197a42c01bfe9edacd0015e33) — same, and [scripts/dep-sweep.sh](https://github.com/panyam/mcpkit/pull/1235/files#diff-cb4f9e18610b053b1917e44073ed7067d09ab673a942102be67e04f4dcdee5c5) no longer shells out to `just`.
4. [Makefile](https://github.com/panyam/mcpkit/pull/1235/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52) — the two delegating targets that were missing.
5. [README.md](https://github.com/panyam/mcpkit/pull/1235/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5), [CLAUDE.md](https://github.com/panyam/mcpkit/pull/1235/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7) — make is the supported runner.

## The drift the README was hiding

`README.md` claimed:

> during the transition the original Makefiles remain alongside the justfiles with the same target names, so both `just <target>` and `make <target>` work

Not true:

```
just testconf-stateless        works
make testconf-stateless        target does not exist
```

Same for `testconf-upstream-audit`. Both existed in `conformance/Makefile`; only the root delegating shims were missing. Added. Root parity is now complete apart from `default`, which is just's implicit list-recipes and whose Make equivalent is `help`.

## Supply chain

`extractions/setup-just@v4` was the odd one out: third-party and pinned by **tag**, while the repo's other third-party actions are pinned by SHA.

```
ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
extractions/setup-just@v4                    ← tag only
```

Deleting it resolves that inconsistency without a pinning exercise. OpenSSF Scorecard checks for exactly this.

## The Pages timeout

On PR 1234 the `build` job was cancelled after **1h45m** with **zero steps recorded**, meaning it never got a runner. Every other job on the same PR was assigned one within seconds and finished in 20s to 1m17s.

Nothing in the config explains it: same `runs-on: ubuntu-latest` as the jobs that ran fine. `timeout-minutes: 20` does not fix the starvation, but it converts a 1h45m merge block into a fast, retryable failure.

## Verified, not assumed

Every make target CI now calls was run locally:

```
make check-dep-consistency   OK: no unexpected divergence
make check-snippets          snippets match examples/getting-started/
make check-apps-compat-stale wrote conformance/apps/COMPAT.md
make test                    exit 0
make test-ui                 exit 0
make -n testconf-stateless        → make -C conformance testconf-stateless
make -n testconf-upstream-audit   → make -C conformance testconf-upstream-audit
```

Plus: no `just` left in any workflow, all three YAML files tab-free, `docs/site/Makefile` has the `build` target `pages.yml` now calls.

## Decision log

**Kept the justfiles rather than deleting them.** They stay as an experiment. `make` is authoritative when the two disagree, and the README and `CLAUDE.md` now say so instead of claiming parity.

**Did not refactor the hardcoded test steps into make targets.** CI's `test-agent` job still hardcodes nine `cd X && go test` steps rather than calling `make test-agent`, and the two lists have diverged in both directions (`agent/store/gorm`, `agent/store/redis`, `agent/surfaces/web` are tested locally but not in CI; `examples/agents/critic` and `examples/agents/deep-agent-supervisor/server` in CI but not locally). That is a real problem but a separate one, and folding it in here would mix a dependency removal with a change to what CI actually runs.

## Risk / blast radius

- CI-only, plus docs. No library code is touched.
- The failure mode would be a make target that does not exist or behaves differently; each was run locally above.
- `scripts/dep-sweep.sh` is exercised by the monthly sweep workflow, which has not run on schedule yet.

## Out of scope

- Making CI call `make test-agent` instead of nine hardcoded steps, and closing the resulting drift.
- Deleting the justfiles.

