### PR TITLE
fix(client): make calls cancellable; wire the per-call interrupt to a surface

### DIFF
--- a/agent/host/app.go
+++ b/agent/host/app.go
@@ -95,6 +95,19 @@ type App struct {
 	turnMu    sync.Mutex
 	emitMu    sync.Mutex // serializes emit's synchronous local delivery (the Group, turn, and event goroutines all emit)
 
+	// ctrl is the in-flight turn's mid-turn control channel, non-nil only
+	// while a single-agent turn is running. InterruptToolCalls sends on it;
+	// RunTurn installs and clears it. It has its own mutex because RunTurn
+	// holds turnMu for the whole turn, so an interrupt arriving mid-turn
+	// could never take turnMu to find the channel.
+	//
+	// Clearing it between turns is load-bearing: agent.TurnRequest.Control
+	// warns that a buffered cancel-all sent while nothing drains would land
+	// on the next turn's first dispatch, so a send with no turn running has
+	// to be dropped rather than queued.
+	ctrlMu sync.Mutex
+	ctrl   chan agent.Control
+
 	// eventLog is the retained per-session event log. emit appends every
 	// HostEvent here in addition to delivering it synchronously to the local
 	// observers, so the log is the single source of truth a web surface
@@ -778,7 +791,22 @@ func (a *App) RunTurn(ctx context.Context, input string) error {
 			a.activeTeamAgent = active
 		}
 	} else {
-		result, err = a.runner.Run(ctx, turnMsgs, emit)
+		// Single-agent mode drives the full turn surface so a surface can
+		// cancel one in-flight tool call without aborting the turn. Team mode
+		// cannot: Team.RunTurn owns its own inner loop and takes no control
+		// channel, so an interrupt there falls back to cancelling ctx.
+		ctrl := make(chan agent.Control, 1)
+		a.ctrlMu.Lock()
+		a.ctrl = ctrl
+		a.ctrlMu.Unlock()
+		result, err = a.runner.RunTurn(ctx, agent.TurnRequest{
+			History: turnMsgs,
+			Emit:    emit,
+			Control: ctrl,
+		})
+		a.ctrlMu.Lock()
+		a.ctrl = nil
+		a.ctrlMu.Unlock()
 	}
 	if err != nil {
 		a.history = a.history[:len(a.history)-1]
@@ -791,6 +819,42 @@ func (a *App) RunTurn(ctx context.Context, input string) error {
 	}
 	a.emit(HostEvent{Kind: HostTurnDone, Result: result})
 	return nil
+}
+
+// InterruptToolCalls cancels every tool call currently in flight without
+// ending the turn. Each cancelled call fails fast, its result is fed back to
+// the model as "cancelled by user" (rendering as EventToolCancelled, which is
+// deliberately distinct from an error), and the model gets to react — pick a
+// different tool, ask what to do, or answer without it.
+//
+// This is the softer half of interrupting, and the reason a surface should
+// reach for it before cancelling the turn's context: cancelling ctx aborts
+// everything and throws the turn's work away, while this keeps the
+// conversation alive. A natural binding is escalating, first press soft and
+// second press hard.
+//
+// It reports whether an interrupt was delivered. False means there was
+// nothing to interrupt: no turn running, a team-mode turn (Team owns its own
+// loop and takes no control channel), or a delivery already pending. False is
+// the caller's cue to fall back to cancelling the turn context.
+//
+// Safe to call from any goroutine, including a signal handler.
+func (a *App) InterruptToolCalls() bool {
+	a.ctrlMu.Lock()
+	ch := a.ctrl
+	a.ctrlMu.Unlock()
+	if ch == nil {
+		return false
+	}
+	// Non-blocking: the Runner drains continuously while a turn runs, so a
+	// full buffer means an interrupt is already on its way and a second one
+	// would be redundant. Never block a signal handler waiting for it.
+	select {
+	case ch <- agent.Control{}:
+		return true
+	default:
+		return false
+	}
 }
 
 // Tools renders the current merged tool list (the /tools command).

