### PR TITLE
docs(agent): state contracts on the seams a caller reaches

### DIFF
--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -141,10 +141,35 @@ type spawnHandle struct {
 }
 
 // SpawnStatus is a wire-serializable snapshot of a handle for list_agents
-// (constraint A2).
+// (constraint A2). It is a point-in-time copy: a running child may have
+// finished by the time the caller reads it.
+//
+// The type serves two callers with different meanings for the same fields,
+// which is a wart worth knowing before reading one:
+//
+//   - statuses() describes live handles. ID is the handle, Name is the agent
+//     it was spawned from, Status is a lifecycle state.
+//   - Names describes registered agents, before any spawn. ID is empty, Name
+//     is the registered name, and Status carries the agent's human-readable
+//     description rather than a lifecycle state.
+//
+// Read Status as a lifecycle value only when ID is non-empty.
 type SpawnStatus struct {
-	ID     string `json:"id"`
-	Name   string `json:"name"`
+	// ID is the handle the model passes to await_agent and cancel_agent.
+	// Empty in a Names listing, which has no handle to report on.
+	ID string `json:"id"`
+
+	// Name is the registered agent name: the one this handle was spawned
+	// from, or the registered name itself in a Names listing.
+	Name string `json:"name"`
+
+	// Status is one of "running", "done", "failed", or "cancelled" for a
+	// live handle. The two failure values are distinct on purpose: "failed"
+	// means the child's own Run returned an error, "cancelled" means the
+	// parent dropped it, and collapsing them loses that.
+	//
+	// In a Names listing this instead holds the registered description. See
+	// the type doc.
 	Status string `json:"status"`
 }
 

--- a/agent/injection.go
+++ b/agent/injection.go
@@ -39,9 +39,32 @@ type ContextHint struct {
 	Sensitivity string `json:"sensitivity,omitempty"`
 }
 
-// AggregateHint is ContextHint's coalescing sub-shape.
+// AggregateHint is ContextHint's coalescing sub-shape: how to fold a burst of
+// one event name into fewer entries before the model sees them. It is part of
+// the wire shape a server may publish under the context-hint _meta key, so
+// treat both fields as an external contract rather than internal tuning.
+//
+// Coalescing is keyed by server plus event name, so two servers emitting the
+// same event name aggregate independently.
 type AggregateHint struct {
-	WindowMs int            `json:"windowMs"`
+	// WindowMs is the coalescing window in milliseconds. Zero or negative
+	// disables aggregation entirely and every event buffers individually,
+	// which is also what a missing AggregateHint means.
+	//
+	// The window's start depends on Strategy: last-wins and merge open it at
+	// the first event of a burst, giving bounded latency, while debounce
+	// restarts it on every event and so can defer release indefinitely under
+	// a sustained stream.
+	WindowMs int `json:"windowMs"`
+
+	// Strategy selects the fold: WindowLastWins keeps only the newest event
+	// per key, WindowMerge combines payloads through the policy's Merge func
+	// (ShallowMergeJSON by default), and WindowDebounce releases only after
+	// the key has been quiet for the window.
+	//
+	// The value is not validated. It is taken verbatim from the server's
+	// JSON, and anything other than the three constants above behaves as
+	// last-wins rather than erroring, so a typo degrades quietly.
 	Strategy WindowStrategy `json:"strategy,omitempty"`
 }
 
