### PR TITLE
feat(host): Extension contract — one registration across every seam

### DIFF
--- a/agent/host/app.go
+++ b/agent/host/app.go
@@ -149,6 +149,7 @@ type appOptions struct {
 	configPath      string
 	promptMutate    func(*SystemPromptBuilder)
 	browserOpener   func(string) error
+	extensions      []Extension
 }
 
 // WithBrowserOpener overrides how the interactive (oauth) auth type opens the
@@ -555,7 +556,7 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 	// contributes no stage at all rather than a stage that no-ops. See
 	// contextPipeline for the order's rationale and where a new stage goes.
 	app.context = contextPipeline{
-		durable:   []contextStage{app.injectionStage()},
+		durable:   []ContextStage{app.injectionStage()},
 		transient: app.memoryStages(),
 	}
 
@@ -587,6 +588,25 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 	if mw := cfg.Spotlight.build(); mw != nil {
 		runnerCfg.ToolMiddleware = append(runnerCfg.ToolMiddleware, mw)
 	}
+	// Built-in commands register before extensions so an extension naming a
+	// command the host already owns fails construction instead of being
+	// silently overwritten later. Their Run closures capture app and are not
+	// invoked here, so registering before the Runner exists is safe.
+	app.registerBuiltinCommands()
+
+	// Extensions contribute across every seam at once, applied after the
+	// built-in producers so their prompt sections and context stages land
+	// after the host's own, and before the gate below so their middleware
+	// wraps outside it. registerBuiltinCommands has already run, so a
+	// collision with a built-in /command is caught here rather than
+	// silently shadowing it.
+	extMW, err := app.applyExtensions(o.extensions)
+	if err != nil {
+		app.Close()
+		return nil, err
+	}
+	runnerCfg.ToolMiddleware = append(runnerCfg.ToolMiddleware, extMW...)
+
 	// The permission gate goes last in the middleware chain so it inspects
 	// the arguments that will actually execute, after any earlier entry has
 	// rewritten them (see agent.RunnerConfig.ToolMiddleware). Appended only
@@ -609,7 +629,6 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 		return nil, err
 	}
 	app.runner = runner
-	app.registerBuiltinCommands()
 
 	// The fanIn + subscription ctx were built before the servers connected, and
 	// the ready-observer has been subscribing each server's event streams; now

--- a/agent/host/contextpipeline.go
+++ b/agent/host/contextpipeline.go
@@ -6,7 +6,7 @@ import (
 	"github.com/panyam/mcpkit/agent"
 )
 
-// contextStage is one named step of pre-turn context assembly: it takes the
+// ContextStage is one named step of pre-turn context assembly: it takes the
 // messages so far and returns them with its own contribution folded in.
 //
 // A stage that has nothing to add returns its input unchanged. Stages do not
