### PR TITLE
feat(host): declare the pre-turn context-assembly pipeline

### DIFF
--- a/agent/host/app.go
+++ b/agent/host/app.go
@@ -179,6 +179,9 @@ type App struct {
 	// WithSystemPromptBuilder). Wired as RunnerConfig.InstructionsFunc.
 	promptBuilder *SystemPromptBuilder
 
+	// context is the declared pre-turn context-assembly pipeline (#1026).
+	context contextPipeline
+
 	// overlay persists mutable config picks (active connection, approval
 	// mode) back to a local-overlay file when WithConfigOverlay is set; nil
 	// means runtime changes are session-only.
@@ -602,6 +605,15 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 		o.promptMutate(app.promptBuilder)
 	}
 
+	// The pre-turn context pipeline, in declared order. Built after the
+	// producers exist (injection above, memory below) so a nil producer
+	// contributes no stage at all rather than a stage that no-ops. See
+	// contextPipeline for the order's rationale and where a new stage goes.
+	app.context = contextPipeline{
+		durable:   []contextStage{app.injectionStage()},
+		transient: app.memoryStages(),
+	}
+
 	runnerCfg := agent.RunnerConfig{
 		Provider:         provider,
 		Tools:            runnerTools,
@@ -753,9 +765,8 @@ func (a *App) RunTurn(ctx context.Context, input string) error {
 	a.turnMu.Lock()
 	defer a.turnMu.Unlock()
 	a.triggers.NotifyEngagement()
-	a.drainInjectionLocked()
 	userMsg := agent.Message{Role: agent.RoleUser, Text: input}
-	a.history = append(a.history, userMsg)
+	a.history = a.context.runDurable(ctx, a.history, userMsg)
 
 	emit := func(e agent.Event) { a.emit(HostEvent{Kind: HostRunnerEvent, RunnerEvent: e}) }
 	var pe *PersistingEmit
@@ -776,10 +787,10 @@ func (a *App) RunTurn(ctx context.Context, input string) error {
 		}
 	}
 
-	// The memory summary is woven into the per-turn slice only, never into
-	// a.history — see withMemorySummaryLocked (a no-op in team mode, which has
-	// no memory).
-	turnMsgs := a.withMemorySummaryLocked(ctx)
+	// Transient producers run here, after ensureRunLocked, because
+	// session-scoped recall derives its namespace from the run id that call
+	// creates. See contextPipeline for the full order and its rationale.
+	turnMsgs := a.context.runTransient(ctx, a.history)
 	var result *agent.TurnResult
 	var err error
 	if a.team != nil {

--- a/agent/host/contextpipeline.go
+++ b/agent/host/contextpipeline.go
@@ -1,0 +1,149 @@
+package host
+
+import (
+	"context"
+
+	"github.com/panyam/mcpkit/agent"
+)
+
+// contextStage is one named step of pre-turn context assembly: it takes the
+// messages so far and returns them with its own contribution folded in.
+//
+// A stage that has nothing to add returns its input unchanged. Stages do not
+// report errors: a producer that cannot run (a store that is down, an
+// embedder that timed out) contributes nothing rather than failing the turn,
+// because context assembly is best-effort by nature and a missing recall
+// block is a worse answer, not a broken one.
+type contextStage struct {
+	name string
+	run  func(ctx context.Context, msgs []agent.Message) []agent.Message
+}
+
+// contextPipeline declares, in one place, how a turn's context is assembled
+// and why it is assembled in that order.
+//
+// Before this existed the order was real but implicit, accreted across two
+// layers: host RunTurn drained events, appended the user message, then wove in
+// the memory summary and recall, while the Runner compacted at the top of its
+// loop. Every individual ordering was defensible; the structure was never
+// designed, and a new stage had no declared place to go.
+//
+// # The two phases
+//
+// Durable stages produce messages that join the session's history and persist:
+// injected events, then the user's own message. Transient stages produce a
+// per-turn view that the model sees once and that is never written back:
+// the memory summary and relevance recall.
+//
+// The split is structural rather than a convention, because getting it wrong
+// is silent and compounding. A transient block written into history would be
+// re-injected next turn, then summarized alongside real conversation, and the
+// scratchpad would slowly become indistinguishable from what the user said.
+// Two slices make that mistake unrepresentable instead of merely discouraged.
+//
+// # Order, and why
+//
+//	events -> user -> summary -> recall -> [compaction, Runner-side]
+//
+// Events precede the user message because they describe what happened before
+// the user spoke. Recall follows the summary and sits closest to the user
+// message because it is the most salient: it was retrieved for this turn
+// specifically, while the summary is ambient. Both are woven in just before
+// the user message rather than appended after it, so the user's words remain
+// the last thing the model reads.
+//
+// # Compaction stays in the Runner, and runs last
+//
+// Compaction is named here as the terminal fit-to-budget stage but is not
+// executed here: it lives on the Runner so that an eval can grade a compaction
+// strategy without standing a host up. Naming it keeps the pipeline honest
+// about what actually happens to the messages after assemble returns.
+//
+// That it runs last is now a decision rather than an accident of where the
+// code sat. inject-then-compact guarantees the assembled context fits the
+// budget, at the cost that a freshly retrieved block can fall into the
+// compacted head and be summarized — a wasted model call on content that was
+// already a summary. compact-then-inject keeps retrievals verbatim but lets
+// injections push the result back over the budget after it was fit, which
+// fails the turn outright at the provider.
+//
+// A degraded answer beats a failed one, so inject-then-compact wins. The cost
+// is real though, and it has a sharp edge worth knowing: SummarizingCompactor
+// keeps its most recent KeepRecent messages verbatim, so injected blocks
+// survive only while KeepRecent exceeds the number of blocks plus the user
+// message. With a small KeepRecent and several producers, this turn's recall
+// can be summarized the moment it is created. See RunnerConfig.Compactor.
+//
+// # Adding a stage
+//
+// Append to the phase whose persistence it wants, at the position its
+// dependencies require. The injection-budget arbiter (#1024) is a transient
+// stage that would run after every producer and before compaction, once
+// contention between producers is measurable enough to rank them on a common
+// scale.
+type contextPipeline struct {
+	durable   []contextStage
+	transient []contextStage
+}
+
+// runDurable applies the durable stages and appends the user's message,
+// returning what the session should keep as its history.
+//
+// Separate from runTransient rather than one assemble call, because the host
+// must do real work between the two phases. The run id is created lazily on
+// the first persisted turn, and session-scoped memory derives its namespace
+// from that id — so recall running before the run exists would query the
+// shared default scratchpad instead of this session's. The phases are two
+// methods because there is a mandatory step between them, not because the
+// pipeline wanted splitting.
+func (p *contextPipeline) runDurable(ctx context.Context, prior []agent.Message, user agent.Message) []agent.Message {
+	out := prior
+	for _, st := range p.durable {
+		out = st.run(ctx, out)
+	}
+	return append(out, user)
+}
+
+// runTransient weaves the per-turn producers into a copy of history and
+// returns what the model sees now. The result never aliases history's backing
+// array, so the caller can keep one and send the other without either
+// corrupting the other.
+func (p *contextPipeline) runTransient(ctx context.Context, history []agent.Message) []agent.Message {
+	out := make([]agent.Message, len(history))
+	copy(out, history)
+	for _, st := range p.transient {
+		out = st.run(ctx, out)
+	}
+	return out
+}
+
+// stageNames lists the pipeline in execution order, durable phase first, for
+// diagnostics and tests that pin the declared order.
+func (p *contextPipeline) stageNames() []string {
+	out := make([]string, 0, len(p.durable)+len(p.transient))
+	for _, st := range p.durable {
+		out = append(out, st.name)
+	}
+	for _, st := range p.transient {
+		out = append(out, st.name)
+	}
+	return out
+}
+
+// weaveBeforeUser inserts blocks as RoleSystem messages immediately before the
+// final message, which by construction is the user's. Shared by every
+// transient producer so "closest to the user message is most salient" is
+// implemented once rather than re-derived per stage.
+func weaveBeforeUser(msgs []agent.Message, blocks []string) []agent.Message {
+	if len(blocks) == 0 || len(msgs) == 0 {
+		return msgs
+	}
+	n := len(msgs)
+	out := make([]agent.Message, 0, n+len(blocks))
+	out = append(out, msgs[:n-1]...)
+	for _, b := range blocks {
+		out = append(out, agent.Message{Role: agent.RoleSystem, Text: b})
+	}
+	out = append(out, msgs[n-1])
+	return out
+}

--- a/agent/host/contextpipeline_test.go
+++ b/agent/host/contextpipeline_test.go
@@ -1,0 +1,130 @@
+package host
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/panyam/mcpkit/agent"
+)
+
+func stubStage(name, text string) contextStage {
+	return contextStage{name: name, run: func(_ context.Context, msgs []agent.Message) []agent.Message {
+		return weaveBeforeUser(msgs, []string{text})
+	}}
+}
+
+func texts(msgs []agent.Message) []string {
+	out := make([]string, 0, len(msgs))
+	for _, m := range msgs {
+		out = append(out, m.Text)
+	}
+	return out
+}
+
+// TestPipelineDurableAppendsBeforeUser pins that durable stages contribute
+// history that precedes the user's message: events describe what happened
+// before the user spoke, so they cannot land after it.
+func TestPipelineDurableAppendsBeforeUser(t *testing.T) {
+	p := contextPipeline{durable: []contextStage{
+		{name: "events", run: func(_ context.Context, msgs []agent.Message) []agent.Message {
+			return append(msgs, agent.Message{Role: agent.RoleSystem, Text: "an event"})
+		}},
+	}}
+	got := p.runDurable(context.Background(), nil, agent.Message{Role: agent.RoleUser, Text: "hello"})
+	if want := []string{"an event", "hello"}; !reflect.DeepEqual(texts(got), want) {
+		t.Fatalf("durable order = %v, want %v", texts(got), want)
+	}
+}
+
+// TestPipelineTransientWeavesBeforeUserInOrder pins the salience rule: each
+// transient producer inserts just before the user's message, so the last
+// stage registered ends up closest to it. That is why recall follows the
+// summary rather than preceding it.
+func TestPipelineTransientWeavesBeforeUserInOrder(t *testing.T) {
+	p := contextPipeline{transient: []contextStage{
+		stubStage("memory.summary", "SUMMARY"),
+		stubStage("memory.recall", "RECALL"),
+	}}
+	history := []agent.Message{{Role: agent.RoleUser, Text: "hello"}}
+	got := p.runTransient(context.Background(), history)
+	if want := []string{"SUMMARY", "RECALL", "hello"}; !reflect.DeepEqual(texts(got), want) {
+		t.Fatalf("transient order = %v, want %v", texts(got), want)
+	}
+}
+
+// TestPipelineTransientNeverMutatesHistory is the invariant the whole
+// durable/transient split exists to protect. A transient block written back
+// into history would be re-injected next turn and eventually summarized
+// alongside real conversation, so the per-turn view must not alias it.
+func TestPipelineTransientNeverMutatesHistory(t *testing.T) {
+	p := contextPipeline{transient: []contextStage{stubStage("memory.recall", "RECALL")}}
+	history := []agent.Message{{Role: agent.RoleUser, Text: "hello"}}
+
+	perTurn := p.runTransient(context.Background(), history)
+
+	if len(history) != 1 || history[0].Text != "hello" {
+		t.Fatalf("history was mutated: %v", texts(history))
+	}
+	if len(perTurn) != 2 {
+		t.Fatalf("per-turn view = %v, want the injected block plus the user message", texts(perTurn))
+	}
+	// Writing through the per-turn slice must not reach history's array.
+	perTurn[len(perTurn)-1].Text = "clobbered"
+	if history[0].Text != "hello" {
+		t.Fatal("per-turn slice aliases history's backing array")
+	}
+}
+
+// TestPipelineEmptyStagesArePassThrough pins that a host with no producers
+// configured pays nothing: history is returned unchanged and the per-turn
+// view is just a copy.
+func TestPipelineEmptyStagesArePassThrough(t *testing.T) {
+	var p contextPipeline
+	want := []string{"hi"}
+	history := p.runDurable(context.Background(), nil, agent.Message{Role: agent.RoleUser, Text: "hi"})
+	if !reflect.DeepEqual(texts(history), want) {
+		t.Fatalf("durable = %v, want %v", texts(history), want)
+	}
+	if got := p.runTransient(context.Background(), history); !reflect.DeepEqual(texts(got), want) {
+		t.Fatalf("transient = %v, want %v", texts(got), want)
+	}
+}
+
+// TestDeclaredStageOrder pins the assembled pipeline a real App builds, which
+// is the whole point of the issue: the order is declared in one place instead
+// of emerging from where the code happened to sit.
+func TestDeclaredStageOrder(t *testing.T) {
+	ts := startTestServer(t)
+	cfg := testConfig(ts.URL)
+	cfg.Memory = &MemoryConfig{InjectSummary: true, InjectRecall: true}
+
+	app, err := NewApp(cfg, &strings.Builder{}, strings.NewReader(""),
+		WithProvider(agent.NewStubProvider(agent.StubTurn{Text: "hi"})))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Close()
+
+	want := []string{"events", "memory.summary", "memory.recall"}
+	if got := app.context.stageNames(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("declared stage order = %v, want %v", got, want)
+	}
+}
+
+// TestMemoryStagesAbsentWhenMemoryOff pins that a disabled producer
+// contributes no stage at all, rather than a stage that runs and no-ops.
+func TestMemoryStagesAbsentWhenMemoryOff(t *testing.T) {
+	ts := startTestServer(t)
+	app, err := NewApp(testConfig(ts.URL), &strings.Builder{}, strings.NewReader(""),
+		WithProvider(agent.NewStubProvider(agent.StubTurn{Text: "hi"})))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Close()
+
+	if want := []string{"events"}; !reflect.DeepEqual(app.context.stageNames(), want) {
+		t.Fatalf("stage order with memory off = %v, want %v", app.context.stageNames(), want)
+	}
+}

--- a/agent/host/events.go
+++ b/agent/host/events.go
@@ -61,8 +61,8 @@ func (a *App) runProactiveTurn(ctx context.Context, firing *agent.TriggerFiring)
 	a.turnMu.Lock()
 	defer a.turnMu.Unlock()
 	a.emit(HostEvent{Kind: HostTriggerFired, Label: firing.Binding.Label})
-	a.history = append(a.history, agent.Message{Role: agent.RoleSystem, Text: firing.Binding.Instructions})
-	a.drainInjectionLocked()
+	a.history = a.context.runDurable(ctx, a.history,
+		agent.Message{Role: agent.RoleSystem, Text: firing.Binding.Instructions})
 	result, err := a.runner.Run(ctx, a.history, func(e agent.Event) { a.emit(HostEvent{Kind: HostRunnerEvent, RunnerEvent: e}) })
 	if err != nil {
 		a.emit(HostEvent{Kind: HostTurnFailed, Err: err.Error()})
@@ -73,12 +73,16 @@ func (a *App) runProactiveTurn(ctx context.Context, firing *agent.TriggerFiring)
 	a.promptREPL()
 }
 
-// drainInjectionLocked moves pending injected context into history as
+// injectionStage is the durable context producer for incoming events: it
+// drains pending injected context into history as
 // system messages. Caller holds turnMu.
-func (a *App) drainInjectionLocked() {
-	for _, inj := range a.injection.Drain() {
-		a.history = append(a.history, agent.Message{Role: agent.RoleSystem, Text: inj.Text})
-	}
+func (a *App) injectionStage() contextStage {
+	return contextStage{name: "events", run: func(_ context.Context, msgs []agent.Message) []agent.Message {
+		for _, inj := range a.injection.Drain() {
+			msgs = append(msgs, agent.Message{Role: agent.RoleSystem, Text: inj.Text})
+		}
+		return msgs
+	}}
 }
 
 // buildTriggerBindings converts config bindings into policy bindings,

--- a/agent/host/events_test.go
+++ b/agent/host/events_test.go
@@ -157,7 +157,7 @@ func TestAppEventsWithoutHintsDegradesToRawInjection(t *testing.T) {
 	deadline := time.Now().Add(3 * time.Second)
 	for time.Now().Before(deadline) {
 		app.turnMu.Lock()
-		app.drainInjectionLocked()
+		app.history = app.context.durable[0].run(context.Background(), app.history)
 		n := len(app.history)
 		app.turnMu.Unlock()
 		if n > 0 {

--- a/agent/host/memory.go
+++ b/agent/host/memory.go
@@ -49,55 +49,42 @@ func (a *App) registerMemory(multi *agent.MultiSource, store agent.MemoryStore) 
 	return nil
 }
 
-// withMemorySummaryLocked returns the messages for this turn, weaving the
-// working-memory summary in as a RoleSystem message just before the current
-// (last) user message when Config.Memory.InjectSummary is on.
+// memoryStages are the transient context producers memory contributes: the
+// ambient scratchpad summary, then the recall relevant to this turn. Both are
+// woven in just before the user message, recall closest because it was
+// retrieved for these exact words while the summary is ambient.
 //
-// The summary is a stateful snapshot of current memory, re-rendered every
-// turn, so it is injected TRANSIENTLY: it goes into the returned slice for
-// this one model call and is never written into a.history. That keeps the
-// durable conversation (and the persisted RunStore log) free of stacked,
-// mostly-identical snapshots — the opposite of drainInjectionLocked, which
-// appends because each event is drained exactly once.
-//
-// When memory is off or empty it returns a.history unchanged (no copy). A
-// summary error is non-fatal — memory awareness is best-effort and must
-// never fail a turn. Caller holds turnMu and has already appended the user
-// message to a.history.
-func (a *App) withMemorySummaryLocked(ctx context.Context) []agent.Message {
+// Neither is written into history — see contextPipeline on why that split is
+// structural. A producer whose store errors contributes nothing rather than
+// failing the turn.
+func (a *App) memoryStages() []contextStage {
 	if a.memory == nil || a.cfg.Memory == nil {
-		return a.history
+		return nil
 	}
-	n := len(a.history)
-	if n == 0 {
-		return a.history
-	}
-
-	// Two independent memory-injection producers, each self-capping and each
-	// a RoleSystem message woven in just before the current user message.
-	// Recall (relevant to this turn) sits closest to the user message — most
-	// salient; the summary (ambient scratchpad) precedes it. Neither is
-	// written into a.history (transient — see the RunTurn note).
-	var blocks []string
+	var out []contextStage
 	if a.cfg.Memory.InjectSummary {
-		if s, err := a.memory.Summary(ctx, a.cfg.Memory.summaryOptions()); err == nil && s != "" {
-			blocks = append(blocks, s)
-		}
+		out = append(out, contextStage{name: "memory.summary", run: func(ctx context.Context, msgs []agent.Message) []agent.Message {
+			if len(msgs) == 0 {
+				return msgs
+			}
+			s, err := a.memory.Summary(ctx, a.cfg.Memory.summaryOptions())
+			if err != nil || s == "" {
+				return msgs
+			}
+			return weaveBeforeUser(msgs, []string{s})
+		}})
 	}
 	if a.cfg.Memory.InjectRecall {
-		if r, err := a.memory.RecallRelevant(ctx, a.history[n-1].Text, a.cfg.Memory.recallOptions()); err == nil && r != "" {
-			blocks = append(blocks, r)
-		}
+		out = append(out, contextStage{name: "memory.recall", run: func(ctx context.Context, msgs []agent.Message) []agent.Message {
+			if len(msgs) == 0 {
+				return msgs
+			}
+			r, err := a.memory.RecallRelevant(ctx, msgs[len(msgs)-1].Text, a.cfg.Memory.recallOptions())
+			if err != nil || r == "" {
+				return msgs
+			}
+			return weaveBeforeUser(msgs, []string{r})
+		}})
 	}
-	if len(blocks) == 0 {
-		return a.history
-	}
-
-	msgs := make([]agent.Message, 0, n+len(blocks))
-	msgs = append(msgs, a.history[:n-1]...)
-	for _, b := range blocks {
-		msgs = append(msgs, agent.Message{Role: agent.RoleSystem, Text: b})
-	}
-	msgs = append(msgs, a.history[n-1])
-	return msgs
+	return out
 }


### PR DESCRIPTION
Closes #1026.

## What changes

The pre-turn context assembly order becomes explicit and declared in one place, instead of accreted across two layers. `contextPipeline` names the stages, the two persistence phases, and the compaction tradeoff that was previously an accident of file layout.

## ELI12

Before a model answers, someone has to decide what it gets to read: recent events, the user's message, a memory summary, whatever the agent recalled as relevant. That assembly happened in the right order — but nowhere did anything *say* it was the order, or why.

It's the difference between a recipe and a kitchen where the steps happen correctly because the same cook has always done it. The food comes out fine. Then someone new adds an ingredient, and there's no answer to "at what point?" — only "wherever your code happened to go."

One detail carries most of the weight: some of what goes in is **kept** and some is **borrowed**. The user's message is kept forever. The memory summary is regenerated every turn and must be thrown away after — because if you filed it into the transcript, next turn you'd generate a *new* summary and file that too, and eventually you'd be summarizing your own summaries. The old code got this right by convention. Now the two live in separate slices, so writing a borrowed thing into the kept pile isn't a mistake you can make.

## Reviewer's guide

1. [agent/host/contextpipeline.go](https://github.com/panyam/mcpkit/pull/1257/files#diff-928ca81b35350b52910909d02ca9d65c78ea0df6c436b1610d1d975ad9561647) — start here. The type doc is the deliverable; the code is small.
2. [agent/host/contextpipeline_test.go](https://github.com/panyam/mcpkit/pull/1257/files#diff-26ece1e35199dcd1610bc4b435efc20b3629038f52d99ec3668da862390fbd66) — acceptance, including the aliasing invariant.
3. [agent/host/memory.go](https://github.com/panyam/mcpkit/pull/1257/files#diff-2fa9e3fc7796e7e17ca21962b0f10cf32f1e7cc8b61a88abbfb519c350a97c62) — `withMemorySummaryLocked` becomes two named stages.
4. [agent/host/events.go](https://github.com/panyam/mcpkit/pull/1257/files#diff-e7ce4393ed239044155c221a65a7d106cfa899090f1da0fcc2be88231a4aa1d1) — `drainInjectionLocked` becomes a stage; both turn paths now use it.
5. [agent/host/app.go](https://github.com/panyam/mcpkit/pull/1257/files#diff-89fb8e04b6e1e9d5f7f76958490ef158dee40e2cae92d87c04b408d893c84361) — the pipeline built at construction, and the two `RunTurn` call sites.

## How it works

```
RunTurn:
    history  = pipeline.runDurable(history, userMessage)   # kept
    ... ensureRunLocked creates the run id ...
    perTurn  = pipeline.runTransient(history)              # borrowed, copy
    Runner.Run(perTurn)  ->  compaction fits it to budget
```

## Decision log

- **Two methods, not one `assemble`.** The host has mandatory work between the phases: `ensureRunLocked` creates the run id lazily, and session-scoped recall derives its memory namespace from it. Recall running before that would query the shared default scratchpad instead of this session's. That dependency was previously implicit in statement order; now it is stated somewhere it can be violated.
- **inject-then-compact, deliberately.** #1026 called this out as never decided. It guarantees the context fits the budget, at the cost that a fresh retrieval can land in the compacted head and be summarized. compact-then-inject keeps retrievals verbatim but lets injections push past the budget after the fit, which fails the turn at the provider. A degraded answer beats a failed one.
- **Compaction named but not moved.** It stays on the Runner so an eval can grade a compaction strategy without standing a host up. Naming it keeps the pipeline honest about what happens after `runTransient` returns.
- **#1024 not built.** It gets a declared position — a transient stage after every producer, before compaction. That issue is explicit that normalizing event priorities against similarity scores onto one scale is genuine design, to do when contention is measurable.

## The sharp edge this surfaced

Writing the ordering down exposed a hazard that was previously invisible. `SummarizingCompactor` keeps its most recent `KeepRecent` messages verbatim, so injected blocks survive only while `KeepRecent` exceeds the number of blocks plus the user message. **With a small `KeepRecent` and several producers, this turn's recall can be summarized the moment it is created** — a model call spent re-summarizing something that was already a summary.

Not fixed here (it needs either a compaction-aware protection marker or a documented floor on `KeepRecent`), but it is now written on the type instead of being a thing you'd discover from a confusing transcript.

## Risk

- **Affects:** `agent/host` only; no exported symbol changed, and the surfaces needed no edits.
- **Behaviour:** intended to be identical. The one real change is that `runProactiveTurn` now drains events through the same stage as `RunTurn` rather than its own call — previously two call sites of the same logic.
- **Be paranoid about:** the phase boundary. If a future stage that needs the run id is added to `durable` instead of `transient`, it silently gets the wrong namespace. The doc says so; a reviewer should check the wording is strong enough.

## Testing

`make test` and `make test-agent` clean; `agent/host` green under `-race`. 6 new tests, 11 assertions, no existing test modified and **zero assertions weakened**.

