### PR TITLE
fix(deps): raise the pillow floor to the version already locked

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,6 +25,8 @@ Recently done: stable v0.4.0 and the v0.5.x line, client conformance harness (ti
 
 The tier-advancement request to the SDK Working Group is deliberately held until the 1.0 release. The protocol surface is already at the conformance and policy bar; the remaining work is on the agent track (see below), and cutting 1.0 once that lands means the tiering system's stable-release and spec-tracking checks are satisfied by a release that represents the whole project rather than a protocol-only slice. The request is a self-assessment issue filed against `modelcontextprotocol/modelcontextprotocol` once 1.0 is published.
 
+**Issue 1240 is the 1.0 tracker.** 1.0 is primarily an API stability commitment rather than a feature milestone: it retires the `VERSIONING.md` clause allowing breaking changes in minor releases, and the agent surface is the young part of the tree. The tracker carries the freeze agenda — generation parameters on the provider seam (1239, done), package layout (constraint A10, done; the `agent/providers/` extraction question still open), an exported-vs-internal audit, seam shapes, naming, and contract documentation.
+
 ## Longer-term
 
 - **SEP-2577 removals:** Roots, Sampling, and Logging surfaces are deprecated with a 12-month annotation window; removal is tracked in issue 850 and lands no earlier than 2027.

--- a/docs/AGENT_SDK_ROADMAP.md
+++ b/docs/AGENT_SDK_ROADMAP.md
@@ -54,6 +54,15 @@ differentiator. See §4.
 
 Legend: ✅ shipped · 🟡 partial/shipped-with-follow-ups · ⏳ tracked (open issue) · ❌ untracked gap.
 
+> **Marking a row ✅ requires checking that the loop can reach the primitive, not that the seam
+> declares it.** §7 credited `ToolChoice` forced-tool as shipped for Best-of-N and judge panels;
+> `ProviderRequest` did declare it and both providers rendered it onto the wire, but the Runner's
+> step loop never populated it, so no caller could set it on a turn (fixed in #1239). The failure
+> mode is specific and worth naming: a seam can look complete while nothing drives it, and reading
+> the type definition confirms the wrong half. The cost was not the doc line — #1056 was scoped and
+> sized against that row, and the estimate was wrong by the size of a missing contract decision.
+> When a row's evidence is a type declaration, grep for a non-test assignment before marking it.
+
 | Area | Status | As-built (file) | Remaining |
 |---|---|---|---|
 | **Tool-call approval / permission ladder** | ✅ #929 | `agent/approval.go` — `ApprovalPolicy`, `TieredApproval`, `ApprovalMode` {AlwaysAsk/ReadOnlyAuto/AlwaysAllow} + per-tool `RuleAsk/Allow/Deny`; "ask" routes through `ElicitationCoordinator.Confirm`; `EventToolDenied`; host `/approve` | — |
@@ -71,8 +80,8 @@ Legend: ✅ shipped · 🟡 partial/shipped-with-follow-ups · ⏳ tracked (open
 | **Observability** | ✅ | SEP-414 tracing (`agent.turn/step/tool`, `agent.memory.recall`) + OTel **metrics** (#1023 — turn/step/token/tool counters + duration histograms via `RunnerConfig.MeterProvider`, `host.WithMeterProvider`, agentchat `SetupMeter`, `mcpkit-agent` Grafana dashboard) | — |
 | **Durable workflows / graphs (Phase 4)** | ❌ **dropped (not-planned, 2026-08-04)** | — | Not building an engine (constraint A8). Workflow patterns build on shipped primitives (§7); durable orchestration → integrate a dedicated engine. #928/#944/#945/#946 closed not-planned. |
 | **Provider routing / cascades** | ⏳ #991 | only `FailoverProvider` (failure+cooldown) today | per-turn/per-role routing **#991**, router presets **#1044**, confidence-gated cascade **#1057** (Phase 6) |
-| **Provider control & decoding fidelity (Phase 5)** | ⏳ #1050 (re-scoped by A9) | structured output via finalizing `Generate` only | logprob/token-confidence **#1053** — **loop-visible** (routing/abstention/cascade), kept as agent-SDK work; OpenAI-wire/local, not Anthropic. Grammar/guided decoding **#1054** — deferred (marginal). Anthropic caching/thinking **dropped (#953, loop-invisible)**. |
-| **Test-time compute (Phase 6)** | ⏳ #1051 | achievable by host loop; `#1033` covers sub-agent fan-out only | sampling/vote helper **#1056**, `FailoverProvider` quality trigger **#1057** |
+| **Provider control & decoding fidelity (Phase 5)** | ⏳ #1050 (re-scoped by A9) | structured output via finalizing `Generate`; generation parameters reachable from a turn via `RunnerConfig.Generation` / `TurnRequest.Generation` (#1239 — temperature, token cap, tool choice; before it, three of the four `ProviderRequest` parameters could not be set on a Runner at all) | logprob/token-confidence **#1053** — **loop-visible** (routing/abstention/cascade), kept as agent-SDK work; OpenAI-wire/local, not Anthropic. Grammar/guided decoding **#1054** — deferred (marginal). Anthropic caching/thinking **dropped (#953, loop-invisible)**. |
+| **Test-time compute (Phase 6)** | ⏳ #1051 | `#1033` `FanOutSource` already gives N concurrent runs, member ordering, failure isolation, and a pluggable `Aggregate` hook | sampling/vote **#1056** — re-scoped down to two aggregators over that hook (see §5a); `FailoverProvider` quality trigger **#1057**, blocked on #1053 |
 | **Safety & guardrails (Phase 7)** | ⏳ #1052 | approval ladder (#929); event stages exist (`stages.go`) but no shipped guardrail Transform | prompt-injection spotlighting **#1058**; opt-in extensions (AgentDojo eval, constitutional gate) unfiled |
 | **Coding-surface: sandboxing, hooks, repo map, LSP** | ⏳ #1059 | — | scope decision (agent/ vs coding agent built on it) **#1059** |
 
@@ -194,8 +203,19 @@ sufficient.
   - The phase's original "provider control" framing was too provider-flavored; A9 is the durable line.
     Capability-optional fields, nil = today's behavior (A2/CONSTRAINTS).
 - **Phase 6 — test-time compute & routing reliability:** epic #1051 → sampling+aggregate helper
-  (self-consistency / Best-of-N + verifier rerank) #1056, `FailoverProvider` quality-score trigger for
-  confidence-gated cascades #1057. Complements upfront routing #991 (selection vs escalation).
+  #1056, `FailoverProvider` quality-score trigger for confidence-gated cascades #1057. Complements
+  upfront routing #991 (selection vs escalation).
+  - **#1056 was re-scoped down (2026-08-07)** after a design pass, and the reasoning generalizes.
+    Most of its mechanism already ships: `FanOutConfig` provides N concurrent runs, stable member
+    ordering, per-member failure isolation, and a pluggable `Aggregate` reduce hook, so the delta is
+    two aggregator functions rather than a new primitive. Its premise was also not portable —
+    self-consistency is defined as sampling at `Temperature>0`, and current Anthropic models reject
+    sampling parameters outright, so identical-member diversity is the one unportable case. The
+    portable source of diversity is per-member providers, which multi-model already gives us free.
+    And no user was identifiable: the issue traces to the §5b competitive sweep, not a request.
+    **Worth applying the same three questions to the other phase children** — what already ships,
+    does the premise hold on every provider, and who asked.
+  - #1057 is blocked on #1053: a confidence-gated cascade needs a confidence signal to gate on.
 - **Phase 7 — safety & guardrails:** epic #1052 → prompt-injection spotlighting/datamarking `Transform`
   stage for untrusted tool output #1058; opt-in extensions AgentDojo eval suite #1060 and constitutional
   pre-dispatch critique gate #1061. The coding-surface scope decision (sandboxing/hooks/repo map/LSP)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,14 @@ dependencies = [
     # Image processing for the apps-compat visual gallery — pixel diff +
     # bounding-box overlays. Used only by scripts/apps_visual_gallery.py;
     # other scripts are stdlib-only.
-    "Pillow>=10.0.0",
+    #
+    # Floor is 12.2.0, not 10.0.0, and must not be lowered: PYSEC-2026-165 and
+    # its siblings affect pillow <12.2.0. The requires-python bump above already
+    # killed the second 11.3.0 resolution, so the lock resolves 12.2.0 alone —
+    # but a floor below it left Dependabot computing an update that produced no
+    # diff, which it reports as a hard error (dependency_file_content_not_changed)
+    # rather than a no-op, failing the Dependabot Updates run.
+    "Pillow>=12.2.0",
     "numpy>=1.24.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "numpy", specifier = ">=1.24.0" },
-    { name = "pillow", specifier = ">=10.0.0" },
+    { name = "pillow", specifier = ">=12.2.0" },
     { name = "pyyaml", specifier = ">=6.0.0" },
 ]
 


### PR DESCRIPTION
## What changes

`pyproject.toml` declares `Pillow>=12.2.0` instead of `>=10.0.0`, matching what `uv.lock` has resolved since the `requires-python` bump. The resolved version does not change and no package moves; the only `uv.lock` edit is the recorded specifier line. It clears the `Dependabot Updates` run, which has been red since 2026-08-07.

## ELI12

A shopping list that says "milk, at least 2% fat" when the fridge already has whole milk in it. Nothing is wrong with the milk. But every time someone checks the list against the fridge, they conclude an errand is needed, drive to the shop, find there is nothing to buy, and come home. A helper who reports "I completed the errand and changed nothing" as a *failure* rather than a shrug turns that into an alarm that fires forever.

Dependabot is that helper. It reads the declared floor, works out an upgrade, discovers the lockfile already satisfies it, produces an empty diff, and reports `dependency_file_content_not_changed` as a hard error. The run goes red even though the dependency is perfectly healthy — in fact *because* it is already ahead of what was asked for.

The reason this only started recently is the interesting bit. The floor was harmlessly stale for as long as the lock genuinely had an older pillow in it, because then the errand had something to buy. Raising `requires-python` to 3.11 dropped the second pillow 11.3.0 resolution, the lock collapsed to 12.2.0 alone, and the previously-harmless floor became a permanently empty errand. A fix in one place turned a dormant inconsistency into a failing job somewhere unrelated.

## Reviewer's guide

1. [pyproject.toml](https://github.com/panyam/mcpkit/pull/1243/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711) — the floor, plus a comment recording why it must not be lowered.
2. [uv.lock](https://github.com/panyam/mcpkit/pull/1243/files#diff-84321598744d84dbee2318e634c74c9aae39a1c253f1c4bd17ebf9ef2f807b11) — one line, the recorded specifier. No resolved version changes.

## Decision log

- **Raised the floor rather than ignoring pillow in `dependabot.yml`.** An ignore would silence a genuine future advisory on a package the repo does pull in, and would treat the symptom: the defect is that the declared constraint was behind the locked reality.
- **`>=12.2.0` rather than pinning `==12.2.0`.** This is repo tooling, not a published package, and the lockfile is what pins. A floor at the advisory boundary keeps future patches flowing.
- **Comment placed on the dependency, not in the changelog.** The `requires-python` block directly above already explains the pillow CVE branch; this is the second half of the same story and belongs next to it, where someone lowering the floor would read it.

## Risk / blast radius

- **Affects:** repo tooling only. This env is not published and is consumed by `scripts/`.
- **Runtime risk: none.** No resolved version changes, so no code runs against a different pillow.
- **Verified:** `uv lock` produces the one-line diff shown, `uv sync` succeeds, `uv run python -c "import PIL, numpy, yaml"` reports pillow 12.2.0 / numpy 2.4.6, and `scripts/apps_visual_gallery.py` — the only pillow consumer — still parses.
- **Be paranoid about:** whether any other declared floor has drifted below its locked version the same way. I did not audit the rest; only pillow was failing.

## Before / after

```
$ gh run list --workflow="Dependabot Updates" --limit 2
2026-08-07  failure    <- pillow: dependency_file_content_not_changed
2026-08-06  success

pyproject.toml   "Pillow>=10.0.0"   ->   "Pillow>=12.2.0"
uv.lock          specifier ">=10.0.0" -> ">=12.2.0"   (resolved version unchanged: 12.2.0)
```

## Out of scope

- Auditing the other declared floors for the same drift.
- The `uv.lock` scanning gap noted in `DEPENDENCY_POLICY.md` — nothing currently scans it.
