### PR TITLE
chore(agent): fix an overloaded seam, rename two, record the rest

### DIFF
--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -40,8 +40,8 @@ func NewSpawnSource(pool *AgentPool) *FuncSource {
 	fs := NewFuncSource()
 
 	var menu strings.Builder
-	for _, a := range pool.Names() {
-		fmt.Fprintf(&menu, "\n- %s: %s", a.Name, a.Status)
+	for _, a := range pool.Registered() {
+		fmt.Fprintf(&menu, "\n- %s: %s", a.Name, a.Description)
 	}
 	_ = AddFunc(fs, SpawnAgentToolName,
 		"Start a sub-agent running in the background and get a handle id back; it keeps running while you do other work. Await its result later with await_agent, or drop it with cancel_agent. Available agents:"+menu.String(),
@@ -140,37 +140,37 @@ type spawnHandle struct {
 	err    error
 }
 
-// SpawnStatus is a wire-serializable snapshot of a handle for list_agents
-// (constraint A2). It is a point-in-time copy: a running child may have
-// finished by the time the caller reads it.
+// SpawnStatus is a wire-serializable snapshot of one live handle for
+// list_agents (constraint A2). It is a point-in-time copy: a running child may
+// have finished by the time the caller reads it.
 //
-// The type serves two callers with different meanings for the same fields,
-// which is a wart worth knowing before reading one:
-//
-//   - statuses() describes live handles. ID is the handle, Name is the agent
-//     it was spawned from, Status is a lifecycle state.
-//   - Names describes registered agents, before any spawn. ID is empty, Name
-//     is the registered name, and Status carries the agent's human-readable
-//     description rather than a lifecycle state.
-//
-// Read Status as a lifecycle value only when ID is non-empty.
+// It describes handles only. For the agents a pool can spawn, before any
+// spawn has happened, see Registered.
 type SpawnStatus struct {
 	// ID is the handle the model passes to await_agent and cancel_agent.
-	// Empty in a Names listing, which has no handle to report on.
 	ID string `json:"id"`
 
-	// Name is the registered agent name: the one this handle was spawned
-	// from, or the registered name itself in a Names listing.
+	// Name is the registered agent this handle was spawned from.
 	Name string `json:"name"`
 
-	// Status is one of "running", "done", "failed", or "cancelled" for a
-	// live handle. The two failure values are distinct on purpose: "failed"
-	// means the child's own Run returned an error, "cancelled" means the
-	// parent dropped it, and collapsing them loses that.
-	//
-	// In a Names listing this instead holds the registered description. See
-	// the type doc.
+	// Status is one of "running", "done", "failed", or "cancelled". The two
+	// failure values are distinct on purpose: "failed" means the child's own
+	// Run returned an error, "cancelled" means the parent dropped it, and
+	// collapsing them loses that.
 	Status string `json:"status"`
+}
+
+// RegisteredAgent describes one agent a pool can spawn, as returned by
+// Registered. It is the pre-spawn view: no handle exists yet, so there is no
+// ID and no lifecycle state.
+type RegisteredAgent struct {
+	// Name is the name Register was called with, and the name the model
+	// passes to spawn_agent.
+	Name string `json:"name"`
+
+	// Description is the human-readable blurb Register was given, used to
+	// build the spawn tool's menu so the model can choose between agents.
+	Description string `json:"description"`
 }
 
 // NewAgentPool returns an empty pool. onEvent, when non-nil, receives every
@@ -205,14 +205,15 @@ func (p *AgentPool) Register(name, description string, runner *Runner, maxDepth 
 	return nil
 }
 
-// Names returns the registered spawnable agent names in registration order,
-// with their descriptions — for a spawn tool's help text.
-func (p *AgentPool) Names() []SpawnStatus {
+// Registered lists the agents this pool can spawn, in registration order,
+// for a spawn tool's help text. It describes registrations rather than live
+// children; use list_agents (backed by statuses) for handles in flight.
+func (p *AgentPool) Registered() []RegisteredAgent {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	out := make([]SpawnStatus, 0, len(p.order))
+	out := make([]RegisteredAgent, 0, len(p.order))
 	for _, n := range p.order {
-		out = append(out, SpawnStatus{Name: n, Status: p.agents[n].description})
+		out = append(out, RegisteredAgent{Name: n, Description: p.agents[n].description})
 	}
 	return out
 }

--- a/agent/anthropic_provider_test.go
+++ b/agent/anthropic_provider_test.go
@@ -178,8 +178,8 @@ func TestAnthropicStreamTextFinishUsage(t *testing.T) {
 		t.Fatalf("delta sequence:\n got: %+v\nwant: %+v", got, want)
 	}
 
-	// The Accumulator folds the same stream into the completed response.
-	var acc Accumulator
+	// The DeltaAccumulator folds the same stream into the completed response.
+	var acc DeltaAccumulator
 	for _, d := range got {
 		acc.Add(d)
 	}
@@ -211,7 +211,7 @@ func TestAnthropicToolNameSanitizedAndReversed(t *testing.T) {
 	}
 	defer s.Close()
 
-	var acc Accumulator
+	var acc DeltaAccumulator
 	for _, d := range collectDeltas(t, s) {
 		acc.Add(d)
 	}
@@ -255,7 +255,7 @@ func TestAnthropicStreamToolUse(t *testing.T) {
 		t.Fatalf("delta sequence:\n got: %+v\nwant: %+v", got, want)
 	}
 
-	var acc Accumulator
+	var acc DeltaAccumulator
 	for _, d := range got {
 		acc.Add(d)
 	}

--- a/agent/async_agent_source_test.go
+++ b/agent/async_agent_source_test.go
@@ -20,7 +20,7 @@ func (p *latchProvider) Stream(ctx context.Context, req ProviderRequest) (Stream
 }
 func (p *latchProvider) Generate(ctx context.Context, req ProviderRequest) (*ProviderResponse, error) {
 	<-p.release
-	var acc Accumulator
+	var acc DeltaAccumulator
 	acc.Add(Delta{Kind: DeltaText, Text: p.text})
 	acc.Add(Delta{Kind: DeltaFinish, FinishReason: "stop"})
 	return acc.Result(), nil

--- a/agent/failover_test.go
+++ b/agent/failover_test.go
@@ -57,7 +57,7 @@ func TestFailoverCleanFailureRetriesBackupOnce(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var acc Accumulator
+	var acc DeltaAccumulator
 	for {
 		d, err := s.Recv()
 		if errors.Is(err, io.EOF) {

--- a/agent/fanout_source_test.go
+++ b/agent/fanout_source_test.go
@@ -45,7 +45,7 @@ func (p *barrierProvider) Stream(ctx context.Context, req ProviderRequest) (Stre
 
 func (p *barrierProvider) Generate(ctx context.Context, req ProviderRequest) (*ProviderResponse, error) {
 	p.b.arrive()
-	var acc Accumulator
+	var acc DeltaAccumulator
 	acc.Add(Delta{Kind: DeltaText, Text: p.text})
 	acc.Add(Delta{Kind: DeltaFinish, FinishReason: "stop"})
 	return acc.Result(), nil

--- a/agent/host/runner_control_test.go
+++ b/agent/host/runner_control_test.go
@@ -43,7 +43,7 @@ func TestAppRunnerControlWiring(t *testing.T) {
 		t.Fatal("agentPool not built with RunnerControl")
 	}
 	var names []string
-	for _, n := range app.agentPool.Names() {
+	for _, n := range app.agentPool.Registered() {
 		names = append(names, n.Name)
 	}
 	if len(names) != 1 || names[0] != "worker" {

--- a/agent/memory.go
+++ b/agent/memory.go
@@ -101,10 +101,21 @@ type ListMemoriesResponse struct {
 // Score is a property of the QUERY, not of the stored fact (the same item
 // scores differently against different queries), which is why it lives here
 // on the result and not on MemoryItem — that keeps MemoryItem the durable,
-// query-independent fact. A substring store returns 1 for a match; a
-// semantic store returns cosine similarity. Room to grow: a future
-// ranking/reranker stage can add per-signal provenance (similarity vs
-// recency vs importance) here without touching the store or the item.
+// query-independent fact. Room to grow: a future ranking/reranker stage can
+// add per-signal provenance (similarity vs recency vs importance) here
+// without touching the store or the item.
+//
+// Direction is contractual and scale is not. Higher always means more
+// relevant, in every backend: the semantic stores report cosine similarity,
+// and the pgvector backend converts distance with 1 - (embedding <=> query)
+// specifically so it agrees. What differs is the range. A matching store (the
+// in-memory default, Redis) reports a flat 1 for every hit because it has no
+// graded notion of relevance, and every store reports 0 on the "list
+// everything" path where there is no query to rank against.
+//
+// So Score is safe to sort and compare within one response, and unsafe to
+// compare across backends or to threshold with a constant tuned elsewhere.
+// See RecallOptions.MinScore, the one place in-tree that thresholds on it.
 type ScoredMemory struct {
 	Item  MemoryItem
 	Score float64
@@ -424,6 +435,15 @@ type RecallOptions struct {
 	// semantic store every note gets some cosine score, so without a floor a
 	// low-TopK recall would inject the least-irrelevant notes even when
 	// nothing is actually relevant. Zero means no floor (keep all TopK).
+	//
+	// The threshold is not portable across backends, because ScoredMemory.Score
+	// shares a direction but not a scale. Ranking stores score on a cosine
+	// scale where a floor discriminates; matching stores (the in-memory
+	// default and Redis) return a flat 1 for every match, so any floor at or
+	// below 1 keeps everything and the guard is inert. It degrades safely —
+	// no filtering rather than wrong filtering — but a value tuned against a
+	// semantic store does nothing after a swap to a substring one. Tune it
+	// against the backend actually in use.
 	MinScore float64
 }
 

--- a/agent/provider.go
+++ b/agent/provider.go
@@ -254,7 +254,7 @@ type DeltaKind string
 // Delta kinds. Tool calls stream as one DeltaToolCallStart (carrying ID and
 // Name) followed by any number of DeltaToolCallArgs fragments for the same
 // Index; there is no explicit end marker, the next start or the finish delta
-// closes the call (fold with Accumulator).
+// closes the call (fold with DeltaAccumulator).
 const (
 	DeltaText          DeltaKind = "text"
 	DeltaReasoning     DeltaKind = "reasoning"
@@ -342,9 +342,9 @@ type Provider interface {
 	Generate(ctx context.Context, req ProviderRequest) (*ProviderResponse, error)
 }
 
-// Accumulator folds a delta stream into a ProviderResponse. Zero value is
+// DeltaAccumulator folds a delta stream into a ProviderResponse. Zero value is
 // ready to use. Not safe for concurrent use.
-type Accumulator struct {
+type DeltaAccumulator struct {
 	resp    ProviderResponse
 	text    strings.Builder
 	reason  strings.Builder
@@ -354,7 +354,7 @@ type Accumulator struct {
 }
 
 // Add folds one delta.
-func (a *Accumulator) Add(d Delta) {
+func (a *DeltaAccumulator) Add(d Delta) {
 	switch d.Kind {
 	case DeltaText:
 		a.text.WriteString(d.Text)
@@ -385,7 +385,7 @@ func (a *Accumulator) Add(d Delta) {
 // Result returns the folded response. Tool-call argument fragments are
 // joined in stream order; an empty argument buffer becomes the empty JSON
 // object so callers can always unmarshal Args.
-func (a *Accumulator) Result() *ProviderResponse {
+func (a *DeltaAccumulator) Result() *ProviderResponse {
 	out := a.resp
 	out.Text = a.text.String()
 	out.Reasoning = a.reason.String()

--- a/agent/provider_test.go
+++ b/agent/provider_test.go
@@ -42,7 +42,7 @@ func newTestProvider(t *testing.T, url string) *OpenAIProvider {
 
 func drain(t *testing.T, s Stream) *ProviderResponse {
 	t.Helper()
-	var acc Accumulator
+	var acc DeltaAccumulator
 	for {
 		d, err := s.Recv()
 		if errors.Is(err, io.EOF) {
@@ -347,7 +347,7 @@ func TestDeltaKindsJSONRoundTrip(t *testing.T) {
 }
 
 func TestAccumulatorEmptyArgsBecomeEmptyObject(t *testing.T) {
-	var acc Accumulator
+	var acc DeltaAccumulator
 	acc.Add(Delta{Kind: DeltaToolCallStart, Index: 0, ToolCallID: "x", ToolName: "noargs"})
 	acc.Add(Delta{Kind: DeltaFinish, FinishReason: "tool_calls"})
 	res := acc.Result()

--- a/agent/runner.go
+++ b/agent/runner.go
@@ -517,7 +517,7 @@ func (r *Runner) failSpan(emit func(Event), span core.Span, err error) error {
 // reasoning delta, end when the step moves on to text, tool calls, or
 // completes.
 func consumeStream(stream Stream, step int, emit func(Event)) (*ProviderResponse, error) {
-	var acc Accumulator
+	var acc DeltaAccumulator
 	thinking := false
 	endThinking := func() {
 		if thinking {

--- a/agent/runstore.go
+++ b/agent/runstore.go
@@ -61,11 +61,21 @@ type RunStore interface {
 // the current length of the message log; the fork lineage (ParentID,
 // ForkPoint) is the session tree a picker renders.
 type RunInfo struct {
-	ID           string    `json:"id"`
-	ParentID     string    `json:"parentId,omitempty"`
-	ForkPoint    int       `json:"forkPoint,omitempty"`
-	CreatedAt    time.Time `json:"createdAt"`
-	MessageCount int       `json:"messageCount"`
+	ID       string `json:"id"`
+	ParentID string `json:"parentId,omitempty"`
+
+	// ForkPoint is the number of ParentID's messages this run was forked
+	// with, and zero for runs created directly. It is a message count, never
+	// a timestamp or a storage sequence value; see Run.ForkPoint for why.
+	// Comparing it against MessageCount tells a picker how far this run has
+	// diverged from its parent.
+	ForkPoint int `json:"forkPoint,omitempty"`
+
+	CreatedAt time.Time `json:"createdAt"`
+
+	// MessageCount is the current length of this run's message log, so a
+	// listing can show size without loading bodies.
+	MessageCount int `json:"messageCount"`
 }
 
 // ListRunsRequest pages the run listing. Cursor is empty for the first

--- a/agent/stub_provider.go
+++ b/agent/stub_provider.go
@@ -101,7 +101,7 @@ func (s *StubProvider) Generate(ctx context.Context, req ProviderRequest) (*Prov
 	if turn.Err != nil {
 		return nil, turn.Err
 	}
-	var acc Accumulator
+	var acc DeltaAccumulator
 	for _, d := range turn.deltas() {
 		acc.Add(d)
 	}


### PR DESCRIPTION
Part of #1240, agenda items **4** (seam shapes) and **5** (naming), taken together so the same code is not touched twice. Renaming something you then reshape costs two passes, and both are irreversible after the freeze in a way doc comments are not.

## Reshaped: `SpawnStatus` was answering two different questions

`AgentPool` returned one type for two unrelated things:

| caller | `ID` | `Name` | `Status` |
|---|---|---|---|
| `statuses()` | the handle | agent spawned from | lifecycle: `running` / `done` / `failed` / `cancelled` |
| `Names()` | *empty* | registered name | **the agent's human-readable description** |

One field, two meanings, discriminated only by whether `ID` happened to be empty. Nothing enforced that and nothing said it.

Registrations now have their own type:

```go
type RegisteredAgent struct {
    Name        string `json:"name"`
    Description string `json:"description"`
}
```

and `SpawnStatus` describes live handles only. This was found while documenting the type in #1245 — I wrote a doc asserting `Names()` left `Status` empty, then read the body and found it did not. It was recorded there and fixed here, since changing the shape is breaking and belonged with the other seam decisions.

## Renamed

- **`AgentPool.Names` → `Registered`.** It never returned names. It returned names *with descriptions*, and now returns registrations. Its only caller outside the package was a single host test.
- **`Accumulator` → `DeltaAccumulator`.** A package-level `agent.Accumulator` says nothing about what it accumulates, and it is exactly the type an external `Provider` implementor has to find in order to fold a `Delta` stream into a `ProviderResponse`. Sixteen references, all in-package.

## Reviewed and kept

The tracker's framing for item 4 is that these are "all defensible; the point is to have looked deliberately." Each verdict is now written into the code so it is not re-litigated from scratch later.

### `ListMemories` returning `[]ScoredMemory` — sound shape, half-stated contract

The shape is right, but `Score` only documented half its contract, and there is a live consumer that depends on the undocumented half.

**Direction is contractual and consistent** across all four backends. Verified: the in-memory semantic store reports `qvec.Cosine(...)`, and the pgvector backend converts distance with `1 - (embedding <=> ?)` *specifically* so it agrees with `Embedding.Cosine`. Higher always means more relevant. There is no direction hazard.

**Scale is not consistent.** A matching store (in-memory default, Redis) reports a flat `1` for every hit because it has no graded notion of relevance. A ranking store reports cosine. Every store reports `0` on the list-everything path.

`RecallOptions.MinScore` thresholds on this (`memory.go`, the poison guard). Against a ranking store a floor of 0.7 discriminates; against a matching store every hit scores 1, so any floor at or below 1 keeps everything and the guard is **inert**. It degrades safely — no filtering rather than wrong filtering — which is why this is a documentation fix rather than a reshape. Both `ScoredMemory` and `MinScore` now say so.

### `Namespace`-per-request — kept

The leak risk it invites (add a method, forget the field, silently operate on the global scratchpad) is real, but it is guarded: isolation is tested in the core store and independently in each of the gorm and redis backends.

### `ForkPoint` as a message count — kept

`Run.ForkPoint` already argues the case at length, both durable backends persist it as a column or meta field, and nothing reconstructs history from it. `RunInfo.ForkPoint` carried no field doc despite `RunInfo` being what a session picker actually reads, so it has one now, including that comparing it against `MessageCount` is what tells a picker how far a run has diverged.

### The `Found` tri-state — kept

Six call sites decode it the same two-step way (`err` first, then `!resp.Found`), and the convention is pinned in `stores/STORAGE_SEAMS.md`. It is working.

## Still open under item 4

The **unwired seams** are deliberately not in this PR: `ApprovalPolicy` (FORCED rather than USED, because host builds `agent.NewTieredApproval(...)` and nothing in-repo implements the interface), `HintFromMeta` + `SetHint` (a complete hint-discovery path no host calls), and `RunTurn`'s `Control` channel (no driver anywhere).

That is an exercise-or-drop decision rather than a shape question. `ApprovalPolicy` in particular looks well-formed; the risk is that nobody has ever implemented one, and finding out means writing a second implementation, which is closer to test work than to API review.

## Reviewer's guide

1. [agent/agent_pool.go](https://github.com/panyam/mcpkit/pull/1246/files#diff-bb46e1fff5d5d2ba3ec6e91f3dd0ccb611a6fc90bddd17d960646ee7eb39402e) — the reshape. `SpawnStatus` now lifecycle-only, new `RegisteredAgent`, `Names` → `Registered`, and the `NewSpawnSource` menu updated to read `.Description`.
2. [agent/memory.go](https://github.com/panyam/mcpkit/pull/1246/files#diff-8b2c5e582714e8b1e26ebd2e85b95f45417d39de02b30621f3715dab3b347f05) — `ScoredMemory` and `RecallOptions.MinScore`. The claim about direction consistency is the one worth checking against `agent/store/gorm/memory.go` and `agent/semantic_memory.go`.
3. [agent/runstore.go](https://github.com/panyam/mcpkit/pull/1246/files#diff-f2ebdb590e8817d70dfdc21e0169cecb55b6a3131172a87aaa59e57301ed2643) — `RunInfo` field docs.
4. [agent/provider.go](https://github.com/panyam/mcpkit/pull/1246/files#diff-a1383b85f643c0c6e93ffd7d81aefd65f427d24348ee2d60c8388c91694f3c5b) — the `DeltaAccumulator` rename.
5. [agent/host/runner_control_test.go](https://github.com/panyam/mcpkit/pull/1246/files#diff-200efd2be7c480a852392ec2cd8465c2db75ba68c45b9001ce2c85cbd148fb6c) and the six `agent/*_test.go` files — call sites following the two renames, no substantive change.

## Testing

`make test-agent` passes across all 12 modules. No test logic changed; the test diffs are the two renames.

