### PR TITLE
agent: add constraint A10 on module boundaries and seam placement

### DIFF
--- a/agent/CLAUDE.md
+++ b/agent/CLAUDE.md
@@ -31,6 +31,11 @@ Full text in `agent/CONSTRAINTS.md`. These four are the ones that get violated b
 - **A9 — the provider seam exposes loop-visible capabilities only.** Loop-invisible provider
   optimizations (prompt caching, extended thinking) stay out; wrap the vendor SDK behind the seam
   if one is ever genuinely needed.
+- **A10 — dependency weight decides module boundaries.** `agent/go.mod` has exactly two direct
+  requires and must stay that way. An implementation belongs beside its interface here when it costs
+  no third-party dependency, and in a satellite module (`agent/store/redis`, `agent/store/gorm`) when
+  it needs a driver or SDK. Seam interfaces stay with the Runner that consumes them; do not create an
+  interface-only package.
 
 Also: **A8 rules out building a workflow engine here.** Orchestration is model-driven or
 integrated with a dedicated engine.

--- a/agent/CONSTRAINTS.md
+++ b/agent/CONSTRAINTS.md
@@ -60,3 +60,17 @@ The dividing test for any provider-specific behavior is **does the agent loop ac
 Never thread provider-specific opaque state (e.g. Anthropic signed thinking blocks) through the neutral `agent.Message` or the Runner — that violates A2 wire-serializability and the provider-agnostic core, regardless of which side of the test the feature falls on. The SDK's job is the Provider *seam*, not provider parity. Rationale (2026-08-04): issue 953 (caching/thinking, loop-invisible) closed not-planned; logprob #1053 kept as a loop-visible capability. See `docs/AGENT_SDK_ROADMAP.md` § Phase 5.
 
 **Verify:** `agent.Message` carries no provider-specific reasoning/signature field; the no-SDK providers send no `cache_control`, `thinking`, fast-mode, or task-budget request fields. (Loop-visible capabilities like logprobs are permitted as capability-optional seam additions.)
+
+## A10: Dependency weight decides module boundaries; seam interfaces stay with the Runner
+
+Two rules, and the second is the one that gets broken by accident.
+
+**Seam interfaces live in `agent/`, with the Runner that consumes them.** `Provider`, `ToolSource`, `MemoryStore`, `RunStore`, `ToolResultStore`, `Embedder`, and `Compactor` are all defined where they are used, per the Go convention that an interface belongs to its consumer rather than its implementors. There is no `agent/api` or interface-only package, and there should not be: it would separate every seam from the only code that depends on it, and implementations satisfy these structurally without importing anything.
+
+**A satellite module is for dependency weight, not for layering.** An implementation lives beside its interface in `agent/` when it costs no third-party dependency, and moves to its own module when it needs a driver or SDK. That is why `InMemoryRunStore`, `InMemoryMemoryStore`, `InMemorySemanticStore`, `FileToolResultStore`, and the no-SDK `OpenAIProvider` / `AnthropicProvider` all sit next to their interfaces, while redis, gorm, and pgvector implementations are `agent/store/redis` and `agent/store/gorm` with their own `go.mod`.
+
+The property this protects is that `agent/` is cheap to embed: it pulls mcpkit's own modules and nothing else, so depending on the agent SDK never drags in a database driver or a vendor SDK a consumer does not use. A1 governs the *outward* direction (nothing outside `agent/` may import an LLM SDK or this module); this governs the inward one. A9 depends on it too — "wrap the vendor's official SDK behind the seam" means in a satellite module, not here.
+
+Adding a dependency-free implementation beside its interface is always fine. Adding one that carries a driver is the violation, and the fix is a new satellite module rather than a new direct require.
+
+**Verify:** `cd agent && go mod edit -json | jq -r '.Require[] | select(.Indirect|not) | .Path'` lists only `github.com/panyam/mcpkit` and `github.com/panyam/servicekit`. Any other entry means a dependency landed in the core agent module: justify it as genuinely dep-free infrastructure, or move the code to a satellite module.


### PR DESCRIPTION
Agenda item on #1240 (1.0 API-freeze review).