@@ -77,10 +100,23 @@ type EventInjectionConfig struct {
 // DefaultMaxPerDrain bounds injected entries per turn when unconfigured.
 const DefaultMaxPerDrain = 16
 
-// InjectedContext is one rendered entry ready to join the model's context.
+// InjectedContext is one rendered entry ready to join the model's context,
+// as returned by a Drain. Entries arrive in priority order, already filtered,
+// transformed, coalesced, and budgeted; a caller renders them into the turn
+// and does not re-apply policy.
 type InjectedContext struct {
-	Event    IncomingEvent
-	Text     string
+	// Event is the event this entry came from, after any Transforms ran.
+	// For a coalesced burst it is the single surviving event, so the
+	// originals are not recoverable from here.
+	Event IncomingEvent
+
+	// Text is the rendered form the model reads.
+	Text string
+
+	// Priority is the originating ContextHint's priority, carried through
+	// so a caller can group or style entries. It is the hint's vocabulary
+	// verbatim and is not normalized, so an unrecognized value reaches the
+	// caller unchanged rather than being defaulted.
 	Priority string
 }
 

--- a/agent/provider.go
+++ b/agent/provider.go
@@ -133,13 +133,29 @@ type ProviderRequest struct {
 // a silently ignored one. See ProviderRequest.Temperature.
 type GenerationParams struct {
 	// Temperature overrides the provider default when non-nil.
+	//
+	// Setting it is not universally safe. Current Anthropic models reject
+	// sampling parameters outright, so a non-nil Temperature makes the
+	// request fail with a 400 rather than being ignored, and mcpkit keeps no
+	// per-model capability table that would catch this first. Leave it nil
+	// unless the target model is known to accept it. Full contract on
+	// ProviderRequest.Temperature.
 	Temperature *float64 `json:"temperature,omitempty"`
 
-	// MaxTokens caps the completion length when positive.
+	// MaxTokens caps the completion length when positive. Zero leaves the
+	// decision to the provider, except on AnthropicProvider, whose API
+	// requires a cap and which substitutes AnthropicConfig.MaxTokens.
+	//
+	// A cap that truncates mid-turn ends the call with a length-flavored
+	// FinishReason and no error: the Runner treats the short completion as
+	// the model's answer, so too small a value silently degrades a turn
+	// rather than failing it.
 	MaxTokens int `json:"maxTokens,omitempty"`
 
 	// ToolChoice biases tool calling. The zero value is the provider
-	// default ("auto").
+	// default ("auto"). Support varies across OpenAI-compatible servers and
+	// one that ignores it degrades to "auto", so forcing a call is a
+	// request, not a guarantee. Full contract on ProviderRequest.ToolChoice.
 	ToolChoice ToolChoice `json:"toolChoice,omitempty"`
 }
 
@@ -211,9 +227,24 @@ func (tc ToolChoice) wire() any {
 	}
 }
 
-// Usage reports token consumption for one model call.
+// Usage reports token consumption for one model call. TurnResult.Usage is the
+// sum across a turn; see its doc for what that total does and does not cover.
+//
+// Both counts are as the provider reported them, not as mcpkit measured them.
+// A provider that reports no usage yields a nil *Usage rather than a zero one,
+// so the caller can tell "not reported" from "reported as zero". The Runner
+// treats a missing report as zero when summing, which means a provider that
+// under-reports produces an undercount rather than an error.
 type Usage struct {
-	InputTokens  int `json:"inputTokens"`
+	// InputTokens is the prompt side of the call: instructions, history, and
+	// tool definitions as the provider counted them. Cache reads and writes
+	// are not broken out; whatever the provider folds into its own input
+	// count is what appears here.
+	InputTokens int `json:"inputTokens"`
+
+	// OutputTokens is the completion side, including tokens spent on tool
+	// calls and on reasoning the provider billed for, even when that
+	// reasoning never reached Delta.Text.
 	OutputTokens int `json:"outputTokens"`
 }
 
@@ -268,13 +299,35 @@ type Stream interface {
 }
 
 // ProviderResponse is a completed model call: the fold of a delta stream, or
-// the direct result of Generate.
+// the direct result of Generate. One response is one call, never a whole turn;
+// the Runner makes as many of these as the step loop needs.
 type ProviderResponse struct {
-	Text         string     `json:"text,omitempty"`
-	Reasoning    string     `json:"reasoning,omitempty"`
-	ToolCalls    []ToolCall `json:"toolCalls,omitempty"`
-	FinishReason string     `json:"finishReason,omitempty"`
-	Usage        *Usage     `json:"usage,omitempty"`
+	// Text is the assistant's message content. Empty is normal and not an
+	// error: a call that only requested tools produces no text.
+	Text string `json:"text,omitempty"`
+
+	// Reasoning is provider-exposed reasoning text, folded from
+	// DeltaReasoning. Empty for providers that expose none, which is most of
+	// them. This is plain text for display and never carries provider-opaque
+	// state such as signed thinking blocks, which constraint A9 keeps off the
+	// neutral types entirely.
+	Reasoning string `json:"reasoning,omitempty"`
+
+	// ToolCalls holds the calls the model requested, in the order the
+	// provider emitted them. Parallel calls all appear here; the Runner
+	// dispatches them and feeds one RoleTool message back per call.
+	ToolCalls []ToolCall `json:"toolCalls,omitempty"`
+
+	// FinishReason is the provider's own vocabulary passed through
+	// unmapped ("stop", "tool_calls", "length", and whatever else a given
+	// provider emits). Compare against it only for a specific provider, and
+	// branch on len(ToolCalls) rather than on this string when deciding
+	// whether the loop should continue.
+	FinishReason string `json:"finishReason,omitempty"`
+
+	// Usage is what the provider reported for this call, or nil when it
+	// reported nothing. Nil is distinct from a zero Usage.
+	Usage *Usage `json:"usage,omitempty"`
 }
 
 // Provider is the LLM seam. Implementations must be safe for concurrent use;

--- a/agent/runner.go
+++ b/agent/runner.go
@@ -211,11 +211,38 @@ func NewRunner(cfg RunnerConfig) (*Runner, error) {
 // turn appended (assistant messages and tool results, in order), so callers
 // thread history as append(history, result.Messages...).
 type TurnResult struct {
-	Text         string    `json:"text,omitempty"`
-	Messages     []Message `json:"messages"`
-	Usage        Usage     `json:"usage"`
-	Steps        int       `json:"steps"`
-	FinishReason string    `json:"finishReason,omitempty"`
+	// Text is the final assistant message of the turn, which is the Text of
+	// the last model call. Intermediate steps' text is not concatenated here;
+	// read Messages for the full sequence, or the event stream to see text as
+	// it arrived.
+	Text string `json:"text,omitempty"`
+
+	// Messages is exactly what the turn appended, never the full history.
+	// Thread it with append(history, result.Messages...).
+	Messages []Message `json:"messages"`
+
+	// Usage sums every model call this Runner made during the turn: each
+	// step of the loop plus the finalizing Generate of a structured-output
+	// turn. Steps whose provider reported no usage contribute zero, so an
+	// under-reporting provider yields an undercount rather than an error.
+	//
+	// It does not include sub-agents. A child reached through AgentSource,
+	// AsyncAgentSource, FanOutSource, Team, or AgentPool runs its own Runner
+	// and accounts for its own tokens, so cost accounting over an agent tree
+	// has to sum the children separately. TreeBudget is the mechanism that
+	// does see the whole tree; this field deliberately does not.
+	Usage Usage `json:"usage"`
+
+	// Steps is how many times the loop called the model, counting from one.
+	// A turn that answered without tools reports 1. The finalizing Generate
+	// of a structured-output turn is not counted here, though its tokens are
+	// counted in Usage. Reaching RunnerConfig.MaxSteps returns an error
+	// wrapping ErrMaxSteps instead of a result.
+	Steps int `json:"steps"`
+
+	// FinishReason is the last model call's finish reason, in the provider's
+	// own vocabulary and unmapped. See ProviderResponse.FinishReason.
+	FinishReason string `json:"finishReason,omitempty"`
 
 	// Structured is the schema-coerced final answer, present only when
 	// RunnerConfig.ResponseSchema was set. It is the JSON document from the


### PR DESCRIPTION
Part of #1240, agenda item 6 (contract documentation). Docs only, no behaviour change, no signature touched.

## Why this item exists

The tracker's own framing: `ProviderRequest.Temperature` documented "overrides the provider default when non-nil" and omitted that current Anthropic models reject sampling parameters outright, which is part of why #1239 was needed. #1239 fixed that field. `GenerationParams.Temperature` — the newer type a caller actually reaches — still carried the original wording. It now carries the warning too.

Every contract here was read out of the code rather than inferred from the signature. Two turned out to be non-obvious enough to justify the words on their own.

### Sub-agent usage does not roll up

`TurnResult.Usage` sums every model call in the turn, including the finalizing `Generate` of a structured-output turn. It does **not** include sub-agents. There is no `Usage` reference anywhere in `agent_source.go`, `fanout_source.go`, or `team.go`: a child reached through `AgentSource`, `AsyncAgentSource`, `FanOutSource`, `Team`, or `AgentPool` runs its own Runner and accounts for its own tokens.

Anyone doing cost accounting over an agent tree has to sum the children separately. `TreeBudget` is the mechanism that does see the whole tree; this field deliberately does not. That was undocumented and is the kind of thing you discover from a billing discrepancy.

### A too-small `MaxTokens` degrades a turn silently

Nothing special-cases a length-flavoured finish reason (verified: no `FinishReason ==` comparison exists outside a doc comment). A completion truncated by the cap is returned as the model's answer with no error, so an over-tight `MaxTokens` quietly produces worse turns rather than failing loudly.

## Also documented

- **`Usage`** — per-call, provider-reported rather than mcpkit-measured. A nil `*Usage` means "not reported" and is distinct from a zero one; the Runner treats missing as zero when summing, so an under-reporting provider yields an undercount rather than an error.
- **`ProviderResponse`** — field by field. Notably that `FinishReason` is the provider's own vocabulary passed through unmapped, so callers should branch on `len(ToolCalls)` rather than on that string, and that `Reasoning` is display text that never carries provider-opaque state (constraint A9 keeps signed thinking blocks off the neutral types).
- **`TurnResult.Text` and `.Steps`** — `Text` is the last call's text, not a concatenation; `Steps` counts model calls from one and excludes the finalizing `Generate`, whose tokens *are* counted in `Usage`.
- **`InjectedContext`** — entries arrive already filtered, transformed, coalesced, and budgeted, so a caller renders rather than re-applying policy. For a coalesced burst the originals are not recoverable.
- **`AggregateHint`** — five words previously, despite being a wire shape servers author under the context-hint `_meta` key. Now states units, the zero-disables rule, the three strategies, that coalescing keys on server plus event name, and that an unrecognized strategy string degrades to last-wins rather than erroring.

## One real defect surfaced

`SpawnStatus` overloads its fields. `Names` puts the agent's human-readable **description** into the `Status` field, while `statuses()` puts a lifecycle value (`"running"` / `"done"` / `"failed"` / `"cancelled"`) there. One field, two unrelated meanings, discriminated only by whether `ID` is empty.

I found this by writing the doc, asserting the wrong thing, and then checking the body. It is documented here as it actually behaves, and carried to agenda item 4 rather than reshaped inside a docs pass — changing the shape is a breaking change and belongs with the other seam decisions.

That is the second item-4 finding to come out of doc-writing, alongside `ForkPoint`-as-a-message-count which the tracker already lists.

## Scope, and what was deliberately left out

An initial pass counted 83 reachable symbols with no doc comment. That overstates the gap: this codebase documents contracts at the **type** level, so `CreateRunRequest`'s doc already covers its `RunID`. Filtering to members where neither the member nor a substantial type doc says anything cut it to 34, and reading those individually cut it again. `memory.go`, `toolresultstore.go`, `runstore.go`, and `CompactionInfo` were already adequate and were left alone rather than padded.

`agent/host` has 273 exported symbols, 56 undocumented, 23 of them used by a surface. None are touched here, on purpose. `VERSIONING.md`'s compatibility promise covers API surface — breaking changes batched into bundles, 12-month deprecation windows, migration docs — and says nothing about doc comments. A doc can be improved in any patch release after 1.0; shapes and names cannot. So exhaustive coverage is ordinary maintenance, while items 4 and 5 are deadline-bound.

## Reviewer's guide

Docs only, so read for accuracy of the claims rather than for structure:

1. [agent/provider.go](https://github.com/panyam/mcpkit/pull/1245/files#diff-a1383b85f643c0c6e93ffd7d81aefd65f427d24348ee2d60c8388c91694f3c5b) — `Usage`, `ProviderResponse`, and the `GenerationParams` fields. The Anthropic-400 warning on `Temperature` is the tracker's worked example.
2. [agent/runner.go](https://github.com/panyam/mcpkit/pull/1245/files#diff-6d787b427ac08cd61669af7e34ff0b747c4264d20b31b21b681a2ec2c826d9f0) — `TurnResult`. The sub-agent rollup paragraph is the highest-value claim in the change; worth checking against `agent_source.go` and `team.go`.
3. [agent/injection.go](https://github.com/panyam/mcpkit/pull/1245/files#diff-8b587a886a9fbe60e4d6832e7b3253a8ad5bee98ce0059ae49bc0951e4d28bd0) — `AggregateHint` and `InjectedContext`.
4. [agent/agent_pool.go](https://github.com/panyam/mcpkit/pull/1245/files#diff-bb46e1fff5d5d2ba3ec6e91f3dd0ccb611a6fc90bddd17d960646ee7eb39402e) — `SpawnStatus`, including the dual-meaning wart.

## Testing

`make test-agent` passes across all 12 modules. No test was modified; nothing executable changed.

