### PR TITLE
agent: make generation parameters reachable from a turn

### DIFF
--- a/agent/NOTES.md
+++ b/agent/NOTES.md
@@ -449,6 +449,38 @@ who-acts-next, not owning the user; in the distributed limit it decouples into t
 
 ## Providers
 
+### Generation parameters: how they reach a turn (#1239)
+
+`GenerationParams` (`agent/provider.go`) carries `Temperature`, `MaxTokens`, and `ToolChoice`.
+Defaults live on `RunnerConfig.Generation`; `TurnRequest.Generation` overrides per turn, **field by
+field, where a zero field inherits**. The corollary is documented on the type: a turn cannot un-set a
+config default back to the provider's own, it can only set a different value.
+
+`ResponseSchema` deliberately stays on `RunnerConfig` and out of the struct — it selects a different
+*turn shape* (a finalizing `Generate`) rather than tuning the calls a turn already makes.
+
+**The trap in the finalizing call.** `finalizeStructured` offers no tools, so a `ToolChoice` carried
+from the turn's params would ask the provider to force a call it has no tool for, which OpenAI
+rejects. `applyTo` is shared with the step loop, so the drop happens at the finalize call site, not
+inside `applyTo`. `TestGenerationToolChoiceDroppedOnFinalize` pins it.
+
+**How this was ever missing.** Before #1239 the step loop built `ProviderRequest{Instructions,
+Messages, Tools}` and nothing else, so three of the four generation parameters the seam defines were
+unreachable from a turn: `Temperature` and `ToolChoice` were set nowhere in non-test code, and
+`MaxTokens` only as a `failover.go` health probe. Both providers had always rendered all three onto
+the wire correctly — the gap was purely loop-side, which is why it stayed invisible. The roadmap's §7
+scorecard credited `ToolChoice` as shipped, which is how #1056 came to be sized against primitives
+that could not actually be driven.
+
+**Unsupported parameters are forwarded, not screened.** A provider sends what it is given, and a
+model that rejects a parameter fails the request rather than ignoring it — current Anthropic models
+400 on sampling params. That is deliberate: `ProviderError{StatusCode, Body}` already carries the
+vendor's message verbatim (up to 2048 bytes) and names the offending field, so a capability layer
+would duplicate diagnostics that already exist, and screening by model would need exactly the
+per-model table this project has declined once already (the reason agentchat takes
+`--context-window` rather than inferring one). Revisit only if a *response*-side signal such as
+logprobs (#1053) needs capability negotiation, which degrades to best-effort rather than failing.
+
 ### Tool-name sanitization (PR 1129, `agent/toolname.go`)
 
 OpenAI and Anthropic both constrain a function/tool name to `^[a-zA-Z0-9_-]{1,64}$`. A connected

--- a/agent/generation_test.go
+++ b/agent/generation_test.go
@@ -1,0 +1,211 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+func floatPtr(f float64) *float64 { return &f }
+
+// genRunner builds a Runner whose config carries gen, with a one-turn script.
+func genRunner(t *testing.T, gen GenerationParams) (*Runner, *StubProvider) {
+	t.Helper()
+	p := NewStubProvider(StubTurn{Text: "done"})
+	r, err := NewRunner(RunnerConfig{Provider: p, Instructions: "be helpful", Generation: gen})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return r, p
+}
+
+// TestGenerationDefaultsReachTheStepLoop is the core of issue 1239: before it,
+// RunnerConfig had no way to express temperature, token cap, or tool choice, so
+// three of the four ProviderRequest generation parameters were unreachable from
+// a turn.
+func TestGenerationDefaultsReachTheStepLoop(t *testing.T) {
+	r, p := genRunner(t, GenerationParams{
+		Temperature: floatPtr(0.7),
+		MaxTokens:   256,
+		ToolChoice:  ToolChoiceRequired,
+	})
+
+	if _, err := r.Run(context.Background(), []Message{{Role: RoleUser, Text: "hi"}}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	reqs := p.Requests()
+	if len(reqs) != 1 {
+		t.Fatalf("want 1 request, got %d", len(reqs))
+	}
+	got := reqs[0]
+	if got.Temperature == nil || *got.Temperature != 0.7 {
+		t.Errorf("Temperature = %v, want 0.7", got.Temperature)
+	}
+	if got.MaxTokens != 256 {
+		t.Errorf("MaxTokens = %d, want 256", got.MaxTokens)
+	}
+	if got.ToolChoice != ToolChoiceRequired {
+		t.Errorf("ToolChoice = %+v, want %+v", got.ToolChoice, ToolChoiceRequired)
+	}
+}
+
+// TestGenerationUnsetSendsNothing pins the default path: a Runner with no
+// Generation must build the same request it built before these fields existed,
+// so an existing caller's wire shape is byte-identical.
+func TestGenerationUnsetSendsNothing(t *testing.T) {
+	r, p := genRunner(t, GenerationParams{})
+
+	if _, err := r.Run(context.Background(), []Message{{Role: RoleUser, Text: "hi"}}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	got := p.Requests()[0]
+	if got.Temperature != nil {
+		t.Errorf("Temperature = %v, want nil", *got.Temperature)
+	}
+	if got.MaxTokens != 0 {
+		t.Errorf("MaxTokens = %d, want 0", got.MaxTokens)
+	}
+	if !got.ToolChoice.IsZero() {
+		t.Errorf("ToolChoice = %+v, want zero", got.ToolChoice)
+	}
+}
+
+// TestGenerationPerTurnOverride covers the per-turn half: TurnRequest.Generation
+// wins over the config for the fields it sets. Forcing a tool call on one
+// proactive turn is the motivating case.
+func TestGenerationPerTurnOverride(t *testing.T) {
+	r, p := genRunner(t, GenerationParams{Temperature: floatPtr(0.2), MaxTokens: 100})
+
+	_, err := r.RunTurn(context.Background(), TurnRequest{
+		History:    []Message{{Role: RoleUser, Text: "hi"}},
+		Generation: GenerationParams{Temperature: floatPtr(0.9)},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := p.Requests()[0]
+	if got.Temperature == nil || *got.Temperature != 0.9 {
+		t.Errorf("Temperature = %v, want 0.9 (turn wins)", got.Temperature)
+	}
+}
+
+// TestGenerationPerTurnMergeInheritsUnsetFields is the merge contract: a zero
+// field on the turn inherits the config's rather than clearing it. Without this
+// a turn that only wants to force a tool call would silently drop the config's
+// temperature and token cap.
+func TestGenerationPerTurnMergeInheritsUnsetFields(t *testing.T) {
+	r, p := genRunner(t, GenerationParams{Temperature: floatPtr(0.2), MaxTokens: 100})
+
+	_, err := r.RunTurn(context.Background(), TurnRequest{
+		History:    []Message{{Role: RoleUser, Text: "hi"}},
+		Generation: GenerationParams{ToolChoice: ToolChoiceRequired},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := p.Requests()[0]
+	if got.Temperature == nil || *got.Temperature != 0.2 {
+		t.Errorf("Temperature = %v, want 0.2 inherited", got.Temperature)
+	}
+	if got.MaxTokens != 100 {
+		t.Errorf("MaxTokens = %d, want 100 inherited", got.MaxTokens)
+	}
+	if got.ToolChoice != ToolChoiceRequired {
+		t.Errorf("ToolChoice = %+v, want the turn's", got.ToolChoice)
+	}
+}
+
+// TestGenerationReachesFinalizingGenerate covers the structured-output path:
+// the finalizing Generate is a second model call and must carry the same
+// params, or a token cap set for the turn would not apply to it.
+func TestGenerationReachesFinalizingGenerate(t *testing.T) {
+	p := NewStubProvider(
+		StubTurn{Text: "done"},
+		StubTurn{Text: `{"ok":true}`},
+	)
+	r, err := NewRunner(RunnerConfig{
+		Provider:       p,
+		Instructions:   "be helpful",
+		ResponseSchema: core.NewRawJSON([]byte(`{"type":"object"}`)),
+		Generation:     GenerationParams{Temperature: floatPtr(0.3), MaxTokens: 64},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := r.Run(context.Background(), []Message{{Role: RoleUser, Text: "hi"}}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	reqs := p.Requests()
+	if len(reqs) != 2 {
+		t.Fatalf("want 2 requests (step + finalize), got %d", len(reqs))
+	}
+	final := reqs[1]
+	if final.Temperature == nil || *final.Temperature != 0.3 {
+		t.Errorf("finalize Temperature = %v, want 0.3", final.Temperature)
+	}
+	if final.MaxTokens != 64 {
+		t.Errorf("finalize MaxTokens = %d, want 64", final.MaxTokens)
+	}
+}
+
+// TestGenerationToolChoiceDroppedOnFinalize guards a real trap: the finalizing
+// call offers no tools, so forwarding a ToolChoice would ask the provider to
+// force a call it has no tool for. OpenAI rejects that combination.
+func TestGenerationToolChoiceDroppedOnFinalize(t *testing.T) {
+	p := NewStubProvider(
+		StubTurn{Text: "done"},
+		StubTurn{Text: `{"ok":true}`},
+	)
+	r, err := NewRunner(RunnerConfig{
+		Provider:       p,
+		Instructions:   "be helpful",
+		ResponseSchema: core.NewRawJSON([]byte(`{"type":"object"}`)),
+		Generation:     GenerationParams{ToolChoice: ToolChoiceRequired},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := r.Run(context.Background(), []Message{{Role: RoleUser, Text: "hi"}}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	final := p.Requests()[1]
+	if !final.ToolChoice.IsZero() {
+		t.Errorf("finalize ToolChoice = %+v, want zero (no tools offered)", final.ToolChoice)
+	}
+}
+
+// TestGenerationParamsMerge exercises the merge rules directly, including the
+// documented corollary that a turn cannot un-set a config default.
+func TestGenerationParamsMerge(t *testing.T) {
+	base := GenerationParams{Temperature: floatPtr(0.2), MaxTokens: 100, ToolChoice: ToolChoiceNone}
+
+	t.Run("zero override inherits everything", func(t *testing.T) {
+		got := base.merge(GenerationParams{})
+		if got.Temperature == nil || *got.Temperature != 0.2 || got.MaxTokens != 100 || got.ToolChoice != ToolChoiceNone {
+			t.Errorf("merge(zero) = %+v, want base", got)
+		}
+	})
+
+	t.Run("explicit zero temperature is a real value", func(t *testing.T) {
+		got := base.merge(GenerationParams{Temperature: floatPtr(0)})
+		if got.Temperature == nil || *got.Temperature != 0 {
+			t.Errorf("Temperature = %v, want an explicit 0", got.Temperature)
+		}
+	})
+
+	t.Run("merge does not mutate the receiver", func(t *testing.T) {
+		_ = base.merge(GenerationParams{MaxTokens: 999})
+		if base.MaxTokens != 100 {
+			t.Errorf("base mutated: MaxTokens = %d, want 100", base.MaxTokens)
+		}
+	})
+}

--- a/agent/provider.go
+++ b/agent/provider.go
@@ -76,25 +76,23 @@ type ProviderRequest struct {
 	// Tools lists what the model may call. Nil means no tools offered.
 	Tools []core.ToolDef `json:"tools,omitempty"`
 
-	// Temperature overrides the provider default when non-nil.
+	// Temperature overrides the provider default when non-nil. Set it on a
+	// turn through RunnerConfig.Generation or TurnRequest.Generation.
 	//
 	// Not universally supported, and the unsupported case is a hard failure
 	// rather than a graceful one: current Anthropic models reject sampling
-	// parameters outright, so a non-nil Temperature makes the request 400.
-	// Leave it nil for those models. Providers forward this field as given
-	// and do not screen it; see issue 1239 for the seam-level decision on
-	// what a provider should do with a parameter it cannot honor.
-	//
-	// The Runner does not set this field, so it is reachable only by calling
-	// a Provider directly (issue 1239).
+	// parameters outright, so a non-nil Temperature makes the request 400
+	// instead of being ignored. Leave it nil for those models. Providers
+	// forward this field as given and do not screen it by model — mcpkit
+	// keeps no per-model capability table — so the vendor's own error is
+	// the diagnostic, carried verbatim in ProviderError.Body.
 	Temperature *float64 `json:"temperature,omitempty"`
 
-	// MaxTokens caps the completion length when positive.
+	// MaxTokens caps the completion length when positive. Set it on a turn
+	// through RunnerConfig.Generation or TurnRequest.Generation.
 	//
-	// The Runner does not set this field, so it is reachable only by calling
-	// a Provider directly (issue 1239). AnthropicProvider always sends a
-	// max_tokens (the Messages API requires one), defaulting to
-	// AnthropicConfig.MaxTokens when this is zero.
+	// AnthropicProvider always sends a max_tokens (the Messages API requires
+	// one), defaulting to AnthropicConfig.MaxTokens when this is zero.
 	MaxTokens int `json:"maxTokens,omitempty"`
 
 	// ToolChoice biases tool calling for this request. Empty is the
@@ -103,16 +101,71 @@ type ProviderRequest struct {
 	// force a specific tool. Support varies across OpenAI-compatible
 	// servers; a server that ignores it degrades to "auto".
 	//
-	// The Runner does not set this field, so it is reachable only by calling
-	// a Provider directly (issue 1239). The pairing with
-	// RunnerConfig.Selector — narrow the offered set, then force a call, to
-	// steer a proactive or injected turn toward acting rather than only
-	// replying — is the intended design but is not wired today.
+	// Pairs with RunnerConfig.Selector (narrow the offered set) to steer a
+	// proactive or injected turn toward acting rather than only replying:
+	// set Selector on the config and ToolChoice on that turn's
+	// TurnRequest.Generation.
 	ToolChoice ToolChoice `json:"toolChoice,omitempty"`
 
 	// ResponseSchema, when set, asks Generate for structured output
 	// conforming to this JSON Schema. Ignored by Stream.
 	ResponseSchema core.RawJSON `json:"responseSchema,omitempty"`
+}
+
+// GenerationParams are the model-facing generation knobs a caller sets for a
+// turn: the subset of ProviderRequest that says *how* to generate rather than
+// *what* to generate from. The Runner copies them onto every ProviderRequest
+// it builds, so they reach both the streaming step loop and the finalizing
+// Generate of a structured-output turn.
+//
+// Set defaults for every turn on RunnerConfig.Generation and override them for
+// one turn on TurnRequest.Generation. Merge is per field, and a zero field
+// inherits: a TurnRequest that sets only ToolChoice keeps the config's
+// Temperature and MaxTokens. The corollary is that a turn cannot un-set a
+// config default back to the provider's own default — set the field to the
+// value you want instead.
+//
+// ResponseSchema is deliberately not here. It lives on RunnerConfig because it
+// selects a different turn shape (a finalizing Generate call) rather than
+// tuning the calls a turn already makes.
+//
+// Support varies by provider and a rejected parameter is a failed request, not
+// a silently ignored one. See ProviderRequest.Temperature.
+type GenerationParams struct {
+	// Temperature overrides the provider default when non-nil.
+	Temperature *float64 `json:"temperature,omitempty"`
+
+	// MaxTokens caps the completion length when positive.
+	MaxTokens int `json:"maxTokens,omitempty"`
+
+	// ToolChoice biases tool calling. The zero value is the provider
+	// default ("auto").
+	ToolChoice ToolChoice `json:"toolChoice,omitempty"`
+}
+
+// merge returns p overlaid with over: each field of over that is set wins,
+// each field that is zero inherits from p. Used to resolve
+// TurnRequest.Generation against RunnerConfig.Generation.
+func (p GenerationParams) merge(over GenerationParams) GenerationParams {
+	out := p
+	if over.Temperature != nil {
+		out.Temperature = over.Temperature
+	}
+	if over.MaxTokens != 0 {
+		out.MaxTokens = over.MaxTokens
+	}
+	if !over.ToolChoice.IsZero() {
+		out.ToolChoice = over.ToolChoice
+	}
+	return out
+}
+
+// applyTo copies the params onto req. Kept as one place so the streaming and
+// finalizing request builders cannot drift.
+func (p GenerationParams) applyTo(req *ProviderRequest) {
+	req.Temperature = p.Temperature
+	req.MaxTokens = p.MaxTokens
+	req.ToolChoice = p.ToolChoice
 }
 
 // ToolChoice is the request-level tool-calling bias. The zero value ("")

--- a/agent/runner.go
+++ b/agent/runner.go
@@ -104,6 +104,16 @@ type RunnerConfig struct {
 	// Nil means every call runs, the pre-approval behavior.
 	Approval ApprovalPolicy
 
+	// Generation carries the default generation knobs (temperature, token
+	// cap, tool-choice bias) for every model call this Runner makes, both
+	// the streaming steps and the finalizing Generate of a structured-output
+	// turn. TurnRequest.Generation overrides it per turn, field by field.
+	//
+	// The zero value sends nothing, which is the behavior before these were
+	// reachable: the provider's own defaults apply and the request carries
+	// no temperature, max_tokens, or tool_choice.
+	Generation GenerationParams
+
 	// Compactor, when non-nil, may rewrite the turn's history before the
 	// first model call — the head summarized, a recent tail kept verbatim —
 	// to keep a long conversation under a context budget. The Runner calls
@@ -264,6 +274,16 @@ type TurnRequest struct {
 	// turn is running: between turns nothing drains the channel, and a
 	// buffered cancel-all would hit the next turn's first dispatch.
 	Control <-chan Control
+
+	// Generation overrides RunnerConfig.Generation for this turn, field by
+	// field: a set field wins, a zero field inherits the config's. Use it
+	// for per-turn decisions the config cannot express — forcing a tool call
+	// on a proactive turn, capping tokens on one cheap turn, varying
+	// temperature across sampled candidates.
+	//
+	// The zero value changes nothing and the turn runs on the config's
+	// defaults.
+	Generation GenerationParams
 }
 
 // Run executes one turn against history. Events stream to emit (nil is
@@ -285,6 +305,7 @@ func (r *Runner) RunTurn(ctx context.Context, req TurnRequest) (*TurnResult, err
 	if emit == nil {
 		emit = func(Event) {}
 	}
+	gen := r.cfg.Generation.merge(req.Generation)
 
 	var reg *callCancels
 	if req.Control != nil {
@@ -367,11 +388,13 @@ func (r *Runner) RunTurn(ctx context.Context, req TurnRequest) (*TurnResult, err
 		}
 		stepSpan.SetAttribute("agent.tools.offered", fmt.Sprint(len(tools)))
 
-		stream, err := r.cfg.Provider.Stream(stepCtx, ProviderRequest{
+		stepReq := ProviderRequest{
 			Instructions: turnInstructions,
 			Messages:     msgs,
 			Tools:        tools,
-		})
+		}
+		gen.applyTo(&stepReq)
+		stream, err := r.cfg.Provider.Stream(stepCtx, stepReq)
 		if err != nil {
 			stepSpan.RecordError(err)
 			stepSpan.End()
@@ -398,7 +421,7 @@ func (r *Runner) RunTurn(ctx context.Context, req TurnRequest) (*TurnResult, err
 			stepSpan.End()
 			var structured core.RawJSON
 			if r.cfg.ResponseSchema.Len() > 0 {
-				s, err := r.finalizeStructured(ctx, turnInstructions, msgs, &usage)
+				s, err := r.finalizeStructured(ctx, turnInstructions, msgs, &usage, gen)
 				if err != nil {
 					return nil, r.failSpan(emit, turnSpan, fmt.Errorf("agent: structured finalize: %w", err))
 				}
@@ -514,14 +537,21 @@ const structuredMaxAttempts = 2
 // aborts (the caller asked for structured output and cannot get it); after the
 // retry budget it returns the last output best-effort so a caller's Bind, not
 // a lost turn, surfaces a still-malformed document.
-func (r *Runner) finalizeStructured(ctx context.Context, instructions string, msgs []Message, usage *Usage) (core.RawJSON, error) {
+func (r *Runner) finalizeStructured(ctx context.Context, instructions string, msgs []Message, usage *Usage, gen GenerationParams) (core.RawJSON, error) {
 	var last string
 	for attempt := 0; attempt < structuredMaxAttempts; attempt++ {
-		resp, err := r.cfg.Provider.Generate(ctx, ProviderRequest{
+		finalReq := ProviderRequest{
 			Instructions:   instructions,
 			Messages:       msgs,
 			ResponseSchema: r.cfg.ResponseSchema,
-		})
+		}
+		gen.applyTo(&finalReq)
+		// The finalizing call offers no tools, so a ToolChoice carried from
+		// the turn's params would ask the provider to force a call it cannot
+		// make. Drop it here rather than in applyTo, which the step loop
+		// shares.
+		finalReq.ToolChoice = ToolChoice{}
+		resp, err := r.cfg.Provider.Generate(ctx, finalReq)
 		if err != nil {
 			return core.RawJSON{}, err
 		}

--- a/docs/AGENT_SDK_ROADMAP.md
+++ b/docs/AGENT_SDK_ROADMAP.md
@@ -273,8 +273,13 @@ primitive" to "buildable today."** Updated status:
 - **Multi-agent debate / Mixture-of-Agents / CAMEL / supervisor** — `AgentSource` + `MultiSource` +
   `Team` (✅). ([2305.14325](https://arxiv.org/abs/2305.14325), [2406.04692](https://arxiv.org/abs/2406.04692))
 - **Best-of-N + verifier / CRITIC / judge panel** — `ToolChoice` forced-tool + `ResponseSchema` +
-  `FuncSource` verifiers + eval scorers (✅). ([2110.14168](https://arxiv.org/abs/2110.14168),
+  `FuncSource` verifiers + eval scorers (✅ as of #1239). ([2110.14168](https://arxiv.org/abs/2110.14168),
   [2305.11738](https://arxiv.org/abs/2305.11738), [2404.18796](https://arxiv.org/abs/2404.18796))
+  *Correction: this row read ✅ before #1239, but `ToolChoice` was unreachable from a turn — the
+  Runner's step loop sent only `{Instructions, Messages, Tools}`, so `Temperature`, `MaxTokens`, and
+  `ToolChoice` could not be set on a Runner at all. #1239 added `RunnerConfig.Generation` /
+  `TurnRequest.Generation` and the row is now accurate. The stale claim is why #1056 was sized S–M;
+  see that issue for the re-scope.*
 - **Tool retrieval via `Selector`** — narrow a big `MultiSource` per step (✅; relevance needs an
   embedder, now present). ([2410.14594](https://arxiv.org/abs/2410.14594))
 - **CodeAct** — `execute_code` `FuncSource` + forced-tool + error-feedback (✅).


### PR DESCRIPTION
Closes #1239.

## What changes

`RunnerConfig.Generation` and `TurnRequest.Generation` let a caller set temperature, a token cap, and a tool-choice bias on a turn. Previously none of the three could be set on a Runner at all: `ProviderRequest` modelled them and both providers rendered them onto the wire, but the Runner's step loop built `ProviderRequest{Instructions, Messages, Tools}` and stopped there. A zero `Generation` produces a byte-identical request to before, so nothing changes for existing callers.

## ELI12

A car with a dashboard that has a temperature dial, a fuel limiter, and a gear selector — all wired to the engine, all working — except the dial knobs were never fitted to the dashboard. The engine bay is complete. You just can't reach any of it from the driver's seat, and the only workaround is opening the hood while driving.

That is what made this invisible for so long. Every obvious place you would look for the bug is correct. `ProviderRequest` declares the fields. `OpenAIProvider` and `AnthropicProvider` both serialise them properly, with tests pinning the exact JSON. The seam looks finished. The missing piece is a single struct literal in the step loop that never listed them, and nothing fails when a field is silently never populated — the requests just quietly go out without a temperature, forever.

The knock-on is the interesting part. `docs/AGENT_SDK_ROADMAP.md` §7 marked "Best-of-N + verifier / judge panel" as buildable today, crediting `ToolChoice` forced-tool among the shipped primitives. That was written by reading the seam, which is exactly the thing that looks complete. Issue #1056 was then scoped and sized against that claim. A missing struct field propagated into a roadmap entry and an issue estimate before anyone tried to actually turn the dial.

## Reviewer's guide

Read in this order:

1. [agent/provider.go](https://github.com/panyam/mcpkit/pull/1241/files#diff-a1383b85f643c0c6e93ffd7d81aefd65f427d24348ee2d60c8388c91694f3c5b) — start here. The `GenerationParams` type, `merge` (per field, zero inherits), and `applyTo`. The doc comment carries the contract, including why `ResponseSchema` is deliberately excluded.
2. [agent/runner.go](https://github.com/panyam/mcpkit/pull/1241/files#diff-6d787b427ac08cd61669af7e34ff0b747c4264d20b31b21b681a2ec2c826d9f0) — the wiring. Three small edits: the two new config/request fields, `gen := r.cfg.Generation.merge(req.Generation)` resolved once at the top of `RunTurn`, and `applyTo` at both `ProviderRequest` sites. Note the `ToolChoice` drop in `finalizeStructured`.
3. [agent/generation_test.go](https://github.com/panyam/mcpkit/pull/1241/files#diff-fab48eeb1d1ce3249cc2b8124eea5c48f1d7e3b9c63a119de4291856887e693d) — acceptance for the above. `TestGenerationUnsetSendsNothing` is the regression guard for the default path; `TestGenerationToolChoiceDroppedOnFinalize` pins the trap in 2.
4. [agent/NOTES.md](https://github.com/panyam/mcpkit/pull/1241/files#diff-41ecf99a6a2f0ad1fc8365997751ee158d45057e49e652e8cc9c8b6f0e65de18) — the rationale, including why unsupported parameters are forwarded rather than screened.
5. [docs/AGENT_SDK_ROADMAP.md](https://github.com/panyam/mcpkit/pull/1241/files#diff-b47a95c62c074f4804e598fe49dae1ba6dac14d094a3821bd3211222a3570501) — mechanical, the §7 correction.

## How it works

```
RunTurn(req):
    gen = cfg.Generation.merge(req.Generation)   # per field; zero inherits
    ...
    each step:
        stepReq = {Instructions, Messages, Tools}
        gen.applyTo(&stepReq)                    # temperature, maxTokens, toolChoice
        Provider.Stream(stepReq)

    if cfg.ResponseSchema set:
        finalizeStructured(..., gen):
            finalReq = {Instructions, Messages, ResponseSchema}
            gen.applyTo(&finalReq)
            finalReq.ToolChoice = zero           # this call offers no tools
            Provider.Generate(finalReq)