## What changes

Documentation only. Adds constraint A10 to `agent/CONSTRAINTS.md` recording the rule the agent module already follows for where code lives, and a pointer in `agent/CLAUDE.md` so it loads when working in that subtree. No code changes; the verify line passes today.

## ELI12

A workshop where the hand tools hang on the wall by the bench that uses them, and only the machines that need their own power supply live in the shed out back. Someone walking in sees tools in two places and assumes it is a filing system — tools here, machines there — and starts tidying by moving things to match. It isn't a filing system. It's about what each thing needs to run. Move a hand tool to the shed and you have made the bench worse for no reason; put a machine on the bench and you have to run power to the whole room.

That is the mistake this constraint prevents. Looking at `agent/`, you see the `RunStore` *interface* next to an in-memory implementation, while the redis and gorm implementations live in separate modules, and it reads like an interface-versus-implementation split done inconsistently. It isn't. `InMemoryRunStore` is there because it costs nothing to include; the gorm one is elsewhere because it drags in a database driver. Same rule, applied honestly, producing a layout that looks arbitrary until you know what the rule is.

The thing being protected is invisible until it's gone: `agent/go.mod` has exactly two direct requires, so depending on the agent SDK never pulls in a database driver or a vendor SDK you don't use. One well-intentioned store added in the wrong place ends that permanently, and nothing in the repo would have objected.

## Reviewer's guide

1. [agent/CONSTRAINTS.md](https://github.com/panyam/mcpkit/pull/1242/files#diff-497adf791edb3f214e980ee66fc031ba79393b9dde38a6060055d818b3168650) — the constraint. Two rules: seam interfaces stay with their consumer, and satellite modules are for dependency weight rather than layering. The verify line is the operative part.
2. [agent/CLAUDE.md](https://github.com/panyam/mcpkit/pull/1242/files#diff-19f03db1f7ac528768d3f560279ebbf73ac046f4ded0937b0b3db9ade84edc80) — one bullet in the nested router's invariant list, so it is loaded when editing in that subtree.

## Decision log

- **Framed as dependency weight, not interface-versus-implementation.** The Go convention is that an interface belongs to the package that *uses* values of it, not the ones implementing it, so an `agent/api` package would be an anti-pattern here — it would separate every seam from the Runner that consumes it. The constraint states the actual rule rather than the one the layout superficially suggests.
- **Verify is a `go mod edit -json` listing, not a count.** A count would be brittle and would not say what is wrong. Listing the direct requires makes the violation self-describing: a third entry names the dependency that landed in the core module.
- **Placed as A10 rather than folded into A1.** A1 governs the outward direction (nothing outside `agent/` may import an LLM SDK or this module). This governs the inward one. They are complementary but distinct, and merging them would bury the new rule inside a constraint about something else.
- **No code moved.** The layout already complies. This records the rule so it survives; whether to extract `agent/providers/` on discoverability grounds is a separate question, still open on #1240.

## Risk / blast radius

- **Affects:** nothing at runtime. Documentation and a verify command.
- **Tests covering this:** none needed. The verify line is the check, and it passes: `cd agent && go mod edit -json | jq -r '.Require[] | select(.Indirect|not) | .Path'` returns `github.com/panyam/mcpkit` and `github.com/panyam/servicekit`.
- **Be paranoid about:** whether the rule as written would wrongly reject something legitimate. It permits any dependency-free implementation beside its interface, and only requires a satellite module when a driver or SDK is involved. If a genuinely dep-free third-party helper is ever wanted, the constraint asks for justification rather than forbidding it outright.

## Before / after

```
$ cd agent && go mod edit -json | jq -r '.Require[] | select(.Indirect|not) | .Path'
github.com/panyam/mcpkit
github.com/panyam/servicekit
```

Before: that property held by habit, undocumented, with nothing to catch a regression.
After: it is a stated constraint with a one-line check.

## Out of scope

- The `agent/providers/` extraction question — still open on #1240.
- Applying the same treatment to other modules. `ext/` and `experimental/ext/` have their own dependency stories that were not audited here.
