### PR TITLE
refactor(host): collapse App's 52 fields into five clusters

### DIFF
--- a/agent/host/app.go
+++ b/agent/host/app.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"strings"
 	"sync"
-	"sync/atomic"
 
 	gocurrent "github.com/panyam/gocurrent"
 	"github.com/panyam/mcpkit/agent"
@@ -40,12 +39,11 @@ type App struct {
 	// nil otherwise.
 	teamEventSink func(agent.Event)
 
-	sources   *agent.MultiSource
-	clients   []*client.Client
-	history   []agent.Message
-	observers []Observer
-	replOut   io.Writer // terminal REPL draws its own prompt here
-	failover  *agent.FailoverProvider
+	sources  *agent.MultiSource
+	clients  []*client.Client
+	history  []agent.Message
+	replOut  io.Writer // terminal REPL draws its own prompt here
+	failover *agent.FailoverProvider
 
 	// group owns the MCP server connection lifecycle (async connect, per-server
 	// state, backoff reconnect); its observer registers a server's tools when it
@@ -84,11 +82,11 @@ type App struct {
 	fanIn     *gocurrent.FanIn[agent.IncomingEvent]
 	streams   []*eventsclient.StreamCall
 	tasks     *taskSet
+	events    *eventSpine
 	subsMu    sync.Mutex
 	subs      map[string]*subscription
 	metaTools bool
 	turnMu    sync.Mutex
-	emitMu    sync.Mutex // serializes emit's synchronous local delivery (the Group, turn, and event goroutines all emit)
 
 	// ctrl is the in-flight turn's mid-turn control channel, non-nil only
 	// while a single-agent turn is running. InterruptToolCalls sends on it;
@@ -103,52 +101,13 @@ type App struct {
 	ctrlMu sync.Mutex
 	ctrl   chan agent.Control
 
-	// eventLog is the retained per-session event log. emit appends every
-	// HostEvent here in addition to delivering it synchronously to the local
-	// observers, so the log is the single source of truth a web surface
-	// subscribes onto (replay from offset 0 + live) and the barrier seam for
-	// multi-surface asks. Local observers stay synchronous because the terminal
-	// renderer writes to a caller-visible io.Writer; the async subscriber
-	// adapter that isolates a remote surface lands with that surface (issue
-	// 1196). Bounded when Config.MaxEventLogRetention > 0 (issue 1200): the
-	// oldest entries evict while offsets stay absolute, and Subscribe deep
-	// replays evicted-but-persisted turns from the RunStore. Unbounded by
-	// default (issue 1194, Option A).
-	eventLog *gocurrent.Queue[HostEvent]
-
-	// persistedOffset is the eventLog offset through which the run's events
-	// have been written to the RunStore: eventLog[0, persistedOffset) is
-	// covered by the store (its runner events are in RunStore.Events; any
-	// non-runner HostEvents in that range are ephemeral). Advanced at the
-	// turn-end persist site (persistTurnLocked) once AppendEvents succeeds,
-	// and read by Subscribe to split its replay between the RunStore (deep
-	// history) and the Queue tail (unpersisted, still in the retained window).
-	// Written and the deep-replay snapshot read under turnMu; atomic so a
-	// lock-free reader stays safe. Stays 0 when no RunStore is configured, so
-	// Subscribe falls back to replaying the whole retained window.
-	persistedOffset atomic.Int64
-
 	evCtx     context.Context // subscription lifetime ctx; the ready-observer subscribes late servers on it
 	eventStop context.CancelFunc
 
-	// store and runID are the persistence seam (WithRunStore): runID is
-	// the run turns append to, created lazily on the first persisted
-	// turn or set by AttachRun / Resume / Fork. Guarded by turnMu; write
-	// through setRunID so runIDAtomic stays in sync.
-	store agent.RunStore
-	runID string
-
-	// runIDAtomic mirrors runID for a lock-free read (currentRunID). The
-	// session-scoped memory namespace func reads it during a turn while
-	// turnMu is already held, so it must NOT go through RunID (which takes
-	// turnMu and would deadlock). Written under turnMu via setRunID.
-	runIDAtomic atomic.Value
-
-	// sessionsMu guards sessionsCursor, the paging position the /sessions
-	// picker remembers so "/sessions more" advances (the store cursor is
-	// opaque, so the host holds where the last page ended).
-	sessionsMu     sync.Mutex
-	sessionsCursor string
+	// session is the persistence seam (WithRunStore): the store, the active
+	// run turns append to, and the /sessions paging position. See
+	// sessionState for why its locking is deliberately not uniform.
+	session sessionState
 
 	// toolResultStore backs tool-result offloading when Config.Offload
 	// is set; nil when offloading is off.
@@ -344,7 +303,7 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 	}
 
 	multi := agent.NewMultiSource()
-	app := &App{cfg: cfg, sources: multi, observers: observers, replOut: out, tasks: newTaskSet(), skills: newSkillSet(), subs: map[string]*subscription{}, store: o.store,
+	app := &App{cfg: cfg, sources: multi, events: &eventSpine{observers: observers}, replOut: out, tasks: newTaskSet(), skills: newSkillSet(), subs: map[string]*subscription{}, session: sessionState{store: o.store},
 		tp: o.tp, log: o.logger, oauthSources: map[string]loginSource{}}
 	// Bring the retained event log up before anything can emit (the
 	// server-connect hooks below capture app and fire asynchronously).
@@ -352,9 +311,9 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 	// retained window (NewBoundedQueue evicts the oldest, offsets stay absolute
 	// so Subscribe's deep replay still stitches).
 	if cfg.MaxEventLogRetention > 0 {
-		app.eventLog = gocurrent.NewBoundedQueue[HostEvent](cfg.MaxEventLogRetention)
+		app.events.log = gocurrent.NewBoundedQueue[HostEvent](cfg.MaxEventLogRetention)
 	} else {
-		app.eventLog = gocurrent.NewQueue[HostEvent]()
+		app.events.log = gocurrent.NewQueue[HostEvent]()
 	}
 	// Elicitations broadcast to every surface via the event log and resolve on
 	// the first responder; the local UI is one responder (barrierElicit).
@@ -752,7 +711,7 @@ func (a *App) RunTurn(ctx context.Context, input string) error {
 
 	emit := func(e agent.Event) { a.emit(HostEvent{Kind: HostRunnerEvent, RunnerEvent: e}) }
 	var pe *PersistingEmit
-	if a.store != nil {
+	if a.session.store != nil {
 		if err := a.ensureRunLocked(ctx); err != nil {
 			a.history = a.history[:len(a.history)-1]
 			a.emit(HostEvent{Kind: HostTurnFailed, Err: err.Error()})
@@ -762,9 +721,9 @@ func (a *App) RunTurn(ctx context.Context, input string) error {
 			// Team member events render attributed via OnEvent, so the persisting
 			// tap must NOT also render (that would double-render) — a nil next
 			// makes pe buffer-only; teamEventSink feeds it below.
-			pe = NewPersistingEmit(a.store, a.runID, nil)
+			pe = NewPersistingEmit(a.session.store, a.session.runID, nil)
 		} else {
-			pe = NewPersistingEmit(a.store, a.runID, emit)
+			pe = NewPersistingEmit(a.session.store, a.session.runID, emit)
 			emit = pe.Emit
 		}
 	}
@@ -905,21 +864,8 @@ func (a *App) SwitchProvider(name string) error {
 }
 
 // emit records a host event on the retained log and delivers it synchronously
-// to every local observer. The append is the source of truth a web surface
-// replays and subscribes onto; the synchronous fan-out preserves the terminal
-// rendering contract (a caller reading the renderer's io.Writer sees the event
-// once emit returns). Serialized by emitMu: the async server connections (Group
-// observer), the turn goroutine, and event goroutines all emit, so the lock
-// keeps the not-inherently-concurrent terminal renderer from racing.
-func (a *App) emit(ev HostEvent) (offset int) {
-	offset = a.eventLog.Append(ev)
-	a.emitMu.Lock()
-	defer a.emitMu.Unlock()
-	for _, o := range a.observers {
-		o.On(ev)
-	}
-	return offset
-}
+// to every local observer. See eventSpine.emit for the ordering contract.
+func (a *App) emit(ev HostEvent) (offset int) { return a.events.emit(ev) }
 
 // promptREPL draws the terminal REPL's input marker. The prompt is
 // surface chrome, not a host event — the REPL owns it because the REPL is

--- a/agent/host/app.go
+++ b/agent/host/app.go
@@ -15,7 +15,6 @@ import (
 	"github.com/panyam/mcpkit/agent"
 	"github.com/panyam/mcpkit/client"
 	"github.com/panyam/mcpkit/core"
-	eventsclient "github.com/panyam/mcpkit/experimental/ext/events/clients/go"
 )
 
 // App is agentchat's testable core: everything the binary does minus flag
@@ -40,27 +39,24 @@ type App struct {
 	teamEventSink func(agent.Event)
 
 	sources  *agent.MultiSource
-	clients  []*client.Client
 	history  []agent.Message
 	replOut  io.Writer // terminal REPL draws its own prompt here
 	failover *agent.FailoverProvider
 
-	// group owns the MCP server connection lifecycle (async connect, per-server
-	// state, backoff reconnect); its observer registers a server's tools when it
-	// becomes ready. serverTools mirrors the server sources for sub-agent
-	// personas. See docs/AGENT_SERVER_STATE.md.
-	group       *client.Group
-	serverTools *agent.MultiSource
+	// servers is the connected MCP servers: the Group owning their connection
+	// lifecycle, the clients, the persona-visible tool mirror, and the oauth
+	// token sources. See docs/AGENT_SERVER_STATE.md and serverSet.
+	servers serverSet
+
+	// streams is the inbound event plumbing over those servers: live
+	// subscriptions, the fan-in that merges them, and the context bounding
+	// them. Only populated when the async control plane is on. See streamSet.
+	streams streamSet
 
 	// agentPool backs the runner-control meta-tools (Config.RunnerControl,
 	// issue 1166): the registry of spawnable personas + their live handles. Nil
 	// when runner control is off.
 	agentPool *agent.AgentPool
-
-	// oauthSources holds the interactive (oauth) token source per server id, so
-	// LoginServer can force a fresh browser login. Only oauth-typed servers have
-	// an entry; its presence is what CanLogin reports.
-	oauthSources map[string]loginSource
 
 	// tp is the tracer provider, held so the ready-observer can load a late
 	// server's skills with the same instrumentation as the boot path.
@@ -79,12 +75,8 @@ type App struct {
 	injection *agent.EventInjectionPolicy
 	triggers  *agent.TriggerPolicy
 	approval  *agent.TieredApproval
-	fanIn     *gocurrent.FanIn[agent.IncomingEvent]
-	streams   []*eventsclient.StreamCall
 	tasks     *taskSet
 	events    *eventSpine
-	subsMu    sync.Mutex
-	subs      map[string]*subscription
 	metaTools bool
 	turnMu    sync.Mutex
 
@@ -100,9 +92,6 @@ type App struct {
 	// to be dropped rather than queued.
 	ctrlMu sync.Mutex
 	ctrl   chan agent.Control
-
-	evCtx     context.Context // subscription lifetime ctx; the ready-observer subscribes late servers on it
-	eventStop context.CancelFunc
 
 	// session is the persistence seam (WithRunStore): the store, the active
 	// run turns append to, and the /sessions paging position. See
@@ -251,8 +240,8 @@ func (a *App) registerServerTools(sc ServerConfig, c *client.Client) {
 		a.emit(HostEvent{Kind: HostSessionWarn, Err: fmt.Sprintf("register tools for %s: %v", sc.ID, err)})
 		return
 	}
-	if a.serverTools != nil {
-		_ = a.serverTools.Add(sc.ID, src)
+	if a.servers.tools != nil {
+		_ = a.servers.tools.Add(sc.ID, src)
 	}
 	// A late-added source changes the tool list; clear any cached aggregate so
 	// the next turn sees the new tools.
@@ -303,8 +292,10 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 	}
 
 	multi := agent.NewMultiSource()
-	app := &App{cfg: cfg, sources: multi, events: &eventSpine{observers: observers}, replOut: out, tasks: newTaskSet(), skills: newSkillSet(), subs: map[string]*subscription{}, session: sessionState{store: o.store},
-		tp: o.tp, log: o.logger, oauthSources: map[string]loginSource{}}
+	app := &App{cfg: cfg, sources: multi, events: &eventSpine{observers: observers}, replOut: out, tasks: newTaskSet(), skills: newSkillSet(), session: sessionState{store: o.store},
+		streams: streamSet{subs: map[string]*subscription{}},
+		servers: serverSet{oauth: map[string]loginSource{}},
+		tp:      o.tp, log: o.logger}
 	// Bring the retained event log up before anything can emit (the
 	// server-connect hooks below capture app and fire asynchronously).
 	// MaxEventLogRetention 0 keeps the unbounded log; a positive value caps the
@@ -336,7 +327,7 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 	// servers without seeing the meta-tools or the other personas (which would
 	// let it recurse). Built only when personas are configured.
 	if len(cfg.SubAgents) > 0 || len(cfg.FanOut) > 0 || cfg.Team != nil {
-		app.serverTools = agent.NewMultiSource()
+		app.servers.tools = agent.NewMultiSource()
 	}
 
 	// Build one client per server and hand it to the connection Group, which
@@ -354,7 +345,7 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 			app.onServerEvents(serverByID[ch.ID])
 		}
 	}
-	app.group = client.NewGroup(client.WithObserver(onState))
+	app.servers.group = client.NewGroup(client.WithObserver(onState))
 	for _, sc := range cfg.Servers {
 		copts := []client.ClientOption{
 			client.WithGetSSEStream(),
@@ -372,13 +363,13 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 			copts = append(copts, authOpt)
 		}
 		if loginSrc != nil {
-			app.oauthSources[sc.ID] = loginSrc
+			app.servers.oauth[sc.ID] = loginSrc
 		}
 		c := client.NewClient(sc.URL, core.ClientInfo{Name: "agentchat", Version: "0.1"}, copts...)
-		app.clients = append(app.clients, c)
+		app.servers.clients = append(app.servers.clients, c)
 		serverByID[sc.ID] = sc
 		clientByID[sc.ID] = c
-		app.group.Add(sc.ID, c, sc.Required)
+		app.servers.group.Add(sc.ID, c, sc.Required)
 	}
 	// The event infrastructure (fanIn + subscription ctx) must exist before the
 	// servers connect, so the ready-observer can subscribe a server's event
@@ -389,14 +380,14 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 		app.metaTools = app.metaTools || len(sc.Events) > 0
 	}
 	if app.metaTools {
-		app.evCtx, app.eventStop = context.WithCancel(context.Background())
-		app.fanIn = gocurrent.NewFanIn[agent.IncomingEvent]()
+		app.streams.ctx, app.streams.stop = context.WithCancel(context.Background())
+		app.streams.fanIn = gocurrent.NewFanIn[agent.IncomingEvent]()
 	}
 
-	app.group.Start(context.Background())
+	app.servers.group.Start(context.Background())
 	// Block only for the servers marked required; the rest keep connecting in
 	// the background and register via the observer as they become ready.
-	if err := app.group.WaitRequired(context.Background()); err != nil {
+	if err := app.servers.group.WaitRequired(context.Background()); err != nil {
 		app.Close()
 		return nil, fmt.Errorf("agentchat: %w", err)
 	}
@@ -407,7 +398,7 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 	// are loaded in the ready-observer (onServerSkills) into shared state that
 	// the dynamic system prompt (buildInstructions) and load_skill read live, so
 	// a server that connects after boot contributes its skills on the next turn.
-	_ = app.group.WaitSettled(context.Background())
+	_ = app.servers.group.WaitSettled(context.Background())
 
 	provider := o.provider
 	if provider == nil && cfg.Connections != nil {
@@ -488,7 +479,7 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 	// a filtered view of serverTools (built above), so it never sees the
 	// meta-tools or its sibling personas.
 	if len(cfg.SubAgents) > 0 {
-		if err := app.registerSubAgents(multi, app.serverTools, provider, o.tp, o.mp); err != nil {
+		if err := app.registerSubAgents(multi, app.servers.tools, provider, o.tp, o.mp); err != nil {
 			app.Close()
 			return nil, err
 		}
@@ -498,7 +489,7 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 	// personas concurrently (agent.FanOutSource). Members are built like
 	// sub-agents (serverTools-only), so the same memory-free rule holds.
 	if len(cfg.FanOut) > 0 {
-		if err := app.registerFanOut(multi, app.serverTools, provider, o.tp, o.mp); err != nil {
+		if err := app.registerFanOut(multi, app.servers.tools, provider, o.tp, o.mp); err != nil {
 			app.Close()
 			return nil, err
 		}
@@ -515,7 +506,7 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 	// configured personas in the background with handles (issue 1166). Reuses
 	// the persona child Runners; only meaningful with SubAgents.
 	if cfg.RunnerControl && len(cfg.SubAgents) > 0 {
-		if err := app.registerRunnerControl(multi, app.serverTools, provider, o.tp, o.mp); err != nil {
+		if err := app.registerRunnerControl(multi, app.servers.tools, provider, o.tp, o.mp); err != nil {
 			app.Close()
 			return nil, err
 		}
@@ -524,7 +515,7 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 	// Team mode: a handoff Team drives RunTurn instead of the single runner.
 	// Validated mutually exclusive with the single-agent features above.
 	if cfg.Team != nil {
-		team, err := app.buildTeam(app.serverTools, provider, o.tp, o.mp)
+		team, err := app.buildTeam(app.servers.tools, provider, o.tp, o.mp)
 		if err != nil {
 			app.Close()
 			return nil, err
@@ -612,25 +603,25 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 	// the ready-observer has been subscribing each server's event streams; now
 	// that the Runner exists, start the consumer that drains them into the
 	// injection/trigger policies.
-	if app.metaTools && app.fanIn != nil {
-		go app.consumeEvents(app.evCtx)
+	if app.metaTools && app.streams.fanIn != nil {
+		go app.consumeEvents(app.streams.ctx)
 	}
 	return app, nil
 }
 
 // Close stops event streams and disconnects every server.
 func (a *App) Close() {
-	if a.eventStop != nil {
-		a.eventStop()
+	if a.streams.stop != nil {
+		a.streams.stop()
 	}
-	for _, s := range a.streams {
+	for _, s := range a.streams.calls {
 		s.Stop()
 	}
 	for _, s := range a.listSubscriptions() {
 		s.call.Stop()
 	}
-	if a.fanIn != nil {
-		a.fanIn.Stop()
+	if a.streams.fanIn != nil {
+		a.streams.fanIn.Stop()
 	}
 	for _, bt := range a.tasks.all() {
 		bt.Cancel(context.Background())
@@ -639,10 +630,10 @@ func (a *App) Close() {
 	// connect/retry goroutines and closes the member clients. Fall back to
 	// closing clients directly only if the Group was never built (an early
 	// construction error).
-	if a.group != nil {
-		a.group.Close()
+	if a.servers.group != nil {
+		a.servers.group.Close()
 	} else {
-		for _, c := range a.clients {
+		for _, c := range a.servers.clients {
 			c.Close()
 		}
 	}
@@ -670,7 +661,7 @@ type loginSource interface{ Invalidate() }
 
 // canLogin reports whether an interactive (oauth) auth type is configured for
 // the server, so a surface knows when to offer the login action.
-func (a *App) canLogin(id string) bool { return a.oauthSources[id] != nil }
+func (a *App) canLogin(id string) bool { return a.servers.oauth[id] != nil }
 
 // LoginServer forces a fresh interactive login for an oauth-configured server:
 // it drops any cached token and reconnects, so the client's next connect runs
@@ -678,7 +669,7 @@ func (a *App) canLogin(id string) bool { return a.oauthSources[id] != nil }
 // (oauth) auth type, or an unknown id, is a no-op — canLogin / the server
 // status CanLogin flag tells a surface when to offer it.
 func (a *App) LoginServer(id string) {
-	src := a.oauthSources[id]
+	src := a.servers.oauth[id]
 	if src == nil {
 		return
 	}
@@ -693,8 +684,8 @@ func (a *App) LoginServer(id string) {
 // reconnect command and the interactive /mcp overlay's reconnect action; the
 // surface renders the resulting state transitions from the group observer.
 func (a *App) ReconnectServer(id string) {
-	if a.group != nil {
-		a.group.Reconnect(id)
+	if a.servers.group != nil {
+		a.servers.group.Reconnect(id)
 	}
 }
 

--- a/agent/host/app.go
+++ b/agent/host/app.go
@@ -76,19 +76,14 @@ type App struct {
 	// blocks and load_skill catalog are shared mutable state read live: the
 	// dynamic system prompt (buildInstructions -> RunnerConfig.InstructionsFunc)
 	// and the load_skill tool. serverOrder keeps assembly deterministic.
-	skillsMu     sync.Mutex
-	skillBlocks  map[string]string         // serverID -> system-prompt block (eager bodies or catalog listing)
-	skillCatalog map[string][]catalogSkill // serverID -> catalog entries for load_skill
-	serverOrder  []string
-	loadSkillReg bool // load_skill registered once, lazily, on the first catalog skill
+	skills *skillSet
 
 	injection *agent.EventInjectionPolicy
 	triggers  *agent.TriggerPolicy
 	approval  *agent.TieredApproval
 	fanIn     *gocurrent.FanIn[agent.IncomingEvent]
 	streams   []*eventsclient.StreamCall
-	tasksMu   sync.Mutex
-	bgTasks   map[string]*client.BackgroundTask
+	tasks     *taskSet
 	subsMu    sync.Mutex
 	subs      map[string]*subscription
 	metaTools bool
@@ -349,8 +344,8 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 	}
 
 	multi := agent.NewMultiSource()
-	app := &App{cfg: cfg, sources: multi, observers: observers, replOut: out, bgTasks: map[string]*client.BackgroundTask{}, subs: map[string]*subscription{}, store: o.store,
-		tp: o.tp, log: o.logger, skillBlocks: map[string]string{}, skillCatalog: map[string][]catalogSkill{}, oauthSources: map[string]loginSource{}}
+	app := &App{cfg: cfg, sources: multi, observers: observers, replOut: out, tasks: newTaskSet(), skills: newSkillSet(), subs: map[string]*subscription{}, store: o.store,
+		tp: o.tp, log: o.logger, oauthSources: map[string]loginSource{}}
 	// Bring the retained event log up before anything can emit (the
 	// server-connect hooks below capture app and fire asynchronously).
 	// MaxEventLogRetention 0 keeps the unbounded log; a positive value caps the
@@ -365,7 +360,7 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 	// the first responder; the local UI is one responder (barrierElicit).
 	coord := agent.NewElicitationCoordinator(app.barrierElicit(elicUI))
 	for _, sc := range cfg.Servers {
-		app.serverOrder = append(app.serverOrder, sc.ID)
+		app.skills.track(sc.ID)
 	}
 	if o.configPath != "" {
 		app.overlay = &configOverlay{path: overlayPathFor(o.configPath)}
@@ -678,11 +673,9 @@ func (a *App) Close() {
 	if a.fanIn != nil {
 		a.fanIn.Stop()
 	}
-	a.tasksMu.Lock()
-	for _, bt := range a.bgTasks {
+	for _, bt := range a.tasks.all() {
 		bt.Cancel(context.Background())
 	}
-	a.tasksMu.Unlock()
 	// The Group owns the server connections' lifecycle: closing it stops the
 	// connect/retry goroutines and closes the member clients. Fall back to
 	// closing clients directly only if the Group was never built (an early

--- a/agent/host/app_test.go
+++ b/agent/host/app_test.go
@@ -52,10 +52,10 @@ func TestAppBootsWithDownOptionalServer(t *testing.T) {
 	}
 	defer app.Close()
 
-	if s, _ := app.group.State("test"); s != client.StateReady {
+	if s, _ := app.servers.group.State("test"); s != client.StateReady {
 		t.Fatalf("reachable server state = %v, want ready", s)
 	}
-	if s, _ := app.group.State("down"); s == client.StateReady {
+	if s, _ := app.servers.group.State("down"); s == client.StateReady {
 		t.Fatalf("down server should not be ready, got %v", s)
 	}
 	res, err := app.Dispatch(context.Background(), "/servers")
@@ -102,7 +102,7 @@ func TestAppRequiredServerReadyAfterBoot(t *testing.T) {
 		t.Fatalf("boot with a reachable required server: %v", err)
 	}
 	defer app.Close()
-	if s, _ := app.group.State("test"); s != client.StateReady {
+	if s, _ := app.servers.group.State("test"); s != client.StateReady {
 		t.Fatalf("required server must be ready after boot, got %v", s)
 	}
 }

--- a/agent/host/ask.go
+++ b/agent/host/ask.go
@@ -25,7 +25,7 @@ type elicitResolution struct {
 // RPC calls (issue 1196); the local terminal UI resolves the same ask through
 // barrierElicit below.
 func (a *App) RespondToAsk(askOffset int, res core.ElicitationResult, by string) error {
-	return a.eventLog.Resolve(askOffset, elicitResolution{res: res, by: by})
+	return a.events.log.Resolve(askOffset, elicitResolution{res: res, by: by})
 }
 
 // barrierElicit wraps a local ElicitationUI so an elicitation is broadcast to
@@ -47,7 +47,7 @@ func (a *App) barrierElicit(local agent.ElicitationUI) agent.ElicitationUI {
 		go func() {
 			res, err := local(localCtx, req)
 			if localCtx.Err() == nil {
-				a.eventLog.Resolve(off, elicitResolution{res: res, err: err, by: "local"})
+				a.events.log.Resolve(off, elicitResolution{res: res, err: err, by: "local"})
 			}
 		}()
 
@@ -55,7 +55,7 @@ func (a *App) barrierElicit(local agent.ElicitationUI) agent.ElicitationUI {
 		// cancelled turn by resolving the ask ourselves (the goroutine then
 		// unblocks and exits; the buffered channel means it never leaks).
 		resolved := make(chan elicitResolution, 1)
-		go func() { resolved <- a.eventLog.AwaitResolution(off).(elicitResolution) }()
+		go func() { resolved <- a.events.log.AwaitResolution(off).(elicitResolution) }()
 
 		select {
 		case r := <-resolved:
@@ -66,7 +66,7 @@ func (a *App) barrierElicit(local agent.ElicitationUI) agent.ElicitationUI {
 			a.emit(HostEvent{Kind: HostElicitResolved, AskID: int64(off), By: r.by})
 			return r.res, r.err
 		case <-ctx.Done():
-			a.eventLog.Resolve(off, elicitResolution{err: ctx.Err(), by: askCancelled})
+			a.events.log.Resolve(off, elicitResolution{err: ctx.Err(), by: askCancelled})
 			return core.ElicitationResult{}, ctx.Err()
 		}
 	}

--- a/agent/host/ask_test.go
+++ b/agent/host/ask_test.go
@@ -10,13 +10,13 @@ import (
 )
 
 func newAskApp() *App {
-	return &App{
-		eventLog:  gocurrent.NewQueue[HostEvent](),
+	return &App{events: &eventSpine{
+		log:       gocurrent.NewQueue[HostEvent](),
 		observers: []Observer{&recordObserver{}},
-	}
+	}}
 }
 
-func askRecorder(a *App) *recordObserver { return a.observers[0].(*recordObserver) }
+func askRecorder(a *App) *recordObserver { return a.events.observers[0].(*recordObserver) }
 
 // waitAskOffset returns the log offset of the pending HostElicitRequest — the
 // ask id a surface reads from its stream position and passes to RespondToAsk.
@@ -24,7 +24,7 @@ func waitAskOffset(t *testing.T, a *App) int {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		evs, _ := a.eventLog.ReadFrom(0)
+		evs, _ := a.events.log.ReadFrom(0)
 		for i := range evs {
 			if evs[i].Kind == HostElicitRequest {
 				return i
@@ -129,7 +129,7 @@ func TestRespondToAsk_Errors(t *testing.T) {
 		t.Fatal("expected an error responding to an out-of-range offset")
 	}
 
-	off := a.eventLog.Append(HostEvent{Kind: HostElicitRequest})
+	off := a.events.log.Append(HostEvent{Kind: HostElicitRequest})
 	if err := a.RespondToAsk(off, core.ElicitationResult{}, "first"); err != nil {
 		t.Fatalf("first response should win: %v", err)
 	}

--- a/agent/host/auth_test.go
+++ b/agent/host/auth_test.go
@@ -85,7 +85,7 @@ func TestBearerAuthReachesTheWire(t *testing.T) {
 		t.Fatalf("without bearer, boot should still succeed gracefully: %v", err)
 	}
 	defer app2.Close()
-	if s, _ := app2.group.State(cfg.Servers[0].ID); s == client.StateReady {
+	if s, _ := app2.servers.group.State(cfg.Servers[0].ID); s == client.StateReady {
 		t.Fatalf("un-bearered connection to the guarded server must not be ready, got %v", s)
 	}
 }

--- a/agent/host/commands.go
+++ b/agent/host/commands.go
@@ -276,8 +276,8 @@ func (a *App) registerBuiltinCommands() {
 				return CmdResult{Kind: CmdMessage, Message: "login started for " + id}, nil
 			}
 			var st []ServerStatus
-			if a.group != nil {
-				for _, ms := range a.group.Status() {
+			if a.servers.group != nil {
+				for _, ms := range a.servers.group.Status() {
 					st = append(st, ServerStatus{MemberStatus: ms, CanLogin: a.canLogin(ms.ID)})
 				}
 			}
@@ -290,8 +290,8 @@ func (a *App) registerBuiltinCommands() {
 					out = append(out, sub)
 				}
 			}
-			if a.group != nil {
-				for _, st := range a.group.Status() {
+			if a.servers.group != nil {
+				for _, st := range a.servers.group.Status() {
 					if strings.HasPrefix(st.ID, prefix) {
 						out = append(out, st.ID)
 					}

--- a/agent/host/commands_test.go
+++ b/agent/host/commands_test.go
@@ -247,7 +247,7 @@ func (f *fakeLoginSource) Invalidate() { f.invalidated++ }
 func TestApp_LoginServer(t *testing.T) {
 	app, _ := newCmdApp(t)
 	fake := &fakeLoginSource{}
-	app.oauthSources["oauth-srv"] = fake
+	app.servers.oauth["oauth-srv"] = fake
 
 	if !app.canLogin("oauth-srv") || app.canLogin("bare-srv") {
 		t.Fatalf("canLogin: oauth-srv=%v bare-srv=%v", app.canLogin("oauth-srv"), app.canLogin("bare-srv"))

--- a/agent/host/eventlog_test.go
+++ b/agent/host/eventlog_test.go
@@ -13,11 +13,11 @@ import (
 // This is what lets a web surface (issue 1196) join a running session and see
 // its history.
 func TestEventLog_RetainsForLateReplay(t *testing.T) {
-	a := &App{eventLog: gocurrent.NewQueue[HostEvent]()}
+	a := &App{events: &eventSpine{log: gocurrent.NewQueue[HostEvent]()}}
 	a.emit(HostEvent{Kind: HostSessionWarn, Err: "0"})
 	a.emit(HostEvent{Kind: HostSessionWarn, Err: "1"})
 
-	sub := a.eventLog.Subscribe() // subscribes late, after "0" and "1"
+	sub := a.events.log.Subscribe() // subscribes late, after "0" and "1"
 	defer sub.Close()
 
 	a.emit(HostEvent{Kind: HostSessionWarn, Err: "2"})
@@ -28,7 +28,7 @@ func TestEventLog_RetainsForLateReplay(t *testing.T) {
 		t.Fatal("late subscriber was not notified of the live event")
 	}
 
-	evs, _ := a.eventLog.ReadFrom(0)
+	evs, _ := a.events.log.ReadFrom(0)
 	got := make([]string, len(evs))
 	for i := range evs {
 		got[i] = evs[i].Err
@@ -44,7 +44,7 @@ func TestEventLog_RetainsForLateReplay(t *testing.T) {
 // wait), and the same events land on the retained log.
 func TestEmit_DeliversToLocalObserversSynchronously(t *testing.T) {
 	rec := &recordObserver{}
-	a := &App{eventLog: gocurrent.NewQueue[HostEvent](), observers: []Observer{rec}}
+	a := &App{events: &eventSpine{log: gocurrent.NewQueue[HostEvent](), observers: []Observer{rec}}}
 
 	want := []HostEventKind{HostRunnerEvent, HostTurnDone, HostSessionWarn}
 	for _, k := range want {
@@ -54,7 +54,7 @@ func TestEmit_DeliversToLocalObserversSynchronously(t *testing.T) {
 	if got := rec.kinds(); !reflect.DeepEqual(got, want) {
 		t.Fatalf("observer order = %v, want %v", got, want)
 	}
-	if n := a.eventLog.Len(); n != len(want) {
+	if n := a.events.log.Len(); n != len(want) {
 		t.Fatalf("retained log length = %d, want %d", n, len(want))
 	}
 }

--- a/agent/host/events.go
+++ b/agent/host/events.go
@@ -19,14 +19,14 @@ import (
 // gocurrent's FanIn. Per-stream buffers isolate backpressure: one noisy stream
 // drops its own events (warned), never a sibling's.
 func (a *App) onServerEvents(sc ServerConfig) {
-	if a.fanIn == nil || len(sc.Events) == 0 {
+	if a.streams.fanIn == nil || len(sc.Events) == 0 {
 		return
 	}
 	// Called from the ready-observer, so a server that connects after boot has
 	// its event streams subscribed with no restart. openSubscription is
 	// idempotent (dedup by server:name), and a failure degrades to a warning.
 	for _, ec := range sc.Events {
-		if _, err := a.openSubscription(a.evCtx, sc.ID, ec.Name); err != nil {
+		if _, err := a.openSubscription(a.streams.ctx, sc.ID, ec.Name); err != nil {
 			a.emit(HostEvent{Kind: HostSessionWarn, Err: fmt.Sprintf("events/stream %s on %s: %v", ec.Name, sc.ID, err)})
 		}
 	}
@@ -41,7 +41,7 @@ func (a *App) consumeEvents(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
-		case ev, ok := <-a.fanIn.OutputChan():
+		case ev, ok := <-a.streams.fanIn.OutputChan():
 			if !ok {
 				return
 			}

--- a/agent/host/eventspine.go
+++ b/agent/host/eventspine.go
@@ -1,0 +1,56 @@
+package host
+
+import (
+	"sync"
+	"sync/atomic"
+
+	gocurrent "github.com/panyam/gocurrent"
+)
+
+// eventSpine is the per-session event backbone: the retained log every surface
+// reads from, the synchronous local observers, and the offset marking how much
+// of the log the RunStore already holds.
+//
+// The three belong together because replay is stitched from two sources that
+// must agree. log covers [persisted, len) in memory; the RunStore covers
+// [0, persisted). Reading them as a consistent pair is what rules out both the
+// duplicate and the gap a two-step read would race — see Subscribe, which takes
+// that snapshot under turnMu.
+//
+// The Queue itself stays reachable as log rather than being wrapped in
+// delegating methods. Its barrier semantics (Resolve, AwaitResolution) carry
+// the multi-surface ask protocol, and hiding them behind pass-throughs would
+// obscure the contract callers actually reason about.
+type eventSpine struct {
+	log *gocurrent.Queue[HostEvent]
+
+	// mu serializes local delivery only. The async server connections, the
+	// turn goroutine, and the event goroutines all emit, and the terminal
+	// renderer is not concurrency-safe.
+	mu        sync.Mutex
+	observers []Observer
+
+	// persisted is the log offset through which this run's events have been
+	// written to the RunStore. Advanced at the turn-end persist site once
+	// AppendEvents succeeds; read lock-free by Subscribe. Stays 0 when no
+	// RunStore is configured, so replay falls back to the whole window.
+	persisted atomic.Int64
+}
+
+// emit records an event on the retained log and delivers it synchronously to
+// every local observer, returning the offset it landed at.
+//
+// The append happens before the fan-out and outside the lock: the log is the
+// source of truth a web surface subscribes onto, so it must record the event
+// even if an observer blocks. The synchronous fan-out preserves the terminal
+// rendering contract — a caller reading the renderer's io.Writer sees the event
+// once emit returns.
+func (s *eventSpine) emit(ev HostEvent) (offset int) {
+	offset = s.log.Append(ev)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, o := range s.observers {
+		o.On(ev)
+	}
+	return offset
+}

--- a/agent/host/memory.go
+++ b/agent/host/memory.go
@@ -33,8 +33,8 @@ func (a *App) registerMemory(multi *agent.MultiSource, store agent.MemoryStore) 
 		// currentRunID is lock-free: it runs during a turn while turnMu is
 		// already held (both the memory tools and the summary/recall injection),
 		// so RunID would deadlock here.
-		opts = append(opts, agent.WithMemoryNamespaceFunc(a.currentRunID))
-		if a.store == nil {
+		opts = append(opts, agent.WithMemoryNamespaceFunc(a.session.currentRunID))
+		if a.session.store == nil {
 			a.log.Warn("host: memory sessionScoped is set but no RunStore is configured; every session shares the default scratchpad (add WithRunStore / --session-store to isolate)")
 		}
 	}

--- a/agent/host/memory_session_scope_test.go
+++ b/agent/host/memory_session_scope_test.go
@@ -32,7 +32,7 @@ func TestCurrentRunIDLockFree(t *testing.T) {
 	app.turnMu.Lock()
 	defer app.turnMu.Unlock()
 	done := make(chan string, 1)
-	go func() { done <- app.currentRunID() }()
+	go func() { done <- app.session.currentRunID() }()
 	select {
 	case got := <-done:
 		if got != "r1" {

--- a/agent/host/metatools.go
+++ b/agent/host/metatools.go
@@ -139,9 +139,7 @@ func (a *App) registerMetaTools(multi *agent.MultiSource) error {
 	if err := agent.AddFunc(fs, "cancel_task",
 		"Cancel a running background task by its id.",
 		func(ctx context.Context, in cancelReq) (string, error) {
-			a.tasksMu.Lock()
-			bt := a.bgTasks[in.ID]
-			a.tasksMu.Unlock()
+			bt := a.tasks.get(in.ID)
 			if bt == nil {
 				return "", fmt.Errorf("no running task %q", in.ID)
 			}

--- a/agent/host/persistence.go
+++ b/agent/host/persistence.go
@@ -39,28 +39,7 @@ func WithProviderBuilder(b ProviderBuilder) AppOption {
 func (a *App) RunID() string {
 	a.turnMu.Lock()
 	defer a.turnMu.Unlock()
-	return a.runID
-}
-
-// setRunID updates the active run id and its lock-free mirror together.
-// Caller holds turnMu (every write site does). Routing all four writers
-// (AttachRun, resumeLocked, Fork, ensureRunLocked) through here keeps
-// runIDAtomic from drifting out of sync with runID.
-func (a *App) setRunID(id string) {
-	a.runID = id
-	a.runIDAtomic.Store(id)
-}
-
-// currentRunID reads the active run id WITHOUT taking turnMu, so it is
-// safe to call from inside a turn (the memory namespace func runs while
-// RunTurn already holds turnMu — RunID would deadlock there). Returns ""
-// before any run is set, which the session-scoped namespace func maps to
-// the shared default scratchpad (the same as unscoped memory).
-func (a *App) currentRunID() string {
-	if v := a.runIDAtomic.Load(); v != nil {
-		return v.(string)
-	}
-	return ""
+	return a.session.runID
 }
 
 // AttachRun binds the session to runID with create-or-resume semantics:
@@ -71,15 +50,15 @@ func (a *App) currentRunID() string {
 func (a *App) AttachRun(ctx context.Context, runID string) error {
 	a.turnMu.Lock()
 	defer a.turnMu.Unlock()
-	if a.store == nil {
+	if a.session.store == nil {
 		return fmt.Errorf("host: no RunStore configured")
 	}
-	resp, err := a.store.CreateRun(ctx, agent.CreateRunRequest{RunID: runID})
+	resp, err := a.session.store.CreateRun(ctx, agent.CreateRunRequest{RunID: runID})
 	if err != nil {
 		return fmt.Errorf("host: attaching run %q: %w", runID, err)
 	}
 	if resp.Created {
-		a.setRunID(resp.RunID)
+		a.session.setRunID(resp.RunID)
 		a.history = nil
 		return nil
 	}
@@ -114,25 +93,21 @@ type SessionPage struct {
 // without the surface handling the opaque cursor. Errors when no RunStore is
 // configured.
 func (a *App) SessionsPage(ctx context.Context, cursor string) (SessionPage, error) {
-	if a.store == nil {
+	if a.session.store == nil {
 		return SessionPage{}, fmt.Errorf("host: no RunStore configured")
 	}
-	resp, err := a.store.ListRuns(ctx, agent.ListRunsRequest{Cursor: cursor})
+	resp, err := a.session.store.ListRuns(ctx, agent.ListRunsRequest{Cursor: cursor})
 	if err != nil {
 		return SessionPage{}, fmt.Errorf("host: listing sessions: %w", err)
 	}
-	a.sessionsMu.Lock()
-	a.sessionsCursor = resp.NextCursor
-	a.sessionsMu.Unlock()
+	a.session.rememberCursor(resp.NextCursor)
 	return SessionPage{Runs: resp.Runs, HasMore: resp.NextCursor != ""}, nil
 }
 
 // PageMore returns the next page after the last SessionsPage call (the
 // /sessions "more" flow), or an empty page when there is nothing more.
 func (a *App) PageMore(ctx context.Context) (SessionPage, error) {
-	a.sessionsMu.Lock()
-	cursor := a.sessionsCursor
-	a.sessionsMu.Unlock()
+	cursor := a.session.nextCursor()
 	if cursor == "" {
 		return SessionPage{}, nil
 	}
@@ -149,7 +124,7 @@ const maxSessionSearchScan = 1000
 // bounded, so a match past the cap is not found — a deliberate limit until a
 // real search index exists.
 func (a *App) SearchSessions(ctx context.Context, query string) ([]agent.RunInfo, error) {
-	if a.store == nil {
+	if a.session.store == nil {
 		return nil, fmt.Errorf("host: no RunStore configured")
 	}
 	q := strings.ToLower(query)
@@ -157,7 +132,7 @@ func (a *App) SearchSessions(ctx context.Context, query string) ([]agent.RunInfo
 	cursor := ""
 	scanned := 0
 	for scanned < maxSessionSearchScan {
-		resp, err := a.store.ListRuns(ctx, agent.ListRunsRequest{Cursor: cursor})
+		resp, err := a.session.store.ListRuns(ctx, agent.ListRunsRequest{Cursor: cursor})
 		if err != nil {
 			return nil, fmt.Errorf("host: searching sessions: %w", err)
 		}
@@ -182,14 +157,14 @@ func (a *App) SearchSessions(ctx context.Context, query string) ([]agent.RunInfo
 func (a *App) Resume(ctx context.Context, runID string) error {
 	a.turnMu.Lock()
 	defer a.turnMu.Unlock()
-	if a.store == nil {
+	if a.session.store == nil {
 		return fmt.Errorf("host: no RunStore configured")
 	}
 	return a.resumeLocked(ctx, runID)
 }
 
 func (a *App) resumeLocked(ctx context.Context, runID string) error {
-	resp, err := a.store.LoadRun(ctx, agent.LoadRunRequest{RunID: runID})
+	resp, err := a.session.store.LoadRun(ctx, agent.LoadRunRequest{RunID: runID})
 	if err != nil {
 		return fmt.Errorf("host: loading run %q: %w", runID, err)
 	}
@@ -197,7 +172,7 @@ func (a *App) resumeLocked(ctx context.Context, runID string) error {
 		return fmt.Errorf("host: run %q not found", runID)
 	}
 	a.history = resp.Run.Messages
-	a.setRunID(runID)
+	a.session.setRunID(runID)
 	return nil
 }
 
@@ -212,18 +187,18 @@ func (a *App) resumeLocked(ctx context.Context, runID string) error {
 func (a *App) Fork(ctx context.Context, newRunID string, atMessage int) (string, error) {
 	a.turnMu.Lock()
 	defer a.turnMu.Unlock()
-	if a.store == nil {
+	if a.session.store == nil {
 		return "", fmt.Errorf("host: no RunStore configured")
 	}
-	if a.runID == "" {
+	if a.session.runID == "" {
 		return "", fmt.Errorf("host: no active run to fork (run at least one turn first)")
 	}
-	resp, err := a.store.ForkRun(ctx, agent.ForkRunRequest{RunID: a.runID, NewRunID: newRunID, AtMessage: atMessage})
+	resp, err := a.session.store.ForkRun(ctx, agent.ForkRunRequest{RunID: a.session.runID, NewRunID: newRunID, AtMessage: atMessage})
 	if err != nil {
-		return "", fmt.Errorf("host: forking run %q: %w", a.runID, err)
+		return "", fmt.Errorf("host: forking run %q: %w", a.session.runID, err)
 	}
 	if !resp.Found {
-		return "", fmt.Errorf("host: run %q not found", a.runID)
+		return "", fmt.Errorf("host: run %q not found", a.session.runID)
 	}
 	if !resp.Created {
 		return "", fmt.Errorf("host: run %q already exists", newRunID)
@@ -231,21 +206,21 @@ func (a *App) Fork(ctx context.Context, newRunID string, atMessage int) (string,
 	if atMessage > 0 {
 		return resp.RunID, a.resumeLocked(ctx, resp.RunID)
 	}
-	a.setRunID(resp.RunID)
+	a.session.setRunID(resp.RunID)
 	return resp.RunID, nil
 }
 
 // ensureRunLocked lazily creates the session's run before the first
 // persisted turn. Caller holds turnMu.
 func (a *App) ensureRunLocked(ctx context.Context) error {
-	if a.runID != "" {
+	if a.session.runID != "" {
 		return nil
 	}
-	resp, err := a.store.CreateRun(ctx, agent.CreateRunRequest{})
+	resp, err := a.session.store.CreateRun(ctx, agent.CreateRunRequest{})
 	if err != nil {
 		return fmt.Errorf("host: creating run: %w", err)
 	}
-	a.setRunID(resp.RunID)
+	a.session.setRunID(resp.RunID)
 	a.emit(HostEvent{Kind: HostSessionChanged, RunID: resp.RunID})
 	return nil
 }
@@ -256,11 +231,11 @@ func (a *App) ensureRunLocked(ctx context.Context) error {
 // and the in-memory session stays usable; only durability degraded.
 // Caller holds turnMu.
 func (a *App) persistTurnLocked(ctx context.Context, msgs []agent.Message, pe *PersistingEmit) {
-	resp, err := a.store.AppendMessages(ctx, agent.AppendMessagesRequest{RunID: a.runID, Messages: msgs})
+	resp, err := a.session.store.AppendMessages(ctx, agent.AppendMessagesRequest{RunID: a.session.runID, Messages: msgs})
 	if err != nil {
 		a.emit(HostEvent{Kind: HostSessionWarn, Err: err.Error()})
 	} else if !resp.Found {
-		a.emit(HostEvent{Kind: HostSessionWarn, Err: fmt.Sprintf("run %q disappeared from the store", a.runID)})
+		a.emit(HostEvent{Kind: HostSessionWarn, Err: fmt.Sprintf("run %q disappeared from the store", a.session.runID)})
 	}
 	if err := pe.Flush(ctx); err != nil {
 		a.emit(HostEvent{Kind: HostSessionWarn, Err: err.Error()})
@@ -273,7 +248,7 @@ func (a *App) persistTurnLocked(ctx context.Context, msgs []agent.Message, pe *P
 	// on a successful Flush keeps unpersisted events in the Queue-tail half of
 	// the replay (no gap). eventLog.Len() is the absolute offset space, so this
 	// stays correct under a bounded (evicting) log.
-	a.persistedOffset.Store(int64(a.eventLog.Len()))
+	a.events.persisted.Store(int64(a.events.log.Len()))
 }
 
 // PersistingEmit tees a Runner event stream into a RunStore event log.

--- a/agent/host/serverset.go
+++ b/agent/host/serverset.go
@@ -1,0 +1,109 @@
+package host
+
+import (
+	"context"
+	"sync"
+
+	gocurrent "github.com/panyam/gocurrent"
+	"github.com/panyam/mcpkit/agent"
+	"github.com/panyam/mcpkit/client"
+	eventsclient "github.com/panyam/mcpkit/experimental/ext/events/clients/go"
+)
+
+// serverSet is the connected MCP servers: the Group that owns their
+// connection lifecycle, the clients it drives, the persona-visible mirror of
+// their tools, and the interactive token sources that make /login possible.
+//
+// Held by value; every field is zero-value usable, and a nil group means
+// construction failed before the Group existed (Close checks for exactly
+// that).
+type serverSet struct {
+	// group owns the connection lifecycle: async connect, per-server state,
+	// backoff reconnect. Its observer registers a server's tools when it
+	// becomes ready. See docs/AGENT_SERVER_STATE.md.
+	group   *client.Group
+	clients []*client.Client
+
+	// tools mirrors the server sources only, with no meta-tools and no
+	// sub-agents, so a persona gets a filtered view of the servers without
+	// seeing the other personas (which would let it recurse). Nil unless
+	// personas are configured.
+	tools *agent.MultiSource
+
+	// oauth holds the interactive token source per server id, so LoginServer
+	// can force a fresh browser login. Only oauth-typed servers have an entry,
+	// and its presence is what CanLogin reports.
+	oauth map[string]loginSource
+}
+
+// canLogin reports whether the server has an interactive token source.
+func (s *serverSet) canLogin(id string) bool { return s.oauth[id] != nil }
+
+// streamSet is the inbound event plumbing: the live subscriptions, the fan-in
+// that merges every server's stream into one channel, and the context that
+// bounds them all.
+//
+// Separate from serverSet despite being per-server, because the lifecycles
+// differ. Connections come up and go down on the Group's schedule and outlive
+// any single subscription; the streams exist only when the async control plane
+// is on (metaTools), and Close stops them before the Group. Merging the two
+// would put a conditional half inside an unconditional whole.
+type streamSet struct {
+	mu   sync.Mutex
+	subs map[string]*subscription
+
+	calls []*eventsclient.StreamCall
+
+	// fanIn merges every subscription into one channel the consumer drains.
+	// Nil when the async control plane is off.
+	fanIn *gocurrent.FanIn[agent.IncomingEvent]
+
+	// ctx bounds every subscription. Built before the servers connect, so the
+	// ready-observer can subscribe a late server the moment it arrives; stop
+	// cancels them all.
+	ctx  context.Context
+	stop context.CancelFunc
+}
+
+// add registers a live subscription. Reports false when the id is already
+// taken, which is the caller's cue that the subscription already exists.
+func (s *streamSet) add(sub *subscription) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.subs[sub.id]; exists {
+		return false
+	}
+	s.subs[sub.id] = sub
+	return true
+}
+
+// take removes and returns a subscription, or nil when it is unknown.
+func (s *streamSet) take(id string) *subscription {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	sub, ok := s.subs[id]
+	if !ok {
+		return nil
+	}
+	delete(s.subs, id)
+	return sub
+}
+
+// has reports whether the id is already subscribed.
+func (s *streamSet) has(id string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, ok := s.subs[id]
+	return ok
+}
+
+// all snapshots the live subscriptions.
+func (s *streamSet) all() []*subscription {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*subscription, 0, len(s.subs))
+	for _, sub := range s.subs {
+		out = append(out, sub)
+	}
+	return out
+}

--- a/agent/host/sessionstate.go
+++ b/agent/host/sessionstate.go
@@ -1,0 +1,79 @@
+package host
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"github.com/panyam/mcpkit/agent"
+)
+
+// sessionState is the persistence half of a session: where runs are stored,
+// which run is active, and where the /sessions picker last paged to.
+//
+// Locking here is deliberately not uniform, because the state is not.
+//
+//   - store is set once at construction and read-only afterwards.
+//   - runID is guarded by the App's turnMu, not by anything here. It changes
+//     only at points a turn already owns (attach, resume, fork, lazy create),
+//     so giving it a second lock would add a hierarchy without removing a
+//     race. runIDAtomic mirrors it for readers that cannot take turnMu.
+//   - cursor has its own mutex because paging is a UI action unrelated to a
+//     turn and can arrive while one is running.
+//
+// Held by value on App rather than by pointer, because every field is
+// zero-value usable: a nil store is "persistence off", and the rest are a
+// string, an atomic, and a mutex. That keeps a partially-constructed App
+// (which the tests build freely) working instead of panicking on a nil
+// cluster — the failure mode a pointer would introduce for no gain. Never
+// copy it; the mutex and atomic make a copy meaningless.
+type sessionState struct {
+	store agent.RunStore
+
+	// runID is the run turns append to. Guarded by App.turnMu; write through
+	// setRunID so the atomic mirror stays in step.
+	runID string
+
+	// runIDAtomic mirrors runID for a lock-free read. The session-scoped
+	// memory namespace func reads it during a turn while turnMu is already
+	// held, so it must not go through anything that takes turnMu.
+	runIDAtomic atomic.Value
+
+	cursorMu sync.Mutex
+	cursor   string
+}
+
+// setRunID updates the active run id and its lock-free mirror together.
+// Caller holds turnMu (every write site does). Routing all four writers
+// (AttachRun, resumeLocked, Fork, ensureRunLocked) through here keeps the
+// mirror from drifting out of sync.
+func (s *sessionState) setRunID(id string) {
+	s.runID = id
+	s.runIDAtomic.Store(id)
+}
+
+// currentRunID reads the active run id WITHOUT taking turnMu, so it is safe
+// to call from inside a turn (the memory namespace func runs while RunTurn
+// already holds turnMu — a locking read would deadlock there). Returns ""
+// before any run is set, which the session-scoped namespace func maps to the
+// shared default scratchpad.
+func (s *sessionState) currentRunID() string {
+	if v := s.runIDAtomic.Load(); v != nil {
+		return v.(string)
+	}
+	return ""
+}
+
+// rememberCursor records where the last /sessions page ended, so "more" can
+// advance. The store's cursor is opaque, which is why the host holds it.
+func (s *sessionState) rememberCursor(c string) {
+	s.cursorMu.Lock()
+	defer s.cursorMu.Unlock()
+	s.cursor = c
+}
+
+// nextCursor returns the paging position, empty when there is no more.
+func (s *sessionState) nextCursor() string {
+	s.cursorMu.Lock()
+	defer s.cursorMu.Unlock()
+	return s.cursor
+}

--- a/agent/host/skills.go
+++ b/agent/host/skills.go
@@ -252,22 +252,7 @@ func (a *App) onServerSkills(sc ServerConfig, c *client.Client) {
 		a.emit(HostEvent{Kind: HostSessionWarn, Err: fmt.Sprintf("load skills for %s: %v", sc.ID, err)})
 		return
 	}
-	var collisions []string
-	a.skillsMu.Lock()
-	if block != "" {
-		a.skillBlocks[sc.ID] = block
-	}
-	if len(cat) > 0 {
-		a.skillCatalog[sc.ID] = cat
-		collisions = a.detectSkillCollisionsLocked(sc.ID)
-	}
-	// Register load_skill lazily, once, on the first catalog skill — so it never
-	// appears when no server offers catalog skills.
-	registerLoader := len(cat) > 0 && !a.loadSkillReg
-	if registerLoader {
-		a.loadSkillReg = true
-	}
-	a.skillsMu.Unlock()
+	collisions, registerLoader := a.skills.add(sc.ID, block, cat)
 
 	// Surface cross-origin name collisions (SEP-2640 SHOULD): the load_skill
 	// handler already refuses to silently shadow, but the user deserves to know.
@@ -290,14 +275,7 @@ func (a *App) onServerSkills(sc ServerConfig, c *client.Client) {
 // instructions), recomputed each turn so a late server's skills land on the next
 // turn.
 func (a *App) skillsSection(context.Context) string {
-	a.skillsMu.Lock()
-	defer a.skillsMu.Unlock()
-	var blocks []string
-	for _, id := range a.serverOrder {
-		if block := a.skillBlocks[id]; block != "" {
-			blocks = append(blocks, block)
-		}
-	}
+	blocks := a.skills.promptBlocks()
 	return strings.Join(blocks, "\n\n")
 }
 
@@ -311,51 +289,8 @@ func (a *App) defaultPromptBuilder() *SystemPromptBuilder {
 	}}
 }
 
-// detectSkillCollisionsLocked returns one human-readable line per catalog-skill
-// name from server newID that another connected origin also serves — the
-// cross-origin collisions SEP-2640 asks hosts to surface. Names are reported
-// once each; callers hold skillsMu.
-func (a *App) detectSkillCollisionsLocked(newID string) []string {
-	var out []string
-	seenName := map[string]struct{}{}
-	for _, cs := range a.skillCatalog[newID] {
-		name := cs.entry.Name
-		if name == "" {
-			continue
-		}
-		if _, dup := seenName[name]; dup {
-			continue
-		}
-		seenName[name] = struct{}{}
-		var others []string
-		for id, entries := range a.skillCatalog {
-			if id == newID {
-				continue
-			}
-			for _, e := range entries {
-				if e.entry.Name == name {
-					others = append(others, id)
-					break
-				}
-			}
-		}
-		if len(others) > 0 {
-			sort.Strings(others)
-			out = append(out, fmt.Sprintf("%q served by %s and %s", name, newID, strings.Join(others, ", ")))
-		}
-	}
-	sort.Strings(out)
-	return out
-}
-
 // allCatalogSkills flattens every connected server's catalog entries, in config
 // order, for the load_skill lookup.
 func (a *App) allCatalogSkills() []catalogSkill {
-	a.skillsMu.Lock()
-	defer a.skillsMu.Unlock()
-	var out []catalogSkill
-	for _, id := range a.serverOrder {
-		out = append(out, a.skillCatalog[id]...)
-	}
-	return out
+	return a.skills.allCatalog()
 }

--- a/agent/host/skills_test.go
+++ b/agent/host/skills_test.go
@@ -92,9 +92,12 @@ func TestFilterSkillsAllow(t *testing.T) {
 // is what makes a late server's eager skills appear on the next turn.
 func TestBuildInstructions(t *testing.T) {
 	a := &App{
-		cfg:         &Config{Instructions: "base"},
-		skillBlocks: map[string]string{"s1": "block1", "s2": "block2"},
-		serverOrder: []string{"s1", "s2"},
+		cfg: &Config{Instructions: "base"},
+		skills: &skillSet{
+			blocks:  map[string]string{"s1": "block1", "s2": "block2"},
+			catalog: map[string][]catalogSkill{},
+			order:   []string{"s1", "s2"},
+		},
 	}
 	build := func() string { return a.defaultPromptBuilder().Build(context.Background()) }
 
@@ -102,13 +105,13 @@ func TestBuildInstructions(t *testing.T) {
 		t.Fatalf("got %q", got)
 	}
 	// order follows serverOrder, not map iteration
-	a.serverOrder = []string{"s2", "s1"}
+	a.skills.order = []string{"s2", "s1"}
 	if got := build(); got != "base\n\nblock2\n\nblock1" {
 		t.Fatalf("order must follow serverOrder: %q", got)
 	}
 	// a server with no block yet is skipped
-	a.skillBlocks = map[string]string{"s1": "only1"}
-	a.serverOrder = []string{"s1", "s2"}
+	a.skills.blocks = map[string]string{"s1": "only1"}
+	a.skills.order = []string{"s1", "s2"}
 	if got := build(); got != "base\n\nonly1" {
 		t.Fatalf("empty block must be skipped: %q", got)
 	}
@@ -117,13 +120,14 @@ func TestBuildInstructions(t *testing.T) {
 // TestAllCatalogSkills covers the live load_skill catalog: every connected
 // server's entries flattened in config order.
 func TestAllCatalogSkills(t *testing.T) {
-	a := &App{
-		skillCatalog: map[string][]catalogSkill{
+	a := &App{skills: &skillSet{
+		blocks: map[string]string{},
+		catalog: map[string][]catalogSkill{
 			"s1": {{serverID: "s1", entry: skills.IndexEntry{Name: "a"}}},
 			"s2": {{serverID: "s2", entry: skills.IndexEntry{Name: "b"}}},
 		},
-		serverOrder: []string{"s1", "s2"},
-	}
+		order: []string{"s1", "s2"},
+	}}
 	got := a.allCatalogSkills()
 	if len(got) != 2 || got[0].entry.Name != "a" || got[1].entry.Name != "b" {
 		t.Fatalf("flatten order wrong: %+v", got)
@@ -131,11 +135,11 @@ func TestAllCatalogSkills(t *testing.T) {
 }
 
 func TestRegisterLoadSkill(t *testing.T) {
-	app := &App{
-		skillBlocks:  map[string]string{},
-		skillCatalog: map[string][]catalogSkill{"s": {{serverID: "s", entry: skills.IndexEntry{Name: "alpha", URL: "skill://a/SKILL.md"}}}},
-		serverOrder:  []string{"s"},
-	}
+	app := &App{skills: &skillSet{
+		blocks:  map[string]string{},
+		catalog: map[string][]catalogSkill{"s": {{serverID: "s", entry: skills.IndexEntry{Name: "alpha", URL: "skill://a/SKILL.md"}}}},
+		order:   []string{"s"},
+	}}
 	multi := agent.NewMultiSource()
 	if err := app.registerLoadSkill(multi); err != nil {
 		t.Fatal(err)
@@ -245,14 +249,14 @@ func TestResolveCatalogSkill(t *testing.T) {
 func TestLoadSkillCollisionNoSilentShadow(t *testing.T) {
 	// Two servers serve "deploy"; client is nil so any attempt to read (silent
 	// shadow) would panic — proving the handler stops at disambiguation.
-	app := &App{
-		skillBlocks: map[string]string{},
-		skillCatalog: map[string][]catalogSkill{
+	app := &App{skills: &skillSet{
+		blocks: map[string]string{},
+		catalog: map[string][]catalogSkill{
 			"alpha": {{serverID: "alpha", entry: skills.IndexEntry{Name: "deploy", URL: "skill://alpha/deploy"}}},
 			"beta":  {{serverID: "beta", entry: skills.IndexEntry{Name: "deploy", URL: "skill://beta/deploy"}}},
 		},
-		serverOrder: []string{"alpha", "beta"},
-	}
+		order: []string{"alpha", "beta"},
+	}}
 	multi := agent.NewMultiSource()
 	if err := app.registerLoadSkill(multi); err != nil {
 		t.Fatal(err)
@@ -268,17 +272,17 @@ func TestLoadSkillCollisionNoSilentShadow(t *testing.T) {
 }
 
 func TestDetectSkillCollisionsLocked(t *testing.T) {
-	a := &App{skillCatalog: map[string][]catalogSkill{
+	a := &App{skills: &skillSet{catalog: map[string][]catalogSkill{
 		"a": {{serverID: "a", entry: skills.IndexEntry{Name: "deploy"}}, {serverID: "a", entry: skills.IndexEntry{Name: "lint"}}},
 		"b": {{serverID: "b", entry: skills.IndexEntry{Name: "deploy"}}},
-	}}
-	got := a.detectSkillCollisionsLocked("b")
+	}}}
+	got := a.skills.collisionsLocked("b")
 	if len(got) != 1 || !strings.Contains(got[0], `"deploy"`) || !strings.Contains(got[0], "a") {
 		t.Fatalf("expected a deploy collision with server a: %v", got)
 	}
 	// a server whose names are all unique reports nothing
-	a.skillCatalog["c"] = []catalogSkill{{serverID: "c", entry: skills.IndexEntry{Name: "unique"}}}
-	if got := a.detectSkillCollisionsLocked("c"); got != nil {
+	a.skills.catalog["c"] = []catalogSkill{{serverID: "c", entry: skills.IndexEntry{Name: "unique"}}}
+	if got := a.skills.collisionsLocked("c"); got != nil {
 		t.Fatalf("no collision expected: %v", got)
 	}
 }

--- a/agent/host/skillset.go
+++ b/agent/host/skillset.go
@@ -1,0 +1,126 @@
+package host
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// skillSet holds every connected server's loaded skills: the system-prompt
+// block a server contributes, its catalog entries for load_skill, and the
+// config order the two are rendered in.
+//
+// These four moved together because they are read together and were always
+// guarded by one mutex. Ordering is the reason the server list lives here
+// rather than beside the connection state: both the prompt block and the
+// catalog are assembled in config order, so the order is a property of how
+// skills render, not of how servers connect.
+//
+// Skills load in the ready-observer, which fires for late servers too, so
+// this is shared mutable state read live by the per-turn prompt builder.
+type skillSet struct {
+	mu      sync.Mutex
+	blocks  map[string]string         // serverID -> system-prompt block
+	catalog map[string][]catalogSkill // serverID -> catalog entries
+	order   []string                  // serverIDs in config order
+	loader  bool                      // load_skill registered once, lazily
+}
+
+func newSkillSet() *skillSet {
+	return &skillSet{
+		blocks:  map[string]string{},
+		catalog: map[string][]catalogSkill{},
+	}
+}
+
+// track records a server in config order, before it has loaded anything.
+func (s *skillSet) track(serverID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.order = append(s.order, serverID)
+}
+
+// add stores one server's loaded skills and reports the cross-origin name
+// collisions this addition created, plus whether load_skill still needs
+// registering. Both are returned rather than acted on here: registering a tool
+// and emitting warnings are the App's business, and doing them under this lock
+// would widen it past the state it protects.
+func (s *skillSet) add(serverID, block string, cat []catalogSkill) (collisions []string, registerLoader bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if block != "" {
+		s.blocks[serverID] = block
+	}
+	if len(cat) > 0 {
+		s.catalog[serverID] = cat
+		collisions = s.collisionsLocked(serverID)
+	}
+	// Lazily, once, on the first catalog skill — so load_skill never appears
+	// when no server offers one.
+	if len(cat) > 0 && !s.loader {
+		s.loader = true
+		registerLoader = true
+	}
+	return collisions, registerLoader
+}
+
+// promptBlocks returns each connected server's skill block in config order.
+func (s *skillSet) promptBlocks() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []string
+	for _, id := range s.order {
+		if block := s.blocks[id]; block != "" {
+			out = append(out, block)
+		}
+	}
+	return out
+}
+
+// allCatalog flattens every server's catalog entries in config order.
+func (s *skillSet) allCatalog() []catalogSkill {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []catalogSkill
+	for _, id := range s.order {
+		out = append(out, s.catalog[id]...)
+	}
+	return out
+}
+
+// collisionsLocked reports names newID serves that another connected origin
+// also serves — the cross-origin collisions SEP-2640 asks hosts to surface.
+// Each name is reported once. Callers hold mu.
+func (s *skillSet) collisionsLocked(newID string) []string {
+	var out []string
+	seenName := map[string]struct{}{}
+	for _, cs := range s.catalog[newID] {
+		name := cs.entry.Name
+		if name == "" {
+			continue
+		}
+		if _, dup := seenName[name]; dup {
+			continue
+		}
+		seenName[name] = struct{}{}
+		var others []string
+		for id, entries := range s.catalog {
+			if id == newID {
+				continue
+			}
+			for _, e := range entries {
+				if e.entry.Name == name {
+					others = append(others, id)
+					break
+				}
+			}
+		}
+		if len(others) > 0 {
+			sort.Strings(others)
+			out = append(out, fmt.Sprintf("%q served by %s and %s", name, newID, strings.Join(others, ", ")))
+		}
+	}
+	sort.Strings(out)
+	return out
+}

--- a/agent/host/subagents.go
+++ b/agent/host/subagents.go
@@ -45,7 +45,7 @@ func preemptGrantFor(allow bool) func(agent.Signal) bool {
 // location is not guaranteed, so shared parent memory would assume a
 // co-location that A2 wire-serializability forbids; parent-to-child is params +
 // injection only. A child that needs memory owns its own (its Runner's config),
-// never a WithMemoryNamespaceFunc(a.currentRunID) into the parent's namespace.
+// never a WithMemoryNamespaceFunc(a.session.currentRunID) into the parent's namespace.
 // Guarded by TestSubAgentCannotReachParentMemory.
 func (a *App) registerSubAgents(multi, serverTools *agent.MultiSource, provider agent.Provider, tp core.TracerProvider, mp core.MeterProvider) error {
 	for _, sub := range a.cfg.SubAgents {

--- a/agent/host/subscribe.go
+++ b/agent/host/subscribe.go
@@ -66,15 +66,15 @@ func (a *App) Subscribe(ctx context.Context) <-chan HostEvent {
 	// after this point wakes the subscription (and is also picked up by the tail
 	// read, harmlessly re-signalled); any Append before it is already in the tail.
 	a.turnMu.Lock()
-	sub := a.eventLog.Subscribe()
-	p := int(a.persistedOffset.Load())
+	sub := a.events.log.Subscribe()
+	p := int(a.events.persisted.Load())
 	var deep []agent.Event
-	if a.store != nil && a.runID != "" && p > 0 {
-		if resp, err := a.store.LoadRun(ctx, agent.LoadRunRequest{RunID: a.runID}); err == nil && resp.Found {
+	if a.session.store != nil && a.session.runID != "" && p > 0 {
+		if resp, err := a.session.store.LoadRun(ctx, agent.LoadRunRequest{RunID: a.session.runID}); err == nil && resp.Found {
 			deep = resp.Run.Events
 		}
 	}
-	tail, next := a.eventLog.ReadFrom(p)
+	tail, next := a.events.log.ReadFrom(p)
 	a.turnMu.Unlock()
 
 	out := make(chan HostEvent, subscribeBuffer)
@@ -107,7 +107,7 @@ func (a *App) Subscribe(ctx context.Context) <-chan HostEvent {
 			case <-ctx.Done():
 				return
 			case <-sub.Notify():
-				evs, n := a.eventLog.ReadFrom(off)
+				evs, n := a.events.log.ReadFrom(off)
 				for i, e := range evs {
 					stampAskID(&e, off+i)
 					select {

--- a/agent/host/subscribe_test.go
+++ b/agent/host/subscribe_test.go
@@ -17,14 +17,14 @@ import (
 // evict, Len keeps counting the absolute offset space, and ReadFrom(0)
 // degrades to the retained suffix (never panics, never renumbers).
 func TestEventLog_BoundedEvicts(t *testing.T) {
-	a := &App{eventLog: gocurrent.NewBoundedQueue[HostEvent](3)}
+	a := &App{events: &eventSpine{log: gocurrent.NewBoundedQueue[HostEvent](3)}}
 	for i := 0; i < 5; i++ {
 		a.emit(HostEvent{Kind: HostSessionWarn, Err: strconv.Itoa(i)})
 	}
-	if got := a.eventLog.Len(); got != 5 {
+	if got := a.events.log.Len(); got != 5 {
 		t.Fatalf("Len = %d, want 5 (absolute offset space keeps counting past eviction)", got)
 	}
-	evs, _ := a.eventLog.ReadFrom(0)
+	evs, _ := a.events.log.ReadFrom(0)
 	got := make([]string, len(evs))
 	for i := range evs {
 		got[i] = evs[i].Err
@@ -39,7 +39,7 @@ func TestEventLog_BoundedEvicts(t *testing.T) {
 // receives live events, until ctx is cancelled. This is what a web Watch RPC
 // drains onto the wire.
 func TestSubscribe_ReplayThenLive(t *testing.T) {
-	a := &App{eventLog: gocurrent.NewQueue[HostEvent]()}
+	a := &App{events: &eventSpine{log: gocurrent.NewQueue[HostEvent]()}}
 	a.emit(HostEvent{Kind: HostSessionWarn, Err: "0"})
 	a.emit(HostEvent{Kind: HostSessionWarn, Err: "1"})
 
@@ -87,7 +87,7 @@ func TestSubscribe_ReplayThenLive(t *testing.T) {
 // (Observer) and a browser (Subscribe) on one App see the same turns.
 func TestSubscribe_LocalObserverAndSubscriberSeeSameStream(t *testing.T) {
 	rec := &recordObserver{}
-	a := &App{eventLog: gocurrent.NewQueue[HostEvent](), observers: []Observer{rec}}
+	a := &App{events: &eventSpine{log: gocurrent.NewQueue[HostEvent](), observers: []Observer{rec}}}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -117,7 +117,7 @@ func TestSubscribe_LocalObserverAndSubscriberSeeSameStream(t *testing.T) {
 // RunStore, Subscribe replays the current retained window and then follows
 // live. With a bounded log the window is the un-evicted suffix.
 func TestSubscribe_NoStoreReplaysRetainedWindow(t *testing.T) {
-	a := &App{eventLog: gocurrent.NewBoundedQueue[HostEvent](2)}
+	a := &App{events: &eventSpine{log: gocurrent.NewBoundedQueue[HostEvent](2)}}
 	a.emit(HostEvent{Kind: HostSessionWarn, Err: "0"}) // evicted before Subscribe
 	a.emit(HostEvent{Kind: HostSessionWarn, Err: "1"})
 	a.emit(HostEvent{Kind: HostSessionWarn, Err: "2"})
@@ -168,10 +168,10 @@ func TestSubscribe_DeepReplayAfterEviction(t *testing.T) {
 
 	// Eviction really happened: the log counted more than the window, and the
 	// retained window is capped, so the early turns are gone from the Queue.
-	if n := app.eventLog.Len(); n <= 4 {
+	if n := app.events.log.Len(); n <= 4 {
 		t.Fatalf("expected the log to exceed the retention window, Len = %d", n)
 	}
-	if evs, _ := app.eventLog.ReadFrom(0); len(evs) > 4 {
+	if evs, _ := app.events.log.ReadFrom(0); len(evs) > 4 {
 		t.Fatalf("retained window = %d entries, want <= 4 (evicting)", len(evs))
 	}
 
@@ -202,17 +202,17 @@ func TestPersistedOffsetAdvancesAtTurnEnd(t *testing.T) {
 	}
 	t.Cleanup(app.Close)
 
-	if got := app.persistedOffset.Load(); got != 0 {
+	if got := app.events.persisted.Load(); got != 0 {
 		t.Fatalf("persistedOffset before any turn = %d, want 0", got)
 	}
 	if err := app.RunTurn(ctx, "hi"); err != nil {
 		t.Fatal(err)
 	}
-	off := app.persistedOffset.Load()
+	off := app.events.persisted.Load()
 	if off == 0 {
 		t.Fatal("persistedOffset did not advance after a persisted turn")
 	}
-	if n := int64(app.eventLog.Len()); off > n {
+	if n := int64(app.events.log.Len()); off > n {
 		t.Fatalf("persistedOffset = %d exceeds event log length %d", off, n)
 	}
 }

--- a/agent/host/subscription.go
+++ b/agent/host/subscription.go
@@ -31,12 +31,9 @@ func (a *App) openSubscription(ctx context.Context, serverID, name string) (stri
 	}
 	id := serverID + ":" + name
 
-	a.subsMu.Lock()
-	if _, exists := a.subs[id]; exists {
-		a.subsMu.Unlock()
+	if a.streams.has(id) {
 		return id, nil // idempotent: already subscribed
 	}
-	a.subsMu.Unlock()
 
 	ch, call, err := eventsclient.StreamChan(ctx, c, eventsclient.ChanStreamOptions{
 		EventName: name,
@@ -46,9 +43,7 @@ func (a *App) openSubscription(ctx context.Context, serverID, name string) (stri
 		return "", err
 	}
 
-	a.subsMu.Lock()
-	a.subs[id] = &subscription{id: id, server: serverID, name: name, call: call}
-	a.subsMu.Unlock()
+	a.streams.add(&subscription{id: id, server: serverID, name: name, call: call})
 
 	adapted := make(chan agent.IncomingEvent, 16)
 	go func() {
@@ -57,19 +52,14 @@ func (a *App) openSubscription(ctx context.Context, serverID, name string) (stri
 			adapted <- adaptEvent(serverID, ev)
 		}
 	}()
-	a.fanIn.Add(adapted)
+	a.streams.fanIn.Add(adapted)
 	return id, nil
 }
 
 // closeSubscription stops one stream. Unknown ids report false.
 func (a *App) closeSubscription(id string) bool {
-	a.subsMu.Lock()
-	sub, ok := a.subs[id]
-	if ok {
-		delete(a.subs, id)
-	}
-	a.subsMu.Unlock()
-	if !ok {
+	sub := a.streams.take(id)
+	if sub == nil {
 		return false
 	}
 	sub.call.Stop()
@@ -78,20 +68,14 @@ func (a *App) closeSubscription(id string) bool {
 
 // listSubscriptions snapshots the open subscriptions.
 func (a *App) listSubscriptions() []*subscription {
-	a.subsMu.Lock()
-	defer a.subsMu.Unlock()
-	out := make([]*subscription, 0, len(a.subs))
-	for _, s := range a.subs {
-		out = append(out, s)
-	}
-	return out
+	return a.streams.all()
 }
 
 // clientByID resolves a configured server id to its connected client, or nil.
 func (a *App) clientByID(id string) *client.Client {
 	for i, sc := range a.cfg.Servers {
 		if sc.ID == id {
-			return a.clients[i]
+			return a.servers.clients[i]
 		}
 	}
 	return nil

--- a/agent/host/tasks_bg.go
+++ b/agent/host/tasks_bg.go
@@ -14,9 +14,7 @@ import (
 // onTaskDetach registers the handle and tells the user their job moved to
 // the background.
 func (a *App) onTaskDetach(bt *client.BackgroundTask) {
-	a.tasksMu.Lock()
-	a.bgTasks[bt.TaskID] = bt
-	a.tasksMu.Unlock()
+	a.tasks.add(bt)
 	a.emit(HostEvent{Kind: HostTaskDetached, Task: bt})
 }
 
@@ -27,9 +25,7 @@ func (a *App) onTaskDetach(bt *client.BackgroundTask) {
 // "tell the user immediately" binds a trigger on task.completed; nothing is
 // hardcoded, so N finishing tasks cannot nag by default).
 func (a *App) onTaskComplete(serverID string, bt *client.BackgroundTask) {
-	a.tasksMu.Lock()
-	delete(a.bgTasks, bt.TaskID)
-	a.tasksMu.Unlock()
+	a.tasks.remove(bt.TaskID)
 	a.emit(HostEvent{Kind: HostTaskCompleted, Task: bt})
 
 	dt, err := bt.Result()
@@ -59,20 +55,12 @@ func (a *App) onTaskComplete(serverID string, bt *client.BackgroundTask) {
 
 // snapshotTasks lists running background tasks for /tasks.
 func (a *App) snapshotTasks() []*client.BackgroundTask {
-	a.tasksMu.Lock()
-	defer a.tasksMu.Unlock()
-	out := make([]*client.BackgroundTask, 0, len(a.bgTasks))
-	for _, bt := range a.bgTasks {
-		out = append(out, bt)
-	}
-	return out
+	return a.tasks.all()
 }
 
 // cancelTask services "/tasks cancel <id>".
 func (a *App) cancelTask(id string) {
-	a.tasksMu.Lock()
-	bt := a.bgTasks[id]
-	a.tasksMu.Unlock()
+	bt := a.tasks.get(id)
 	if bt == nil {
 		a.emit(HostEvent{Kind: HostMessage, Message: fmt.Sprintf("no running task %q (see /tasks)", id)})
 		return

--- a/agent/host/taskset.go
+++ b/agent/host/taskset.go
@@ -1,0 +1,59 @@
+package host
+
+import (
+	"sync"
+
+	"github.com/panyam/mcpkit/client"
+)
+
+// taskSet tracks the background tasks a turn detached, keyed by task id.
+//
+// It owns its own mutex rather than borrowing the App's, because the
+// membership it guards is unrelated to a turn: a completion poll goroutine
+// removes an entry while a turn is running, and /tasks reads the set between
+// turns. Keeping the lock here also keeps its scope honest — every path that
+// touches the map goes through a method, so there is no site that reads it
+// unlocked.
+type taskSet struct {
+	mu sync.Mutex
+	m  map[string]*client.BackgroundTask
+}
+
+func newTaskSet() *taskSet {
+	return &taskSet{m: map[string]*client.BackgroundTask{}}
+}
+
+// add registers a task that has detached to the background.
+func (t *taskSet) add(bt *client.BackgroundTask) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.m[bt.TaskID] = bt
+}
+
+// remove drops a task that has finished. Removing an unknown id is a no-op,
+// so a completion racing a cancel is safe.
+func (t *taskSet) remove(id string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.m, id)
+}
+
+// get returns the task, or nil when it is unknown — already finished, or
+// never detached.
+func (t *taskSet) get(id string) *client.BackgroundTask {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.m[id]
+}
+
+// all snapshots the running tasks. The slice is the caller's; the handles in
+// it are shared and may finish while the caller reads them.
+func (t *taskSet) all() []*client.BackgroundTask {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	out := make([]*client.BackgroundTask, 0, len(t.m))
+	for _, bt := range t.m {
+		out = append(out, bt)
+	}
+	return out
+}


### PR DESCRIPTION
Closes #1251.

## What changes

`host.App` goes from **52 fields to 32**, by grouping five clusters of related state into named sub-structs that own their own locking. No behaviour change.

## ELI12

Imagine a workshop where every tool, screw, and offcut lives loose on one bench. You can build anything, and you do — but finding the 4mm hex key means scanning the whole surface, and the only person who knows the little pile by the vice is "the subscription stuff" is whoever put it there.

`App` is that bench. It reached 52 fields honestly: with no way for a feature to live outside it (#1250 fixes that), every feature had to be poured onto the bench. So the ten fields that are really "the connected MCP servers and their event plumbing" sit interleaved with the four that are really "the event log and who reads it".

This PR puts things in labelled drawers. Nothing is thrown away and nothing behaves differently — but a mutex now sits in the same drawer as the exact thing it guards, instead of three fields away from it, and the drawer has a name that says what the invariant is.

The one genuinely interesting bit is *which* container to use. Go structs come in two flavours here: a pointer, which must be built before use, and a value, which works empty. Choosing wrong turns a harmless empty field into a crash. More on that below, because the tests caught me.

## Reviewer's guide

Read in this order. Each cluster type is self-contained; the doc comment on each carries the reasoning for why those fields belong together.

1. [agent/host/sessionstate.go](https://github.com/panyam/mcpkit/pull/1256/files#diff-da35f5fd5bfa85478b84d00caf330900fd611d01ebd9376e0b4c225f882d7d8b) — start here. Smallest type, and its doc comment carries the pointer-vs-value rule and the deliberately non-uniform locking.
2. [agent/host/serverset.go](https://github.com/panyam/mcpkit/pull/1256/files#diff-babe9097edb006ce980ce6b7bad488eb9d60ea9c173929262ad2f427648c6bf6) — the cluster this issue was about, and the one I split in two.
3. [agent/host/eventspine.go](https://github.com/panyam/mcpkit/pull/1256/files#diff-3be2343fb1050cbaef7d3399efa059f664f9a0fdb00a8da49135c3d27851bcf6) — check the argument for *not* wrapping the Queue.
4. [agent/host/taskset.go](https://github.com/panyam/mcpkit/pull/1256/files#diff-b90a6f78dea3cf3e6b7080f632b9e59b127876fda7dee31f412a91a06b3786c5) and [agent/host/skillset.go](https://github.com/panyam/mcpkit/pull/1256/files#diff-715cb661ed5aaf4e866949db17e4dac0f20efde9a3ebe1302daf6446c03e663a) — the mechanical pattern, established first.
5. [agent/host/app.go](https://github.com/panyam/mcpkit/pull/1256/files#diff-89fb8e04b6e1e9d5f7f76958490ef158dee40e2cae92d87c04b408d893c84361) — the struct itself, before and after.
6. [agent/host/subscription.go](https://github.com/panyam/mcpkit/pull/1256/files#diff-e30db8813094c6d0ae9601a6746ee2a176d06bec418aad6c3057ee4decffbb2b) — the largest behavioural rewrite: four lock/unlock blocks become four method calls.

Skim or skip: the remaining renames (`skills.go`, `persistence.go`, `events.go`, `metatools.go`, `tasks_bg.go`, `commands.go`, `ask.go`, `subscribe.go`) and every `*_test.go`, which change literals only.

## Diff groups

- **New cluster types:** `taskset.go`, `skillset.go`, `eventspine.go`, `sessionstate.go`, `serverset.go`
- **Mechanical:** field renames across `app.go`, `skills.go`, `subscription.go`, `persistence.go`, `events.go`, `metatools.go`, `tasks_bg.go`, `commands.go`, `ask.go`, `subscribe.go`
- **Tests:** literal updates only, no assertion changed

## The five clusters

| Cluster | Absorbs | Notes |
|---|---|---|
| `taskSet` | `tasksMu`, `bgTasks` | 19 call sites → 5 method calls |
| `skillSet` | `skillsMu`, `skillBlocks`, `skillCatalog`, `serverOrder`, `loadSkillReg` | `detectSkillCollisionsLocked` moves across unchanged, sorting included |
| `eventSpine` | `observers`, `emitMu`, `eventLog`, `persistedOffset` | Queue stays reachable, see below |
| `sessionState` | `store`, `runID`, `runIDAtomic`, `sessionsMu`, `sessionsCursor` | takes `setRunID` / `currentRunID` with it |
| `serverSet` + `streamSet` | `group`, `clients`, `serverTools`, `oauthSources`, `subs`, `subsMu`, `streams`, `fanIn`, `evCtx`, `eventStop` | split in two, see below |

This is **constraint C2 applied to a struct that predates it** — "consolidated entry structs over parallel maps", same argument, same benefit.

## Three judgement calls worth reviewing

**1. Pointer vs value, and the bug it caused.** I made the clusters pointers at first. `TestSubscribe_ReplayThenLive` then panicked: it builds `&App{events: ...}` with no session, which used to be fine because `store` (nil interface), `runID` (string), and `persistedOffset` (atomic) are all zero-value usable. A pointer cluster turns that harmless zero value into a nil dereference.

So the rule here is: **value when every field is zero-value usable, pointer only when construction is genuinely required.** `sessionState`, `serverSet`, and `streamSet` are values; `taskSet` and `skillSet` are pointers because their maps need initialising. Building a partial `App` is a legitimate thing for a test to do, and the refactor shouldn't take that away.

**2. The MCP cluster is two structs, not one.** The issue proposed a single `serverSet`. Splitting it: connections come up and down on the Group's schedule and outlive any subscription, while the streams exist only when the async control plane is on, and `Close` stops streams *before* the Group. One struct would have put a conditional half inside an unconditional whole.

**3. `eventSpine` does not wrap the Queue.** Only `emit` is a method, because append-then-fan-out is an invariant worth enforcing in one place. `Resolve` / `AwaitResolution` / `ReadFrom` stay reachable as `events.log.X`: those barrier semantics carry the multi-surface ask protocol, and delegating pass-throughs would hide the contract callers actually reason about.

## Before / after

```
before                                  after
─────────────────────────────────       ─────────────────────────────────
group        *client.Group              servers serverSet
clients      []*client.Client             .group  .clients  .tools  .oauth
serverTools  *agent.MultiSource
oauthSources map[string]loginSource      streams streamSet
subsMu       sync.Mutex                    .subs  .calls  .fanIn  .ctx  .stop
subs         map[string]*subscription
streams      []*eventsclient.StreamCall  events  *eventSpine
fanIn        *gocurrent.FanIn[...]         .log  .observers  .persisted
evCtx        context.Context
eventStop    context.CancelFunc          session sessionState
observers    []Observer                    .store  .runID  .cursor
emitMu       sync.Mutex
eventLog     *gocurrent.Queue[...]       skills  *skillSet
persistedOffset atomic.Int64               .blocks  .catalog  .order  .loader
store        agent.RunStore
runID        string                      tasks   *taskSet
runIDAtomic  atomic.Value                  .m
sessionsMu   sync.Mutex
sessionsCursor string
skillsMu     sync.Mutex
skillBlocks  map[string]string
skillCatalog map[string][]catalogSkill
serverOrder  []string
loadSkillReg bool
tasksMu      sync.Mutex
bgTasks      map[string]*client.BackgroundTask

52 fields total                          32 fields total
```

## Scope I did not take

The issue predicted "roughly 25 fields". I landed at 32 and stopped at the five scoped clusters rather than expanding the diff. Two obvious candidates remain, both cheap, neither done here:

- **team** — `team`, `activeTeamAgent`, `teamEventSink` (one concept; `teamEventSink` is set under `turnMu` for the duration of a team turn, which is worth documenting).
- **provider switching** — `failover`, `connections`, `providerSwitch`.

Also explicitly out of scope, and the reason 32 is the floor for *this* PR: moving feature clusters **out** of `App` entirely (skills, memory, approval, injection). That depends on #1250 and #1026 and should land per-feature, each as its own PR.

## Risk

- **Affects:** `agent/host` internals only. No exported symbol changed, so `agent/surfaces/chat` and `agent/surfaces/web` needed no edits at all.
- **Be paranoid about:** the locking moves. Each cluster now owns its mutex, and the one place that is deliberately *not* uniform is `sessionState` — `runID` stays under `App.turnMu` rather than gaining a second lock, because it only changes at points a turn already owns. That is documented on the type; check the reasoning holds.
- **Tests:** the whole `agent/host` suite, unmodified except for literal updates. Zero assertions changed or weakened.

## Testing

`make test` and `make test-agent` both clean. `agent/host` also passes under `-race`, which matters more than usual for a change that relocates five mutexes.