```

The merge resolves once per turn rather than per step, so every step in a turn sees identical parameters.

## Decision log

- **One struct rather than three fields on each of `RunnerConfig` and `TurnRequest`.** Root `CONSTRAINTS.md` C2 (consolidated entry structs) points this way, and it keeps a future logprob field (#1053) additive instead of adding a fourth pair of parallel fields.
- **Value with per-field merge, not `*GenerationParams`.** The fields already encode "unset" natively: `Temperature *float64` nil, `MaxTokens` 0, `ToolChoice` zero. A pointer-to-struct would add nil-checking at every call site to express the same thing. Documented corollary: a turn cannot un-set a config default back to the provider's own, only set a different value. No caller wants that today.
- **Per-turn override, not config-only.** `ToolChoice`'s own doc comment already described steering *a proactive or injected turn* toward acting rather than replying — inherently per-turn, and the integration that was never wired. Config-only would not express it.
- **`ResponseSchema` stays out of the struct.** It selects a different turn shape (a finalizing `Generate` call) rather than tuning the calls a turn already makes. Grouping them would imply they compose the same way.
- **Unsupported parameters are forwarded, not screened.** A rejected parameter fails the request rather than being ignored — current Anthropic models 400 on sampling params. I considered a capability interface and a per-provider opt-in flag, and rejected both: `ProviderError{StatusCode, Body}` already carries the vendor's message verbatim up to 2048 bytes and names the offending field, so screening duplicates diagnostics that exist, and screening *by model* needs the per-model capability table this project already declined once (the reason agentchat takes `--context-window` rather than inferring one). Revisit only if a response-side signal such as logprobs needs negotiation, which degrades to best-effort rather than failing.
- **`ToolChoice` dropped at the finalize call site rather than inside `applyTo`.** `applyTo` is shared with the step loop, where `ToolChoice` is exactly the point.

## Risk / blast radius

- **Affects:** every Runner turn, via two struct literals. Behaviour is unchanged unless a caller sets `Generation`.
- **Does not affect providers.** No provider file changed. `FailoverProvider` and `thinkingProvider` pass the request through untouched; both concrete providers already rendered all three parameters.
- **Tests covering this:** `agent/generation_test.go`, 7 tests plus 3 subtests, 27 assertions. `make test-agent` green across all 13 modules; `-race` green on the agent module.
- **Be paranoid about:** the default path. `TestGenerationUnsetSendsNothing` asserts a zero `Generation` sends no temperature, no max_tokens, no tool_choice — if that regressed, every existing deployment's wire shape would change silently.
- **Red-before-green verified** by neutering `applyTo`: the four behavioural tests fail, the merge unit test and the default-path guard correctly pass either way (they are a unit test and a regression guard, not new-behaviour tests).
- **Assertions: 27 added, 0 removed, 0 weakened.** No existing test file was modified.

## Before / after

`StubProvider.Requests()[0]` for a Runner configured with `Temperature: 0.7, MaxTokens: 256, ToolChoice: required`:

```
before                          after
------                          -----
Instructions: "be helpful"      Instructions: "be helpful"
Messages:     [user "hi"]       Messages:     [user "hi"]
Tools:        []                Tools:        []
Temperature:  <nil>             Temperature:  0.7
MaxTokens:    0                 MaxTokens:    256
ToolChoice:   {Mode:""}         ToolChoice:   {Mode:"required"}
```

With no `Generation` set, the "after" column is identical to "before".

## Out of scope

- Capability negotiation on the seam — see the decision log; revisit with logprobs #1053.
- Grammar-constrained decoding #1054.
- The #1056 aggregators, now re-scoped and blocked on this landing.
- The roadmap correction is included, but a broader audit of other §7 rows for the same class of stale claim is not. Worth doing under #1240.
