### PR TITLE
chore(agent): shrink the exported surface ahead of the 1.0 freeze

### DIFF
--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -49,7 +49,7 @@ func NewSpawnSource(pool *AgentPool) *FuncSource {
 			if strings.TrimSpace(in.Task) == "" {
 				return "", fmt.Errorf("spawn_agent requires a non-empty 'task'")
 			}
-			id, err := pool.Spawn(ctx, in.Name, in.Task)
+			id, err := pool.spawn(ctx, in.Name, in.Task)
 			if err != nil {
 				return "", err
 			}
@@ -59,7 +59,7 @@ func NewSpawnSource(pool *AgentPool) *FuncSource {
 	_ = AddFunc(fs, AwaitAgentToolName,
 		"Wait for a spawned sub-agent to finish and return its result. Blocks until it completes.",
 		func(ctx context.Context, in agentIDArgs) (string, error) {
-			result, err := pool.Await(ctx, in.ID)
+			result, err := pool.await(ctx, in.ID)
 			if err != nil {
 				return "", err
 			}
@@ -75,7 +75,7 @@ func NewSpawnSource(pool *AgentPool) *FuncSource {
 	_ = AddFunc(fs, CancelAgentToolName,
 		"Cancel a spawned sub-agent you no longer need, by its handle id.",
 		func(ctx context.Context, in agentIDArgs) (string, error) {
-			if err := pool.Cancel(in.ID); err != nil {
+			if err := pool.cancel(in.ID); err != nil {
 				return "", err
 			}
 			return "cancelled " + in.ID, nil
@@ -84,7 +84,7 @@ func NewSpawnSource(pool *AgentPool) *FuncSource {
 	_ = AddFunc(fs, ListAgentsToolName,
 		"List the sub-agents you have spawned and their status (running / done / failed / cancelled).",
 		func(ctx context.Context, _ struct{}) (string, error) {
-			st := pool.Statuses()
+			st := pool.statuses()
 			if len(st) == 0 {
 				return "no spawned agents", nil
 			}
@@ -108,7 +108,7 @@ func NewSpawnSource(pool *AgentPool) *FuncSource {
 //
 // A handle outlives the spawning turn (the child runs on a DetachForBackground
 // context), so spawn-in-turn-1 / await-in-turn-3 works. Delivery is pull-only:
-// a spawned result is stored on the handle and returned by Await, never
+// a spawned result is stored on the handle and returned by await, never
 // auto-injected — auto-injection is AsyncAgentSource's model. The pool is
 // safe for concurrent use.
 type AgentPool struct {
@@ -192,12 +192,12 @@ func (p *AgentPool) Names() []SpawnStatus {
 	return out
 }
 
-// Spawn starts the named agent on a detached, cancellable goroutine over an
+// spawn starts the named agent on a detached, cancellable goroutine over an
 // isolated slice seeded with task, and returns a handle id. Depth and the
 // ctx-threaded call budget are checked before the spawn (an unknown name or an
 // exhausted guard is an error, not a started agent). The child outlives ctx
 // (DetachForBackground), so it keeps running after the spawning turn ends.
-func (p *AgentPool) Spawn(ctx context.Context, name, task string) (string, error) {
+func (p *AgentPool) spawn(ctx context.Context, name, task string) (string, error) {
 	p.mu.Lock()
 	spec, ok := p.agents[name]
 	if !ok {
@@ -257,10 +257,10 @@ func (h *spawnHandle) finish(result *TurnResult, err error) {
 	close(h.done)
 }
 
-// Await blocks until the spawned agent id finishes and returns its result, or
+// await blocks until the spawned agent id finishes and returns its result, or
 // returns when ctx is cancelled (the turn was cancelled). An unknown id is an
-// error. Await is idempotent: a second call returns the same stored result.
-func (p *AgentPool) Await(ctx context.Context, id string) (*TurnResult, error) {
+// error. await is idempotent: a second call returns the same stored result.
+func (p *AgentPool) await(ctx context.Context, id string) (*TurnResult, error) {
 	p.mu.Lock()
 	h, ok := p.handles[id]
 	p.mu.Unlock()
@@ -280,10 +280,10 @@ func (p *AgentPool) Await(ctx context.Context, id string) (*TurnResult, error) {
 	return h.result, nil
 }
 
-// Cancel aborts the spawned agent id (its context is cancelled; the running
+// cancel aborts the spawned agent id (its context is cancelled; the running
 // child returns and its handle moves to "cancelled"). An unknown id is an
 // error. Cancelling a finished agent is a no-op that still succeeds.
-func (p *AgentPool) Cancel(id string) error {
+func (p *AgentPool) cancel(id string) error {
 	p.mu.Lock()
 	h, ok := p.handles[id]
 	p.mu.Unlock()
@@ -299,9 +299,9 @@ func (p *AgentPool) Cancel(id string) error {
 	return nil
 }
 
-// Statuses snapshots every handle (running and finished) for list_agents,
+// statuses snapshots every handle (running and finished) for list_agents,
 // in id order of creation.
-func (p *AgentPool) Statuses() []SpawnStatus {
+func (p *AgentPool) statuses() []SpawnStatus {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	out := make([]SpawnStatus, 0, len(p.handles))

--- a/agent/agent_pool_test.go
+++ b/agent/agent_pool_test.go
@@ -21,11 +21,11 @@ func TestAgentPool_SpawnAwait(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	id, err := pool.Spawn(context.Background(), "worker", "go")
+	id, err := pool.spawn(context.Background(), "worker", "go")
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := pool.Await(context.Background(), id)
+	res, err := pool.await(context.Background(), id)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -33,24 +33,24 @@ func TestAgentPool_SpawnAwait(t *testing.T) {
 		t.Fatalf("await result = %q, want the child's answer", res.Text)
 	}
 	// Await is idempotent.
-	if res2, err := pool.Await(context.Background(), id); err != nil || res2.Text != "the answer" {
+	if res2, err := pool.await(context.Background(), id); err != nil || res2.Text != "the answer" {
 		t.Fatalf("second await = (%+v, %v), want the same stored result", res2, err)
 	}
 }
 
 func TestAgentPool_UnknownName(t *testing.T) {
 	pool := NewAgentPool(nil)
-	if _, err := pool.Spawn(context.Background(), "nope", "go"); err == nil {
+	if _, err := pool.spawn(context.Background(), "nope", "go"); err == nil {
 		t.Fatal("spawning an unregistered agent should error")
 	}
 }
 
 func TestAgentPool_UnknownHandle(t *testing.T) {
 	pool := NewAgentPool(nil)
-	if _, err := pool.Await(context.Background(), "agent-99"); err == nil {
+	if _, err := pool.await(context.Background(), "agent-99"); err == nil {
 		t.Fatal("await of an unknown handle should error")
 	}
-	if err := pool.Cancel("agent-99"); err == nil {
+	if err := pool.cancel("agent-99"); err == nil {
 		t.Fatal("cancel of an unknown handle should error")
 	}
 }
@@ -64,18 +64,18 @@ func TestAgentPool_Cancel(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	id, err := pool.Spawn(context.Background(), "slow", "go")
+	id, err := pool.spawn(context.Background(), "slow", "go")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := pool.Cancel(id); err != nil {
+	if err := pool.cancel(id); err != nil {
 		t.Fatal(err)
 	}
 	// Awaiting a cancelled agent errors (its run returned ctx.Canceled).
-	if _, err := pool.Await(context.Background(), id); err == nil {
+	if _, err := pool.await(context.Background(), id); err == nil {
 		t.Fatal("await of a cancelled agent should error")
 	}
-	for _, s := range pool.Statuses() {
+	for _, s := range pool.statuses() {
 		if s.ID == id && s.Status != "cancelled" {
 			t.Fatalf("status = %q, want cancelled", s.Status)
 		}
@@ -85,11 +85,11 @@ func TestAgentPool_Cancel(t *testing.T) {
 func TestAgentPool_Statuses(t *testing.T) {
 	pool := NewAgentPool(nil)
 	_ = pool.Register("a", "a", poolRunner(t, StubTurn{Text: "x"}), 0)
-	id, _ := pool.Spawn(context.Background(), "a", "go")
-	if _, err := pool.Await(context.Background(), id); err != nil {
+	id, _ := pool.spawn(context.Background(), "a", "go")
+	if _, err := pool.await(context.Background(), id); err != nil {
 		t.Fatal(err)
 	}
-	st := pool.Statuses()
+	st := pool.statuses()
 	if len(st) != 1 || st[0].ID != id || st[0].Status != "done" {
 		t.Fatalf("statuses = %+v, want one done handle", st)
 	}

--- a/agent/injection.go
+++ b/agent/injection.go
@@ -93,7 +93,7 @@ type EventInjectionPolicy struct {
 	cfg EventInjectionConfig
 
 	mu      sync.Mutex
-	windows map[string]Stage[IncomingEvent]
+	windows map[string]stage[IncomingEvent]
 	pending []IncomingEvent
 	session map[string]IncomingEvent
 	sessOrd []string
@@ -111,7 +111,7 @@ func NewEventInjectionPolicy(cfg EventInjectionConfig) *EventInjectionPolicy {
 	if cfg.now == nil {
 		cfg.now = time.Now
 	}
-	return &EventInjectionPolicy{cfg: cfg, windows: map[string]Stage[IncomingEvent]{}, session: map[string]IncomingEvent{}}
+	return &EventInjectionPolicy{cfg: cfg, windows: map[string]stage[IncomingEvent]{}, session: map[string]IncomingEvent{}}
 }
 
 // HintFromMeta extracts a server-advertised ContextHint from an events/list
@@ -196,7 +196,7 @@ func (p *EventInjectionPolicy) Ingest(ev IncomingEvent) {
 	}
 	w, ok := p.windows[ev.Name]
 	if !ok {
-		w = Window(time.Duration(h.Aggregate.WindowMs)*time.Millisecond, h.Aggregate.Strategy,
+		w = newWindowStage(time.Duration(h.Aggregate.WindowMs)*time.Millisecond, h.Aggregate.Strategy,
 			func(e IncomingEvent) string { return e.Server + "/" + e.Name },
 			p.cfg.Merge)
 		p.windows[ev.Name] = w

--- a/agent/policy_test.go
+++ b/agent/policy_test.go
@@ -264,7 +264,7 @@ func TestGenericWindowIsPromotable(t *testing.T) {
 	// The stages are generic machinery: prove they work on a non-event
 	// type (the promotability contract from the design discussion).
 	clock := newClock()
-	w := Window[int](time.Second, WindowMerge, func(int) string { return "k" }, func(a, b int) int { return a + b })
+	w := newWindowStage[int](time.Second, WindowMerge, func(int) string { return "k" }, func(a, b int) int { return a + b })
 	w.Push(clock.t, 1)
 	w.Push(clock.t, 2)
 	w.Push(clock.t, 3)
@@ -272,9 +272,9 @@ func TestGenericWindowIsPromotable(t *testing.T) {
 		t.Fatalf("generic merge window = %v", got)
 	}
 
-	pipe := NewPipeline[int](
-		Filter(func(n int) bool { return n%2 == 0 }),
-		Transform(func(n int) (int, bool) { return n * 10, true }),
+	pipe := newPipeline[int](
+		newFilterStage(func(n int) bool { return n%2 == 0 }),
+		newTransformStage(func(n int) (int, bool) { return n * 10, true }),
 	)
 	if got := pipe.Push(clock.t, 4); len(got) != 1 || got[0] != 40 {
 		t.Fatalf("generic pipeline = %v", got)

--- a/agent/stages.go
+++ b/agent/stages.go
@@ -7,31 +7,36 @@ import (
 	"github.com/panyam/mcpkit/core"
 )
 
-// Stage is one step of an event pipeline, generic over the event type so the
-// machinery is promotable to any consumer (webhook receivers, page bridges)
-// unchanged: nothing here knows about MCP or the model. Push feeds one event
-// and returns whatever the stage releases now; Flush releases anything whose
+// stage is one step of an event pipeline, generic over the event type so the
+// machinery stays independent of MCP and the model. Push feeds one event and
+// returns whatever the stage releases now; Flush releases anything whose
 // window has expired by now. Stateless stages return their result from Push
 // and nil from Flush. Stages are not safe for concurrent use; drive each
 // pipeline from one goroutine (the policies do).
-type Stage[E any] interface {
+//
+// This is deliberately unexported. Nothing in the public API accepts a stage:
+// the injection and trigger configs take plain funcs, and the typed adapters
+// below (TypedFilter, TypedTransform, MergeWith, ShallowMergeJSON) are what
+// callers compose. Export it only when a public seam genuinely needs to
+// receive one.
+type stage[E any] interface {
 	Push(now time.Time, ev E) []E
 	Flush(now time.Time) []E
 }
 
-// Pipeline chains stages: each event Pushed cascades through every stage in
+// pipeline chains stages: each event Pushed cascades through every stage in
 // order, and Flush cascades expirations the same way.
-type Pipeline[E any] struct {
-	stages []Stage[E]
+type pipeline[E any] struct {
+	stages []stage[E]
 }
 
-// NewPipeline builds a pipeline from stages, applied in order.
-func NewPipeline[E any](stages ...Stage[E]) *Pipeline[E] {
-	return &Pipeline[E]{stages: stages}
+// newPipeline builds a pipeline from stages, applied in order.
+func newPipeline[E any](stages ...stage[E]) *pipeline[E] {
+	return &pipeline[E]{stages: stages}
 }
 
 // Push cascades ev through the stages.
-func (p *Pipeline[E]) Push(now time.Time, ev E) []E {
+func (p *pipeline[E]) Push(now time.Time, ev E) []E {
 	events := []E{ev}
 	for _, s := range p.stages {
 		var next []E
@@ -48,7 +53,7 @@ func (p *Pipeline[E]) Push(now time.Time, ev E) []E {
 
 // Flush cascades window expirations: stage i's flushed events still traverse
 // stages i+1..n before release.
-func (p *Pipeline[E]) Flush(now time.Time) []E {
+func (p *pipeline[E]) Flush(now time.Time) []E {
 	var out []E
 	for i, s := range p.stages {
 		for _, e := range s.Flush(now) {
@@ -66,8 +71,8 @@ func (p *Pipeline[E]) Flush(now time.Time) []E {
 	return out
 }
 
-// Filter keeps events for which fn returns true.
-func Filter[E any](fn func(E) bool) Stage[E] { return filterStage[E]{fn: fn} }
+// newFilterStage keeps events for which fn returns true.
+func newFilterStage[E any](fn func(E) bool) stage[E] { return filterStage[E]{fn: fn} }
 
 type filterStage[E any] struct{ fn func(E) bool }
 
@@ -79,8 +84,8 @@ func (s filterStage[E]) Push(_ time.Time, ev E) []E {
 }
 func (s filterStage[E]) Flush(time.Time) []E { return nil }
 
-// Transform rewrites events; returning false drops the event.
-func Transform[E any](fn func(E) (E, bool)) Stage[E] { return transformStage[E]{fn: fn} }
+// newTransformStage rewrites events; returning false drops the event.
+func newTransformStage[E any](fn func(E) (E, bool)) stage[E] { return transformStage[E]{fn: fn} }
 
 type transformStage[E any] struct{ fn func(E) (E, bool) }
 
@@ -104,12 +109,12 @@ const (
 	WindowDebounce WindowStrategy = "debounce"
 )
 
-// Window buffers events per key and releases per strategy when the window
-// expires. For last-wins and merge the window opens at the FIRST event of a
-// burst (bounded latency); for debounce every event restarts the window
+// newWindowStage buffers events per key and releases per strategy when the
+// window expires. For last-wins and merge the window opens at the FIRST event
+// of a burst (bounded latency); for debounce every event restarts the window
 // (quiet-gap semantics). merge folds with the supplied combiner; nil merge
 // falls back to last-wins behavior.
-func Window[E any](d time.Duration, strategy WindowStrategy, key func(E) string, merge func(acc, next E) E) Stage[E] {
+func newWindowStage[E any](d time.Duration, strategy WindowStrategy, key func(E) string, merge func(acc, next E) E) stage[E] {
 	return &windowStage[E]{d: d, strategy: strategy, key: key, merge: merge, buckets: map[string]*bucket[E]{}}
 }
 

--- a/agent/triggers.go
+++ b/agent/triggers.go
@@ -6,12 +6,13 @@ import (
 	"time"
 )
 
-// MetaKeyTrigger is the vendor _meta key on an events/list EventDef carrying
-// a server-suggested trigger binding. Server-advertised triggers are
-// suggestions only: the host decides whether to install them, and every
-// firing is mediated by TriggerPolicy regardless of origin (the triggers SEP
-// draft's stance: the server signals, the host owns the turn).
-const MetaKeyTrigger = "io.github.panyam.mcpkit/trigger"
+// Server-advertised trigger bindings are not implemented. The vendor _meta
+// key reserved for them (io.github.panyam.mcpkit/trigger, planned in
+// docs/AGENT_DESIGN.md) previously had an exported constant here with no
+// reader anywhere, which promised a capability the code does not have: a
+// server could set the key and nothing would install a binding. The constant
+// returns alongside the parser that consumes it, mirroring MetaKeyContextHint
+// and HintFromMeta in injection.go. Bindings today are host-configured only.
 
 // DefaultTriggerCooldown gates re-arming when a binding does not set its own.
 const DefaultTriggerCooldown = 5 * time.Minute


### PR DESCRIPTION
Part of #1240, agenda item 3 (exported-vs-internal audit).

1.0 retires the `VERSIONING.md` clause allowing breaking changes in minor releases, so every symbol exported at the freeze is exported permanently. This shrinks the agent surface to what consumers actually reach, ahead of that.

**Almost nothing is deleted.** 14 of the 15 symbols are unexported in place: same file, same package, same behaviour, still called by in-package code and still covered by the same tests. Only `MetaKeyTrigger` is removed outright, and only because it had no reader anywhere. No `internal/` package was created — every caller of these symbols was already in-package, so a directory move would have added structure without changing reachability.

## How the list was produced

Grep cannot answer this: a type reached only through `agent.NewClientSource(...)` never has its name spelled, and generic instantiation (`NewPipeline[int](`) hides call sites. So this used a `go/packages` reachability pass with full type information over all 13 consumer modules, classifying every exported symbol as:

- **USED** — directly referenced by a consumer
- **FORCED** — never referenced, but reachable through a used symbol's signature, so it must stay exported (`ClientSource` via `NewClientSource`)
- **UNUSED** — neither, and therefore a candidate

Consumer test files count as consumers. Symbols are keyed by declaration position rather than `types.Object` identity, which does not survive the separate `packages.Load` call each consumer module needs.

| | before | after |
|---|---|---|
| USED | 432 | 432 |
| FORCED | 33 | 32 |
| UNUSED | 191 | 177 |

`USED` is unchanged, which is the check that matters: nothing any consumer touches was affected.

## What changed

### The `Stage[E]` machinery (the bulk of it)

Nothing in the public API accepts a `Stage`. The injection and trigger configs take plain funcs, so `Window`, `Filter`, `Transform`, and `Pipeline` could be constructed but never handed anywhere. The only production call site is `injection.go`, which stores a single window per key. The doc comment described the machinery as "promotable to any consumer (webhook receivers, page bridges)"; no promotion happened in the two months since.

`Stage`, `Pipeline`, `NewPipeline`, and the three stage constructors are now unexported, renamed to match the unexported stage types they already returned (`newFilterStage`, `newTransformStage`, `newWindowStage`).

What stays public in `stages.go` is what a caller can actually use:

- `WindowStrategy` and its three constants are the JSON vocabulary on `AggregateHint.Strategy`, and `WindowMerge` is referenced externally from `host/events_test.go`.
- `TypedFilter`, `TypedTransform`, `MergeWith`, and `ShallowMergeJSON` return the plain funcs that populate `EventInjectionConfig.Filters`, `.Transforms`, and `.Merge`.

### `AgentPool.Spawn` / `Await` / `Cancel` / `Statuses`

Reached only through `NewSpawnSource`, which wraps them as model-facing tools from inside the same package. Host calls `Register` and `Names`; both stay exported.

### `MetaKeyTrigger` (deleted)

Declared the vendor `_meta` key `io.github.panyam.mcpkit/trigger` with no reader anywhere, so a server could set it and nothing would install a binding. That is a promise the code does not keep. A comment records that the constant returns alongside the parser that consumes it, mirroring `MetaKeyContextHint` / `HintFromMeta`. The key remains listed as planned in `docs/AGENT_DESIGN.md`.

## What was deliberately left alone

A conservative freeze is about withholding surface that costs nothing to withhold, not about removing capability. Four groups were held, each for a stated reason:

- **`Err*` sentinels.** Callers need them for `errors.Is`, and `Run`'s doc comment promises `ErrMaxSteps`.
- **`RunTurn` / `TurnRequest` / `Control`.** Mid-turn per-call cancellation is shipped and works; it simply has no in-repo caller. Unexporting deletes the feature rather than tidying it.
- **The 13 `Default*` constants.** Each is load-bearing in doc comments ("zero uses `DefaultX`"), and a constant commits to nothing beyond a value that is already observable behaviour.
- **The `With*` option constructors.** Their option types are parameter types of used constructors, so unexporting a constructor would leave an exported option type with no way to build one. Each preserves something real (tree budget, store bounds, collision policy).

Every other remaining `UNUSED` entry was read individually. They fall into interface declarations and their implementations (unused because implementing an interface is not calling it), the #1239 generation-parameter surface that landed a day earlier, vocabulary constants, and methods whose removal costs function rather than surface — `Accumulator.Add`/`Result` is what an external `Provider` implementor needs to fold a `Delta` stream, `FuncSource.AddToolFunc` is the raw-`ToolDef` form beneath the generic `AddFunc`, `MultiSource.Remove` is the counterpart to a used `Add`, and `FailoverProvider.StartReconciler` is the only way to run health probing.

## Worth a follow-up, not addressed here

The recurring pattern in what remains is not over-export but **built, public, and unwired**. `HintFromMeta` + `SetHint` form a complete path for discovering context hints from `events/list` that no host calls. `RunTurn`'s `Control` channel has no driver. `ApprovalPolicy` is FORCED rather than USED, because host builds `agent.NewTieredApproval(...)` and nothing in the repo ever implements the interface or reads `ApprovalDecision.Allowed`.

These will freeze without an external implementor having exercised them. Hiding them is the wrong fix; the decision is whether to exercise or drop them, and it belongs on #1240 rather than in this PR.

## Reviewer's guide

Read in this order:

1. [agent/stages.go](https://github.com/panyam/mcpkit/pull/1244/files#diff-8857194cfc87fe75755a6c90093ac1804f84b7b01ab1681dba73220c15261a8c) — the main change. Check that the split between the unexported machinery and the still-public `WindowStrategy` vocabulary plus the four typed adapters matches the reasoning above.
2. [agent/injection.go](https://github.com/panyam/mcpkit/pull/1244/files#diff-8b587a886a9fbe60e4d6832e7b3253a8ad5bee98ce0059ae49bc0951e4d28bd0) — the one production call site, updated to `stage[IncomingEvent]` and `newWindowStage`.
3. [agent/policy_test.go](https://github.com/panyam/mcpkit/pull/1244/files#diff-52ea94a567dc7195fe8cd13af59d3f3cbb4558bfd6b6c73aba6e8f53080289f0) — the in-package tests that exercise the now-unexported machinery, unchanged in substance.
4. [agent/agent_pool.go](https://github.com/panyam/mcpkit/pull/1244/files#diff-bb46e1fff5d5d2ba3ec6e91f3dd0ccb611a6fc90bddd17d960646ee7eb39402e) — four methods unexported, doc comments updated to match; `Register` and `Names` untouched.
5. [agent/agent_pool_test.go](https://github.com/panyam/mcpkit/pull/1244/files#diff-7d978a8e2c1c93a4c3c37d8870b8e9a1e08b7f8d62d0f5a5180417b237a3674f) — call sites follow the rename.
6. [agent/triggers.go](https://github.com/panyam/mcpkit/pull/1244/files#diff-31fbf33129473581024f927aafc2aceb2ffce9e9daf4bf2a7b6de7612dad6152) — the only deletion.

## Testing

`make test-agent` passes across all 12 modules (`agent`, `agent/eval`, `agent/eval/longmemeval`, `agent/store/redis`, `agent/store/gorm`, `agent/host`, `agent/surfaces`, `agent/surfaces/web`, `agent/surfaces/chat`, and the three example modules). No test was modified beyond following the renames.