@@ -14,9 +14,14 @@ import (
 // embedder that timed out) contributes nothing rather than failing the turn,
 // because context assembly is best-effort by nature and a missing recall
 // block is a worse answer, not a broken one.
-type contextStage struct {
-	name string
-	run  func(ctx context.Context, msgs []agent.Message) []agent.Message
+type ContextStage struct {
+	// Name identifies the stage in stageNames and in diagnostics. Use a
+	// dotted form scoped to the contributor ("memory.recall") so a pipeline
+	// listing says who added what.
+	Name string
+
+	// Run folds this stage's contribution into the messages so far.
+	Run func(ctx context.Context, msgs []agent.Message) []agent.Message
 }
 
 // contextPipeline declares, in one place, how a turn's context is assembled
@@ -82,8 +87,8 @@ type contextStage struct {
 // contention between producers is measurable enough to rank them on a common
 // scale.
 type contextPipeline struct {
-	durable   []contextStage
-	transient []contextStage
+	durable   []ContextStage
+	transient []ContextStage
 }
 
 // runDurable applies the durable stages and appends the user's message,
@@ -99,7 +104,7 @@ type contextPipeline struct {
 func (p *contextPipeline) runDurable(ctx context.Context, prior []agent.Message, user agent.Message) []agent.Message {
 	out := prior
 	for _, st := range p.durable {
-		out = st.run(ctx, out)
+		out = st.Run(ctx, out)
 	}
 	return append(out, user)
 }
@@ -112,7 +117,7 @@ func (p *contextPipeline) runTransient(ctx context.Context, history []agent.Mess
 	out := make([]agent.Message, len(history))
 	copy(out, history)
 	for _, st := range p.transient {
-		out = st.run(ctx, out)
+		out = st.Run(ctx, out)
 	}
 	return out
 }
@@ -122,10 +127,10 @@ func (p *contextPipeline) runTransient(ctx context.Context, history []agent.Mess
 func (p *contextPipeline) stageNames() []string {
 	out := make([]string, 0, len(p.durable)+len(p.transient))
 	for _, st := range p.durable {
-		out = append(out, st.name)
+		out = append(out, st.Name)
 	}
 	for _, st := range p.transient {
-		out = append(out, st.name)
+		out = append(out, st.Name)
 	}
 	return out
 }

--- a/agent/host/contextpipeline_test.go
+++ b/agent/host/contextpipeline_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/panyam/mcpkit/agent"
 )
 
-func stubStage(name, text string) contextStage {
-	return contextStage{name: name, run: func(_ context.Context, msgs []agent.Message) []agent.Message {
+func stubStage(name, text string) ContextStage {
+	return ContextStage{Name: name, Run: func(_ context.Context, msgs []agent.Message) []agent.Message {
 		return weaveBeforeUser(msgs, []string{text})
 	}}
 }
@@ -27,8 +27,8 @@ func texts(msgs []agent.Message) []string {
 // history that precedes the user's message: events describe what happened
 // before the user spoke, so they cannot land after it.
 func TestPipelineDurableAppendsBeforeUser(t *testing.T) {
-	p := contextPipeline{durable: []contextStage{
-		{name: "events", run: func(_ context.Context, msgs []agent.Message) []agent.Message {
+	p := contextPipeline{durable: []ContextStage{
+		{Name: "events", Run: func(_ context.Context, msgs []agent.Message) []agent.Message {
 			return append(msgs, agent.Message{Role: agent.RoleSystem, Text: "an event"})
 		}},
 	}}
@@ -43,7 +43,7 @@ func TestPipelineDurableAppendsBeforeUser(t *testing.T) {
 // stage registered ends up closest to it. That is why recall follows the
 // summary rather than preceding it.
 func TestPipelineTransientWeavesBeforeUserInOrder(t *testing.T) {
-	p := contextPipeline{transient: []contextStage{
+	p := contextPipeline{transient: []ContextStage{
 		stubStage("memory.summary", "SUMMARY"),
 		stubStage("memory.recall", "RECALL"),
 	}}
@@ -59,7 +59,7 @@ func TestPipelineTransientWeavesBeforeUserInOrder(t *testing.T) {
 // into history would be re-injected next turn and eventually summarized
 // alongside real conversation, so the per-turn view must not alias it.
 func TestPipelineTransientNeverMutatesHistory(t *testing.T) {
-	p := contextPipeline{transient: []contextStage{stubStage("memory.recall", "RECALL")}}
+	p := contextPipeline{transient: []ContextStage{stubStage("memory.recall", "RECALL")}}
 	history := []agent.Message{{Role: agent.RoleUser, Text: "hello"}}
 
 	perTurn := p.runTransient(context.Background(), history)

--- a/agent/host/events.go
+++ b/agent/host/events.go
@@ -76,8 +76,8 @@ func (a *App) runProactiveTurn(ctx context.Context, firing *agent.TriggerFiring)
 // injectionStage is the durable context producer for incoming events: it
 // drains pending injected context into history as
 // system messages. Caller holds turnMu.
-func (a *App) injectionStage() contextStage {
-	return contextStage{name: "events", run: func(_ context.Context, msgs []agent.Message) []agent.Message {
+func (a *App) injectionStage() ContextStage {
+	return ContextStage{Name: "events", Run: func(_ context.Context, msgs []agent.Message) []agent.Message {
 		for _, inj := range a.injection.Drain() {
 			msgs = append(msgs, agent.Message{Role: agent.RoleSystem, Text: inj.Text})
 		}

--- a/agent/host/events_test.go
+++ b/agent/host/events_test.go
@@ -157,7 +157,7 @@ func TestAppEventsWithoutHintsDegradesToRawInjection(t *testing.T) {
 	deadline := time.Now().Add(3 * time.Second)
 	for time.Now().Before(deadline) {
 		app.turnMu.Lock()
-		app.history = app.context.durable[0].run(context.Background(), app.history)
+		app.history = app.context.durable[0].Run(context.Background(), app.history)
 		n := len(app.history)
 		app.turnMu.Unlock()
 		if n > 0 {

--- a/agent/host/extension.go
+++ b/agent/host/extension.go
@@ -1,0 +1,158 @@
+package host
+
+import (
+	"fmt"
+
+	"github.com/panyam/mcpkit/agent"
+)
+
+// Extension contributes capability to an App across every seam at once.
+//
+// It exists because App had no way to *add* anything. All the other
+// AppOptions replace something already pluggable — the provider, the stores,
+// the observer, the prompt builder — so a caller who wanted their own tools
+// plus the harness behaviour around them had nowhere to put it. That absence
+// is why App accumulated a feature per field instead of a registry per seam.
+//
+// Nothing here is a new mechanism. ToolSource, ToolMiddleware, PromptSection,
+// Command, and ContextStage all already exist and are all already wired. An
+// Extension's only job is to let one package contribute across all five as a
+// unit, because a feature is not five independent contributions — it is one
+// thing with five facets that have to agree. Memory's recall tool and its
+// pre-turn producer share a store; a checkpoint middleware and its /undo
+// command share a snapshot directory. Registering those separately would put
+// the coherence in the caller's head and leave their ordering unstated.
+//
+// Every method except Name is optional: return nil for the seams you do not
+// use. Embed BaseExtension to no-op all of them and override only what you
+// need.
+//
+// # Ordering
+//
+// Extensions are applied in the order given to WithExtension, and within one
+// extension each seam keeps the order its slice declares. Two orderings are
+// load-bearing:
+//
+//   - Middleware lands before the host's own permission gate, so a gate still
+//     sees the arguments an extension rewrote. See
+//     agent.RunnerConfig.ToolMiddleware, where a gate belongs last.
+//   - Context stages append after the built-in producers, so an extension's
+//     block sits closer to the user's message than the memory summary. Later
+//     is more salient; see contextPipeline.
+//
+// # What stays host-owned
+//
+// The permission gate is not an extension and should not become one. Its
+// position is load-bearing rather than incidental: it must run last so it
+// decides on the arguments every other middleware has already rewritten. An
+// extension that could claim that slot could also take it from the gate,
+// which is the one ordering nobody should be able to change by registration
+// order. So TieredApproval stays wired by the host, after extension
+// middleware, and an extension that wants to refuse a call returns
+// agent.DenyTool from its own middleware instead.
+//
+// # Naming
+//
+// Tools register into the same MultiSource as everything else, so a tool name
+// that collides with another source's resolves through the existing
+// disambiguation rather than a rule invented here. Commands collide loudly:
+// registering a name the registry already holds is an error, because a
+// silently shadowed /command is worse than a failed startup.
+type Extension interface {
+	// Name identifies the extension in errors, diagnostics, and stage names.
+	// It is also the source id its tools register under, so it must be unique
+	// across the extensions given to one App.
+	Name() string
+
+	// Tools returns the extension's tool source, or nil for none. An error
+	// fails App construction: an extension that cannot build its tools is not
+	// something to start up half-configured.
+	Tools() (agent.ToolSource, error)
+
+	// Middleware wraps tool dispatch. Applied before the host's permission
+	// gate; see the ordering note above.
+	Middleware() []agent.ToolMiddleware
+
+	// PromptSections contribute to the per-turn system prompt, appended after
+	// the host's own sections.
+	PromptSections() []PromptSection
+
+	// Commands are slash commands every surface dispatches. A name already in
+	// the registry is an error.
+	Commands() []*Command
+
+	// ContextStages are per-turn context producers, appended to the transient
+	// phase. Use this for context the model should see for one turn without
+	// it joining the session's history.
+	ContextStages() []ContextStage
+}
+
+// BaseExtension implements every optional Extension seam as a no-op, so an
+// extension embeds it and overrides only what it contributes. It deliberately
+// does not supply Name: an unnamed extension is never what a caller meant.
+//
+//	type coding struct{ host.BaseExtension }
+//
+//	func (coding) Name() string { return "coding" }
+//	func (c coding) Tools() (agent.ToolSource, error) { return c.src, nil }
+type BaseExtension struct{}
+
+func (BaseExtension) Tools() (agent.ToolSource, error)   { return nil, nil }
+func (BaseExtension) Middleware() []agent.ToolMiddleware { return nil }
+func (BaseExtension) PromptSections() []PromptSection    { return nil }
+func (BaseExtension) Commands() []*Command               { return nil }
+func (BaseExtension) ContextStages() []ContextStage      { return nil }
+
+// WithExtension registers extensions with the App, applied in the order
+// given. Repeated calls accumulate rather than replace, so a caller can build
+// the list across several options.
+func WithExtension(exts ...Extension) AppOption {
+	return func(o *appOptions) { o.extensions = append(o.extensions, exts...) }
+}
+
+// applyExtensions wires every extension into the seams it contributes to.
+//
+// Called during construction, after the built-in producers exist so an
+// extension's contributions land after theirs, and before the Runner is built
+// so extension middleware reaches RunnerConfig. Middleware is returned rather
+// than applied because the caller must still append the permission gate after
+// it.
+func (a *App) applyExtensions(exts []Extension) ([]agent.ToolMiddleware, error) {
+	var mw []agent.ToolMiddleware
+	seen := map[string]bool{}
+	for _, ext := range exts {
+		name := ext.Name()
+		if name == "" {
+			return nil, fmt.Errorf("host: extension has no name")
+		}
+		if seen[name] {
+			return nil, fmt.Errorf("host: duplicate extension %q", name)
+		}
+		seen[name] = true
+
+		src, err := ext.Tools()
+		if err != nil {
+			return nil, fmt.Errorf("host: extension %q tools: %w", name, err)
+		}
+		if src != nil {
+			if err := a.sources.Add(name, src); err != nil {
+				return nil, fmt.Errorf("host: extension %q tools: %w", name, err)
+			}
+		}
+
+		mw = append(mw, ext.Middleware()...)
+		a.promptBuilder.Sections = append(a.promptBuilder.Sections, ext.PromptSections()...)
+		a.context.transient = append(a.context.transient, ext.ContextStages()...)
+
+		for _, cmd := range ext.Commands() {
+			// Register overwrites silently, which is the wrong behaviour for
+			// a command an extension did not know was taken: a shadowed
+			// /command fails at use, far from the cause. Refuse instead.
+			if _, taken := a.commands.Lookup(cmd.Name); taken {
+				return nil, fmt.Errorf("host: extension %q command %q is already registered", name, cmd.Name)
+			}
+			a.commands.Register(cmd)
+		}
+	}
+	return mw, nil
+}

--- a/agent/host/extension_test.go
+++ b/agent/host/extension_test.go
@@ -1,0 +1,220 @@
+package host
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/panyam/mcpkit/agent"
+	"github.com/panyam/mcpkit/core"
+)
+
+// fullExt contributes to every seam at once, which is the point of the
+// contract: a feature is one thing with five facets, not five registrations.
+type fullExt struct {
+	BaseExtension
+	name    string
+	sawTool bool
+}
+
+func (e *fullExt) Name() string { return e.name }
+
+func (e *fullExt) Tools() (agent.ToolSource, error) {
+	src := agent.NewFuncSource()
+	err := agent.AddFunc(src, "ext_ping", "pings", func(context.Context, struct{}) (string, error) {
+		e.sawTool = true
+		return "pong", nil
+	})
+	return src, err
+}
+
+func (e *fullExt) Middleware() []agent.ToolMiddleware {
+	return []agent.ToolMiddleware{agent.AfterToolCall(
+		func(_ context.Context, _ agent.ToolCallInfo, res *core.ToolResult) (*core.ToolResult, error) {
+			return &core.ToolResult{Content: []core.Content{{Type: "text", Text: "[wrapped]"}}}, nil
+		})}
+}
+
+func (e *fullExt) PromptSections() []PromptSection {
+	return []PromptSection{PromptSectionFunc(func(context.Context) string { return "EXT PROMPT" })}
+}
+
+func (e *fullExt) Commands() []*Command {
+	return []*Command{{Name: "extcmd", Help: "an extension command",
+		Run: func(context.Context, string) (CmdResult, error) {
+			return CmdResult{Kind: CmdMessage, Message: "ran"}, nil
+		}}}
+}
+
+func (e *fullExt) ContextStages() []ContextStage {
+	return []ContextStage{{Name: "ext.note", Run: func(_ context.Context, msgs []agent.Message) []agent.Message {
+		return weaveBeforeUser(msgs, []string{"EXT CONTEXT"})
+	}}}
+}
+
+// minimalExt contributes nothing but a name, proving BaseExtension makes every
+// other seam genuinely optional.
+type minimalExt struct{ BaseExtension }
+
+func (minimalExt) Name() string { return "minimal" }
+
+func extApp(t *testing.T, stub *agent.StubProvider, exts ...Extension) *App {
+	t.Helper()
+	ts := startTestServer(t)
+	app, err := NewApp(testConfig(ts.URL), &strings.Builder{}, strings.NewReader(""),
+		WithProvider(stub), WithExtension(exts...))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { app.Close() })
+	return app
+}
+
+// TestExtensionContributesEverySeam is the acceptance: one registration wires
+// tools, middleware, a prompt section, a command, and a context stage.
+func TestExtensionContributesEverySeam(t *testing.T) {
+	ext := &fullExt{name: "full"}
+	stub := agent.NewStubProvider(
+		agent.StubTurn{ToolCalls: []agent.ToolCall{{
+			ID: "c1", Name: "ext_ping", Args: core.NewRawJSON(json.RawMessage(`{}`)),
+		}}},
+		agent.StubTurn{Text: "done"},
+	)
+	app := extApp(t, stub, ext)
+
+	// Tools
+	defs, err := app.sources.Tools(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found bool
+	for _, d := range defs {
+		if strings.Contains(d.Name, "ext_ping") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("extension tool not registered: %v", defs)
+	}
+
+	// Command
+	if _, ok := app.commands.Lookup("extcmd"); !ok {
+		t.Fatal("extension command not registered")
+	}
+
+	// Prompt section
+	if got := app.promptBuilder.Build(context.Background()); !strings.Contains(got, "EXT PROMPT") {
+		t.Fatalf("extension prompt section missing:\n%s", got)
+	}
+
+	// Context stage, declared last so it sits closest to the user message.
+	names := app.context.stageNames()
+	if names[len(names)-1] != "ext.note" {
+		t.Fatalf("stage order = %v, want ext.note last", names)
+	}
+
+	// Middleware: the tool ran, and its result reached the model rewritten.
+	if err := app.RunTurn(context.Background(), "ping"); err != nil {
+		t.Fatal(err)
+	}
+	if !ext.sawTool {
+		t.Fatal("extension tool was never dispatched")
+	}
+	// Find by role: the context stage adds a message, so a fixed index would
+	// couple this assertion to how many producers happen to be configured.
+	var toolText string
+	for _, m := range stub.Requests()[1].Messages {
+		if m.Role == agent.RoleTool {
+			toolText = m.Text
+		}
+	}
+	if toolText != "[wrapped]" {
+		t.Fatalf("extension middleware did not wrap the result: %q", toolText)
+	}
+}
+
+// TestExtensionContextStageReachesTheModel pins that a context stage's block
+// lands in the per-turn view, before the user's message.
+func TestExtensionContextStageReachesTheModel(t *testing.T) {
+	stub := agent.NewStubProvider(agent.StubTurn{Text: "ok"})
+	app := extApp(t, stub, &fullExt{name: "full"})
+
+	if err := app.RunTurn(context.Background(), "hello"); err != nil {
+		t.Fatal(err)
+	}
+	msgs := stub.Requests()[0].Messages
+	if len(msgs) < 2 {
+		t.Fatalf("expected the injected block plus the user message, got %d", len(msgs))
+	}
+	if msgs[len(msgs)-2].Text != "EXT CONTEXT" || msgs[len(msgs)-1].Text != "hello" {
+		t.Fatalf("context stage did not weave before the user message: %+v", msgs)
+	}
+}
+
+// TestExtensionContextStageIsTransient pins that a stage's block is per-turn:
+// writing it into history would re-inject it every turn afterwards.
+func TestExtensionContextStageIsTransient(t *testing.T) {
+	stub := agent.NewStubProvider(agent.StubTurn{Text: "one"}, agent.StubTurn{Text: "two"})
+	app := extApp(t, stub, &fullExt{name: "full"})
+
+	if err := app.RunTurn(context.Background(), "first"); err != nil {
+		t.Fatal(err)
+	}
+	for _, m := range app.history {
+		if m.Text == "EXT CONTEXT" {
+			t.Fatal("a transient context stage was written into history")
+		}
+	}
+}
+
+// TestBaseExtensionMakesSeamsOptional pins that an extension contributing only
+// a name constructs cleanly and adds nothing.
+func TestBaseExtensionMakesSeamsOptional(t *testing.T) {
+	app := extApp(t, agent.NewStubProvider(agent.StubTurn{Text: "ok"}), minimalExt{})
+	if got := app.context.stageNames(); got[len(got)-1] == "ext.note" {
+		t.Fatal("minimal extension contributed a stage")
+	}
+	if err := app.RunTurn(context.Background(), "hi"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestExtensionDuplicateNameFails pins that two extensions claiming one name
+// fail construction rather than one silently winning the tool namespace.
+func TestExtensionDuplicateNameFails(t *testing.T) {
+	ts := startTestServer(t)
+	_, err := NewApp(testConfig(ts.URL), &strings.Builder{}, strings.NewReader(""),
+		WithProvider(agent.NewStubProvider(agent.StubTurn{Text: "ok"})),
+		WithExtension(&fullExt{name: "dup"}, &fullExt{name: "dup"}))
+	if err == nil {
+		t.Fatal("duplicate extension names must fail construction")
+	}
+	if !strings.Contains(err.Error(), "duplicate extension") {
+		t.Fatalf("unhelpful error: %v", err)
+	}
+}
+
+// TestExtensionCommandCollisionFails pins that an extension cannot shadow a
+// built-in command. Register overwrites silently, so this has to be refused
+// before it reaches the registry — a shadowed /command fails at use, far from
+// the cause.
+func TestExtensionCommandCollisionFails(t *testing.T) {
+	ts := startTestServer(t)
+	_, err := NewApp(testConfig(ts.URL), &strings.Builder{}, strings.NewReader(""),
+		WithProvider(agent.NewStubProvider(agent.StubTurn{Text: "ok"})),
+		WithExtension(&collidingExt{}))
+	if err == nil {
+		t.Fatal("an extension shadowing a built-in command must fail construction")
+	}
+	if !strings.Contains(err.Error(), "already registered") {
+		t.Fatalf("unhelpful error: %v", err)
+	}
+}
+
+type collidingExt struct{ BaseExtension }
+
+func (collidingExt) Name() string { return "collider" }
+func (collidingExt) Commands() []*Command {
+	return []*Command{{Name: "tools", Help: "shadows the built-in"}}
+}

--- a/agent/host/memory.go
+++ b/agent/host/memory.go
@@ -57,13 +57,13 @@ func (a *App) registerMemory(multi *agent.MultiSource, store agent.MemoryStore) 
 // Neither is written into history — see contextPipeline on why that split is
 // structural. A producer whose store errors contributes nothing rather than
 // failing the turn.
-func (a *App) memoryStages() []contextStage {
+func (a *App) memoryStages() []ContextStage {
 	if a.memory == nil || a.cfg.Memory == nil {
 		return nil
 	}
-	var out []contextStage
+	var out []ContextStage
 	if a.cfg.Memory.InjectSummary {
-		out = append(out, contextStage{name: "memory.summary", run: func(ctx context.Context, msgs []agent.Message) []agent.Message {
+		out = append(out, ContextStage{Name: "memory.summary", Run: func(ctx context.Context, msgs []agent.Message) []agent.Message {
 			if len(msgs) == 0 {
 				return msgs
 			}
@@ -75,7 +75,7 @@ func (a *App) memoryStages() []contextStage {
 		}})
 	}
 	if a.cfg.Memory.InjectRecall {
-		out = append(out, contextStage{name: "memory.recall", run: func(ctx context.Context, msgs []agent.Message) []agent.Message {
+		out = append(out, ContextStage{Name: "memory.recall", Run: func(ctx context.Context, msgs []agent.Message) []agent.Message {
 			if len(msgs) == 0 {
 				return msgs
 			}


### PR DESCRIPTION
Closes #1250.

## What changes

`host.App` gains an `Extension` contract: one registration that contributes tools, middleware, prompt sections, commands, and per-turn context stages together. This is the unlock from #1059 — coding is an extension over the general harness, and until now nothing could extend the harness at all.

## ELI12

A browser ships with tabs and a URL bar, and an ad blocker adds a button, a request filter, a settings page, and a right-click menu item. Nobody thinks the ad blocker should be a *different browser*. It plugs into places the browser already has.

`host.App` had all the sockets — a place for tools, a place to wrap tool calls, a place to add system-prompt text, a place for slash commands — and **no plug**. Its thirteen options all *swap* a part that already exists (use my storage, use my renderer). Not one *adds* a part. So every feature had to be built into the app itself, which is how one struct ended up with 52 fields.

The one design choice worth explaining: this is a single interface with five methods rather than five separate `WithTool` / `WithCommand` calls. A feature isn't five unrelated contributions. An undo feature is a middleware that snapshots files *and* the `/undo` command that restores them, and those two share a directory. Registered separately, nothing says they belong together, and nothing says which order they apply in. Registered as one thing with five facets, the coherence is in the type.

## Reviewer's guide

1. [agent/host/extension.go](https://github.com/panyam/mcpkit/pull/1258/files#diff-985592cc5a0e6e0c3b925b74b96eee4d2eccfb9049a8dbc9638c2a995e705e89) — the contract. The doc comment is the deliverable; the code is ~40 lines.
2. [agent/host/extension_test.go](https://github.com/panyam/mcpkit/pull/1258/files#diff-524332413dfecfe69f9852ef984e68b84ce96dad358c7da5af1e766cc2d09181) — acceptance, including an extension exercising all five seams at once.
3. [agent/host/app.go](https://github.com/panyam/mcpkit/pull/1258/files#diff-89fb8e04b6e1e9d5f7f76958490ef158dee40e2cae92d87c04b408d893c84361) — `applyExtensions` call site, and the moved `registerBuiltinCommands`.
4. [agent/host/contextpipeline.go](https://github.com/panyam/mcpkit/pull/1258/files#diff-928ca81b35350b52910909d02ca9d65c78ea0df6c436b1610d1d975ad9561647) — `contextStage` → exported `ContextStage`.

## How it works

```
NewApp:
    ... build built-in producers (injection, memory, prompt sections) ...
    registerBuiltinCommands()          # so a collision is caught, not shadowed
    extMW = applyExtensions(exts):
        for each extension:
            tools           -> MultiSource.Add(name, src)
            promptSections  -> promptBuilder.Sections (appended)
            contextStages   -> pipeline.transient   (appended)
            commands        -> registry, refusing a name already taken
            middleware      -> collected, returned
    runnerCfg.ToolMiddleware += extMW
    runnerCfg.ToolMiddleware += approval gate   # last, always
```

## Decision log

- **One interface, not five options.** See ELI12. `BaseExtension` no-ops every seam so the boilerplate objection goes away; it deliberately omits `Name`, since an unnamed extension is never what a caller meant.
- **`ContextStage` is now exported.** It landed unexported in #1026, which was correct while every producer was in-package, and stops being correct the moment an extension in another package has to build one.
- **Commands collide loudly.** `CommandRegistry.Register` overwrites silently. For an extension that didn't know a name was taken, that means a `/command` that fails at *use*, far from its cause. `applyExtensions` refuses instead. This also required moving `registerBuiltinCommands` ahead of extension registration — its `Run` closures capture `app` and aren't invoked at registration, so running it before the Runner exists is safe.
- **Tools collide quietly.** Opposite call, deliberately: tool names go into the same `MultiSource` as every server, so a collision resolves through the disambiguation that already exists rather than a second rule invented here.

## The finding: the permission gate must not be an extension

The issue proposed migrating approval as the cheapest proof, since #1248 already made it a `ToolMiddleware`. Working through it, that turns out to be the wrong first migration, for a reason worth keeping.

The gate's **position is the point**. It runs last so it decides on the arguments every other middleware has already rewritten. If an extension could claim that slot, an extension could also *take it from the gate* — and registration order would silently decide whether the permission check means anything.

So `TieredApproval` stays host-wired, after all extension middleware. An extension that wants to refuse a call returns `agent.DenyTool` from its own middleware, which is the supported path and doesn't move the gate.

**This means I did not do the "one real feature migrated" acceptance item**, and I'd rather say so than migrate something unsuitable to tick it. The five-seam test extension is the proof instead. The right first real migration is skills or memory, both of which want #1024's arbiter question answered first for the context-stage half.

## Risk

- **Affects:** additive. No existing behaviour changes and no exported symbol was removed, so the surfaces needed no edits. The one reordering is `registerBuiltinCommands` moving earlier in `NewApp`.
- **Be paranoid about:** the middleware ordering. `TestExtensionContributesEverySeam` pins that an extension's `AfterToolCall` rewrite reaches the model, but the interaction that matters most — extension middleware rewriting arguments that the gate then inspects — is asserted at the agent layer (`TestTieredApprovalIsToolMiddleware`) rather than here.
- **Tests:** 6 new, 15 assertions. Zero existing assertions modified or weakened.

## Testing

`make test` and `make test-agent` clean; `agent/host` green under `-race`.