--- a/agent/host/interrupt_test.go
+++ b/agent/host/interrupt_test.go
@@ -1,0 +1,179 @@
+package host
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/panyam/mcpkit/agent"
+	"github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/server"
+	"github.com/panyam/mcpkit/testutil"
+)
+
+// recordingObserver captures HostEvents and can run a hook on each one, so a
+// test can act at an exact point in a turn rather than racing a sleep.
+type recordingObserver struct {
+	mu     sync.Mutex
+	runner []agent.Event
+	hook   func(agent.Event)
+}
+
+func (o *recordingObserver) On(e HostEvent) {
+	if e.Kind != HostRunnerEvent || e.RunnerEvent.Kind == "" {
+		return
+	}
+	o.mu.Lock()
+	o.runner = append(o.runner, e.RunnerEvent)
+	hook := o.hook
+	o.mu.Unlock()
+	if hook != nil {
+		hook(e.RunnerEvent)
+	}
+}
+
+func (o *recordingObserver) kinds() []agent.EventKind {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	out := make([]agent.EventKind, 0, len(o.runner))
+	for _, e := range o.runner {
+		out = append(out, e.Kind)
+	}
+	return out
+}
+
+func has(kinds []agent.EventKind, want agent.EventKind) bool {
+	for _, k := range kinds {
+		if k == want {
+			return true
+		}
+	}
+	return false
+}
+
+// blockingToolServer serves a "block" tool that parks until release is closed
+// or its context is cancelled, which is what makes a mid-call interrupt
+// observable without a sleep-based race.
+func blockingToolServer(t *testing.T, release <-chan struct{}) *httptest.Server {
+	t.Helper()
+	srv := testutil.NewTestServer()
+	srv.Register(core.TextTool[struct{}]("block", "Blocks until released or cancelled",
+		func(ctx core.ToolContext, _ struct{}) (string, error) {
+			select {
+			case <-release:
+				return "released", nil
+			case <-ctx.Done():
+				return "", ctx.Err()
+			}
+		},
+	))
+	ts := httptest.NewServer(srv.Handler(server.WithStreamableHTTP(true)))
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// TestInterruptToolCallsNoTurnRunning pins the between-turns guard. A control
+// send with nothing draining would otherwise sit buffered and cancel the next
+// turn's first tool call, which agent.TurnRequest.Control warns about
+// explicitly, so RunTurn clears the channel and this must report false.
+func TestInterruptToolCallsNoTurnRunning(t *testing.T) {
+	ts := startTestServer(t)
+	app, err := NewApp(testConfig(ts.URL), &strings.Builder{}, strings.NewReader(""),
+		WithProvider(agent.NewStubProvider(agent.StubTurn{Text: "hi"})))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Close()
+
+	if app.InterruptToolCalls() {
+		t.Fatal("InterruptToolCalls must report false with no turn running")
+	}
+	if err := app.RunTurn(context.Background(), "hello"); err != nil {
+		t.Fatal(err)
+	}
+	if app.InterruptToolCalls() {
+		t.Fatal("InterruptToolCalls must report false again once the turn has ended")
+	}
+}
+
+// TestInterruptToolCallsCancelsCallAndTurnContinues is the wiring acceptance:
+// App.RunTurn must drive agent.Runner.RunTurn with a live control channel, so
+// a surface can cancel one in-flight tool call and still get an answer. Before
+// this wiring the host called Runner.Run, which takes no control channel, and
+// the only interrupt available was cancelling ctx and losing the whole turn.
+//
+// The per-call cancellation semantics themselves are covered at the agent
+// layer (TestRunTurnControlCancelsOneCallTurnContinues and friends); this
+// asserts the host actually reaches them.
+func TestInterruptToolCallsCancelsCallAndTurnContinues(t *testing.T) {
+	release := make(chan struct{})
+	defer close(release) // unblock the tool if the test fails before cancelling
+
+	ts := blockingToolServer(t, release)
+	stub := agent.NewStubProvider(
+		agent.StubTurn{ToolCalls: []agent.ToolCall{{
+			ID: "c1", Name: "block", Args: core.NewRawJSON(json.RawMessage(`{}`)),
+		}}},
+		agent.StubTurn{Text: "the tool was cancelled, so here is an answer without it"},
+	)
+
+	obs := &recordingObserver{}
+	interrupted := make(chan bool, 1)
+	// Fire the interrupt the moment the tool starts, so the call is provably
+	// in flight rather than probably in flight. app is assigned below and read
+	// through the closure; the hook cannot run before RunTurn, which is well
+	// after NewApp returns.
+	var app *App
+	obs.hook = func(e agent.Event) {
+		if e.Kind == agent.EventToolBegin {
+			interrupted <- app.InterruptToolCalls()
+		}
+	}
+
+	var out strings.Builder
+	app, err := NewApp(testConfig(ts.URL), &out, strings.NewReader(""),
+		WithProvider(stub), WithObserver(obs))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Close()
+
+	done := make(chan error, 1)
+	go func() { done <- app.RunTurn(context.Background(), "call the blocking tool") }()
+
+	select {
+	case ok := <-interrupted:
+		if !ok {
+			t.Fatal("InterruptToolCalls reported false while a tool call was in flight")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("tool never started")
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("turn must survive a cancelled tool call, got %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatalf("turn did not finish after the interrupt; events so far: %v", obs.kinds())
+	}
+
+	kinds := obs.kinds()
+	if !has(kinds, agent.EventToolCancelled) {
+		t.Fatalf("expected EventToolCancelled, got %v", kinds)
+	}
+
+	// The model is told, and the turn ran on to a second step and answered.
+	if n := len(stub.Requests()); n < 2 {
+		t.Fatalf("turn stopped after the cancelled call: %d provider requests, want >= 2", n)
+	}
+	toolMsg := stub.Requests()[1].Messages[2]
+	if toolMsg.Role != agent.RoleTool || !strings.Contains(strings.ToLower(toolMsg.Text), "cancel") {
+		t.Fatalf("model-visible cancellation missing: %+v", toolMsg)
+	}
+}

--- a/agent/surfaces/chat/main.go
+++ b/agent/surfaces/chat/main.go
@@ -358,17 +358,34 @@ func runChat(v *viper.Viper) error {
 		return runNotebook(app, nbSurface, v.GetInt("notebook-max-lines"), window)
 	}
 
-	fmt.Printf("agentchat: %d server(s), model %s. /tools /history /quit; Ctrl-C cancels a turn.\n", len(cfg.Servers), cfg.Model.Model)
+	fmt.Printf("agentchat: %d server(s), model %s. /tools /history /quit; Ctrl-C interrupts a tool call, twice aborts the turn.\n", len(cfg.Servers), cfg.Model.Model)
 
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT)
+	// Ctrl-C escalates. The first press cancels whatever tool calls are in
+	// flight and lets the turn continue, so the model sees "cancelled by user"
+	// and can react; the second aborts the turn outright. Escalating matters
+	// because the common case is one wedged tool call, and throwing away the
+	// whole turn to escape it loses the reasoning that got there.
+	//
+	// A press with nothing to interrupt (no call in flight, or team mode,
+	// where Team owns its own loop) reports false and falls straight through
+	// to the hard abort, so Ctrl-C is never a no-op.
 	turnCtx := func() (context.Context, context.CancelFunc) {
 		ctx, cancel := context.WithCancel(context.Background())
 		go func() {
-			select {
-			case <-sigs:
-				cancel()
-			case <-ctx.Done():
+			for {
+				select {
+				case <-sigs:
+					if app.InterruptToolCalls() {
+						fmt.Println("^C interrupting tool call; Ctrl-C again to abort the turn.")
+						continue
+					}
+					cancel()
+					return
+				case <-ctx.Done():
+					return
+				}
 			}
 		}()
 		return ctx, cancel

--- a/client/call_cancel_test.go
+++ b/client/call_cancel_test.go
@@ -1,0 +1,136 @@
+package client_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/panyam/mcpkit/client"
+	"github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/server"
+	"github.com/panyam/mcpkit/testutil"
+)
+
+// blockingServer serves a tool that parks until release is closed or its own
+// context is cancelled, so a test can observe whether a caller's cancellation
+// actually reaches the wire.
+func blockingServer(t *testing.T, release <-chan struct{}) *httptest.Server {
+	t.Helper()
+	srv := testutil.NewTestServer()
+	srv.Register(core.TextTool[struct{}]("block", "blocks until released or cancelled",
+		func(ctx core.ToolContext, _ struct{}) (string, error) {
+			select {
+			case <-release:
+				return "released", nil
+			case <-ctx.Done():
+				return "", ctx.Err()
+			}
+		},
+	))
+	ts := httptest.NewServer(srv.Handler(server.WithStreamableHTTP(true)))
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func connectTo(t *testing.T, url string) *client.Client {
+	t.Helper()
+	c := client.NewClient(url+"/mcp", core.ClientInfo{Name: "cancel-test", Version: "1.0"})
+	if err := c.Connect(t.Context()); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { c.Close() })
+	return c
+}
+
+// TestCallHonoursContextCancellation pins that an ordinary call is
+// cancellable. It was not: callImpl took a ctx, spent it on trace capture,
+// then called callDirect without it, and the streamable transport fell back
+// to context.Background(). Only callers that hand-built a NewCallContext
+// (events/stream) could abort a request, so a wedged tool call could not be
+// interrupted by anything short of tearing down the client.
+func TestCallHonoursContextCancellation(t *testing.T) {
+	release := make(chan struct{})
+	defer close(release)
+	c := connectTo(t, blockingServer(t, release).URL)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	returned := make(chan error, 1)
+	go func() {
+		_, err := c.ToolCall(ctx, "block", nil)
+		returned <- err
+	}()
+
+	// Give the call time to reach the server and park, so this proves an
+	// in-flight request is aborted rather than a pre-flight ctx check.
+	time.Sleep(300 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-returned:
+		if err == nil {
+			t.Fatal("cancelled call returned a nil error")
+		}
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("want a context.Canceled error, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("call did not return within 5s of cancellation: ctx is not reaching the wire")
+	}
+}
+
+// TestCallHonoursContextDeadline is the deadline half of the same contract: a
+// caller that bounds a call with a timeout must get control back when it
+// expires, not when the server finally answers.
+func TestCallHonoursContextDeadline(t *testing.T) {
+	release := make(chan struct{})
+	defer close(release)
+	c := connectTo(t, blockingServer(t, release).URL)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := c.ToolCall(ctx, "block", nil)
+	if err == nil {
+		t.Fatal("call outlived its deadline and returned success")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("want context.DeadlineExceeded, got %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 3*time.Second {
+		t.Fatalf("deadline took %v to take effect", elapsed)
+	}
+}
+
+// TestCallContextExplicitContextWins pins the precedence rule on
+// Client.CallContext: a caller who built a CallContext with its own Context is
+// stating intent, so the ambient ctx argument must not replace it.
+func TestCallContextExplicitContextWins(t *testing.T) {
+	release := make(chan struct{})
+	defer close(release)
+	c := connectTo(t, blockingServer(t, release).URL)
+
+	inner, cancelInner := context.WithCancel(context.Background())
+	cc := client.NewCallContext(inner)
+
+	returned := make(chan error, 1)
+	go func() {
+		_, err := c.CallContext(context.Background(), cc, "tools/call",
+			map[string]any{"name": "block", "arguments": map[string]any{}})
+		returned <- err
+	}()
+
+	time.Sleep(300 * time.Millisecond)
+	cancelInner() // the CallContext's own context, not the argument
+
+	select {
+	case err := <-returned:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("want context.Canceled from the explicit CallContext, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("cancelling the explicit CallContext did not abort the call")
+	}
+}

--- a/client/client.go
+++ b/client/client.go
@@ -1168,7 +1168,17 @@ func (cc *CallContext) WithNotifyHook(hook func(method string, params json.RawMe
 // CallContext issues a JSON-RPC call with per-call configuration carried
 // on the typed CallContext. Identical to Call when cc has no hooks set
 // beyond a plain context.
+//
+// ctx bounds the call. A cc that already carries its own Context keeps it —
+// an explicitly built NewCallContext is the caller stating intent, and it
+// wins over the ambient argument.
 func (c *Client) CallContext(ctx context.Context, cc *CallContext, method string, params any) (*CallResult, error) {
+	if cc == nil {
+		cc = &CallContext{}
+	}
+	if cc.Context == nil {
+		cc.Context = ctxOrBackground(ctx)
+	}
 	resp, err := c.rawCallWithContext(method, params, cc)
 	if err != nil {
 		return nil, err
@@ -1222,12 +1232,14 @@ func (c *Client) Call(ctx context.Context, method string, params any) (*CallResu
 func (c *Client) callImpl(ctx context.Context, method string, params any) (*CallResult, error) {
 	traceEnabled := tracingEnabled(c.tracerProvider)
 	if len(c.callMiddleware) == 0 && !traceEnabled {
-		return c.callDirect(method, params)
+		return c.callDirect(ctx, method, params)
 	}
 
-	// Build the terminal handler.
-	terminal := ClientCallFunc(func(_ context.Context, method string, params any) (*CallResult, error) {
-		return c.callDirect(method, params)
+	// Build the terminal handler. It takes the ctx the middleware chain hands
+	// it rather than the one captured here, so middleware that derives a ctx
+	// (a per-call timeout, a retry budget) bounds the request it wraps.
+	terminal := ClientCallFunc(func(ctx context.Context, method string, params any) (*CallResult, error) {
+		return c.callDirect(ctx, method, params)
 	})
 	// Wrap with user middleware (reverse order: first registered = outermost).
 	handler := terminal
@@ -1251,9 +1263,16 @@ func (c *Client) callImpl(ctx context.Context, method string, params any) (*Call
 	return handler(ctx, method, params)
 }
 
-// callDirect is the non-middleware Call path.
-func (c *Client) callDirect(method string, params any) (*CallResult, error) {
-	resp, err := c.rawCall(method, params)
+// callDirect is the non-middleware Call path. ctx bounds the request: it is
+// carried down as CallContext.Context so the streamable HTTP transport builds
+// its http.Request with it and cancelling actually aborts the in-flight POST.
+//
+// Threading ctx here is what makes an ordinary call cancellable. Before it,
+// every caller's ctx was used for tracing and then dropped, callWithContext
+// fell back to context.Background(), and only callers that hand-built a
+// NewCallContext (events/stream) could be cancelled at all.
+func (c *Client) callDirect(ctx context.Context, method string, params any) (*CallResult, error) {
+	resp, err := c.rawCallWithContext(method, params, &CallContext{Context: ctx})
 	if err != nil {
 		return nil, err
 	}

--- a/client/iterators.go
+++ b/client/iterators.go
@@ -185,6 +185,13 @@ func paginate[T any](ctx context.Context, c *Client, method string,
 		var cursor string
 		pageCount := 0
 		for {
+			// Stop before spending a request the caller no longer wants. The
+			// per-item check below cannot cover this: cancellation between the
+			// last yield of one page and the fetch of the next would otherwise
+			// still hit the wire.
+			if ctx.Err() != nil {
+				return
+			}
 			if c.maxListPages > 0 && pageCount >= c.maxListPages {
 				var zero T
 				yield(zero, ErrListPaginationOverrun)
@@ -199,6 +206,15 @@ func paginate[T any](ctx context.Context, c *Client, method string,
 
 			result, err := c.Call(ctx, method, params)
 			if err != nil {
+				// A call aborted by the caller's own cancellation is a clean
+				// stop, not an iteration error — the same rule the per-item
+				// check below applies. Requests are cancellable now that the
+				// client threads ctx to the wire, so this arm is reachable
+				// where previously the ctx was dropped and the request ran to
+				// completion regardless.
+				if ctx.Err() != nil {
+					return
+				}
 				var zero T
 				yield(zero, err)
 				return


### PR DESCRIPTION
Makes mid-turn interrupt actually work. Two commits, readable in order: the `client/` fix that unblocks it, then the `agent/host` wiring that uses it.

## What prompted this

`agent.Runner` has supported cancelling a single in-flight tool call since #936 — the call fails fast, the model is told "cancelled by user", and the turn continues. The scorecard in `docs/AGENT_SDK_ROADMAP.md` marks it ✅ and Gap table B lists mid-turn interrupt as a closed gap.

Checking what actually drives it:

- **Runner side:** implemented.
- **Event side:** `EventToolCancelled` is rendered in `host/render.go` and `chat/notebook.go`, with a test pinning it as visually distinct from an error.
- **Producer side:** nothing. Zero non-test drivers of `agent.Control` anywhere.

Both surfaces did the other thing. agentchat's Ctrl-C is `context.WithCancel` on the whole turn, which is precisely what `TurnRequest.Control`'s doc contrasts itself against: *"unlike cancelling RunTurn's ctx, which aborts the whole turn."* So the differentiated half of the feature shipped with a renderer for an event nothing emitted.

Wiring it up surfaced a second, larger problem.

## Commit 1 — `client/`: an ordinary call was not cancellable

Not just tool calls. **Any** call, on any transport, for any caller.

`Client.callImpl` accepted a `ctx`, spent it on trace-context capture, then called `callDirect(method, params)` **without it**. Its middleware terminal handler was written `func(_ context.Context, ...)`. Downstream, `streamableClientTransport.callWithContext` did `reqCtx := context.Background()` and only used a real context when the caller had hand-built a `CallContext`.

The one caller that did is `events/stream`, and the comment says why: *"required for events/stream's Stop() to actually close the connection."* Context threading was added for that single case and never generalized. For everyone else `ctx` was decorative — cancelling did nothing, a deadline did nothing, and a wedged call could only be escaped by tearing down the client.

The fix:

- `callDirect` takes a `ctx` and carries it as `CallContext.Context`.
- The middleware terminal handler uses the ctx the *chain* hands it rather than the one captured at entry, so middleware deriving a bounded ctx (a per-call timeout, a retry budget) bounds the request it wraps.
- `Client.CallContext`, which ignored its `ctx` argument entirely, fills a nil `cc.Context` from it — while leaving an explicitly built `NewCallContext` alone, since a caller who constructed one is stating intent and should win over the ambient argument.

Only the streamable HTTP transport honours cancellation. Legacy SSE and the core adapter already document that they ignore `cc`; unchanged.

**`paginate` needed a matching fix.** It already treated cancellation as a clean stop — checking `ctx.Err()` before each yield and returning without an error — but that only held while requests were uncancellable. Once the in-flight page fetch could fail with `context.Canceled`, it would have surfaced as an iteration error and broken `TestListResources_CtxCancellationStopsMidIteration`. A call that fails because the caller cancelled is now also a clean stop, matching the rule the per-item check already applied. It also checks ctx before fetching the next page, so cancelling between pages no longer spends a request nobody wants.

New tests, all against a real server over streamable HTTP with a tool that parks until cancelled: cancellation of an in-flight call, a deadline, and the `CallContext` precedence rule.

## Commit 2 — `agent/host`: drive it from a surface

`App.RunTurn` now drives `Runner.RunTurn` with a live control channel, and `App.InterruptToolCalls()` sends on it.

Two details worth review:

- The channel is installed for the turn and **cleared after**. `TurnRequest.Control` warns that a buffered cancel-all sent while nothing drains would land on the next turn's first dispatch, so a send with no turn running is dropped and reports false.
- It has its own mutex. `RunTurn` holds `turnMu` for the whole turn, so an interrupt arriving mid-turn could never take `turnMu` to find the channel.

**Team mode keeps the old behaviour.** `Team.RunTurn` owns its inner loop and takes no control channel, so `InterruptToolCalls` reports false there and the caller falls through to cancelling ctx.

**agentchat's Ctrl-C escalates:** first press cancels in-flight tool calls and lets the turn continue, second aborts. A press with nothing to interrupt reports false and falls straight through to the hard abort, so Ctrl-C is never a no-op. Escalating matters because the common case is one wedged tool call, and throwing away the turn to escape it discards the reasoning that got there.

## Why the gap was invisible

Every existing per-call cancel test (`agent/runner_cancel_test.go`) uses an in-process `FuncSource` whose handler is `<-ctx.Done()`. That cancels fine. The wire path had never been exercised, so the feature was green in CI and broken for the case an MCP agent SDK mostly serves.

The host test here closes that: it drives a real MCP tool over streamable HTTP and fires the interrupt from an observer on `tool-begin`, so the call is provably in flight rather than probably in flight.

This is the same failure mode the roadmap's own scorecard warns about — *"a seam can look complete while nothing drives it"* — one layer below where that warning was aimed.

## Reviewer's guide

1. [client/client.go](https://github.com/panyam/mcpkit/pull/1247/files#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09) — `callDirect`, the `callImpl` terminal handler, and `CallContext`. The precedence rule is the one judgement call.
2. [client/iterators.go](https://github.com/panyam/mcpkit/pull/1247/files#diff-dad5f13ba9bbe79fea35412961defa3afd21011bb0cc42c65e36dee5c9b00277) — `paginate`, cancellation as a clean stop.
3. [client/call_cancel_test.go](https://github.com/panyam/mcpkit/pull/1247/files#diff-7a0327387c8a3b93f646e3aeb4edc0b4098f48b76af8e05037d84759584bd033) — the three contract tests.
4. [agent/host/app.go](https://github.com/panyam/mcpkit/pull/1247/files#diff-89fb8e04b6e1e9d5f7f76958490ef158dee40e2cae92d87c04b408d893c84361) — the control channel lifecycle and `InterruptToolCalls`.
5. [agent/surfaces/chat/main.go](https://github.com/panyam/mcpkit/pull/1247/files#diff-de1f6704aa015837cae2f70c85eaab525bdc5ff446d724128749ab52e56d53aa) — the escalating Ctrl-C.
6. [agent/host/interrupt_test.go](https://github.com/panyam/mcpkit/pull/1247/files#diff-0b1cd64138c94b95424824a85bb79c416f78adc6f51a0f0318c3ac570374a827) — the end-to-end proof and the between-turns guard.

## Testing

`make test`, `make test-agent`, `make test-e2e`, `make test-auth`, `make test-ui` all pass. The client change touches a core protocol module, so the full sweep matters more than usual here.

