### PR TITLE
feat(agent): exported run scope so a call knows where it sits

### DIFF
--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -243,10 +243,7 @@ func (p *AgentPool) spawn(ctx context.Context, name, task string) (string, error
 	id := fmt.Sprintf("agent-%d", p.seq)
 	p.mu.Unlock()
 
-	childScope := name
-	if parent := agentScope(ctx); parent != "" {
-		childScope = parent + "/" + name
-	}
+	childScope := agentScope(ctx).Child(name)
 	bgCtx := withAgentScope(withAgentDepth(core.DetachForBackground(ctx), depth+1), childScope)
 	runCtx, cancel := context.WithCancel(bgCtx)
 
@@ -258,7 +255,7 @@ func (p *AgentPool) spawn(ctx context.Context, name, task string) (string, error
 	emit := func(Event) {}
 	if p.onEvent != nil {
 		childDepth := depth + 1
-		emit = func(e Event) { p.onEvent(SubAgentEvent{Scope: childScope, Depth: childDepth, Event: e}) }
+		emit = func(e Event) { p.onEvent(SubAgentEvent{Scope: childScope.String(), Depth: childDepth, Event: e}) }
 	}
 	go func() {
 		result, err := spec.runner.Run(runCtx, []Message{{Role: RoleUser, Text: task}}, emit)

--- a/agent/agent_source.go
+++ b/agent/agent_source.go
@@ -159,10 +159,7 @@ func (s *AgentSource) Call(ctx context.Context, name string, args map[string]any
 
 	// Extend both ctx threads for the child: depth (guards) and scope (the
 	// path this sub-agent's events are tagged with).
-	childScope := s.cfg.Name
-	if parent := agentScope(ctx); parent != "" {
-		childScope = parent + "/" + s.cfg.Name
-	}
+	childScope := agentScope(ctx).Child(s.cfg.Name)
 	childCtx := withAgentScope(withAgentDepth(ctx, depth+1), childScope)
 	// Hand the child the sink of the dispatch that spawned it (issue 1165), so
 	// the child's signal_parent raises to THIS parent — the child's own dispatch
@@ -174,7 +171,7 @@ func (s *AgentSource) Call(ctx context.Context, name string, args map[string]any
 	emit := func(Event) {}
 	if s.cfg.OnEvent != nil {
 		childDepth := depth + 1
-		emit = func(e Event) { s.cfg.OnEvent(SubAgentEvent{Scope: childScope, Depth: childDepth, Event: e}) }
+		emit = func(e Event) { s.cfg.OnEvent(SubAgentEvent{Scope: childScope.String(), Depth: childDepth, Event: e}) }
 	}
 	result, err := s.cfg.Runner.Run(childCtx, []Message{{Role: RoleUser, Text: seed}}, emit)
 	if err != nil {
@@ -193,17 +190,21 @@ type agentDepthKey struct{}
 type agentBudgetKey struct{}
 type agentScopeKey struct{}
 
-// withAgentScope stamps the slash-joined sub-agent path on ctx so a nested
-// AgentSource can prefix its own name and tag its child's events with the
-// full path.
-func withAgentScope(ctx context.Context, scope string) context.Context {
-	return context.WithValue(ctx, agentScopeKey{}, scope)
+// withAgentScope stamps the sub-agent ancestry on ctx so a nested source can
+// extend it and tag its child's events with the full path.
+//
+// Stored structurally rather than slash-joined because RunScope exports it:
+// a joined string cannot answer "am I under X" without substring traps, and
+// cannot be split back safely when a name contains the separator. String() is
+// the display form, applied at the point of display.
+func withAgentScope(ctx context.Context, path AgentPath) context.Context {
+	return context.WithValue(ctx, agentScopeKey{}, path)
 }
 
-// agentScope reads the current sub-agent path ("" at the top level).
-func agentScope(ctx context.Context) string {
-	s, _ := ctx.Value(agentScopeKey{}).(string)
-	return s
+// agentScope reads the current sub-agent ancestry (empty at the top level).
+func agentScope(ctx context.Context) AgentPath {
+	p, _ := ctx.Value(agentScopeKey{}).(AgentPath)
+	return p
 }
 
 // withAgentDepth stamps the current sub-agent nesting depth on ctx; each

--- a/agent/async_agent_source.go
+++ b/agent/async_agent_source.go
@@ -129,10 +129,7 @@ func (s *AsyncAgentSource) Call(ctx context.Context, name string, args map[strin
 		seed = in.Task
 	}
 
-	childScope := s.cfg.Name
-	if parent := agentScope(ctx); parent != "" {
-		childScope = parent + "/" + s.cfg.Name
-	}
+	childScope := agentScope(ctx).Child(s.cfg.Name)
 	// Detach for background: the child outlives the spawning turn AND calls MCP
 	// server tools, so it needs the session-level push (DetachForBackground),
 	// not a plain context.WithoutCancel. Depth/scope are threaded onto the
@@ -142,7 +139,7 @@ func (s *AsyncAgentSource) Call(ctx context.Context, name string, args map[strin
 	emit := func(Event) {}
 	if s.cfg.OnEvent != nil {
 		childDepth := depth + 1
-		emit = func(e Event) { s.cfg.OnEvent(SubAgentEvent{Scope: childScope, Depth: childDepth, Event: e}) }
+		emit = func(e Event) { s.cfg.OnEvent(SubAgentEvent{Scope: childScope.String(), Depth: childDepth, Event: e}) }
 	}
 
 	go func() {

--- a/agent/runner.go
+++ b/agent/runner.go
@@ -809,6 +809,7 @@ func (r *Runner) callTool(ctx context.Context, parent context.Context, step int,
 	res, err := chainToolMiddleware(r.cfg.ToolMiddleware, dispatch)(ctx, ToolCallInfo{
 		Step:     step,
 		Call:     call,
+		Scope:    ScopeFrom(ctx),
 		ReadOnly: toolReadOnly(tools, call.Name),
 	})
 	if err != nil {

--- a/agent/runscope.go
+++ b/agent/runscope.go
@@ -1,0 +1,140 @@
+package agent
+
+import (
+	"context"
+	"strings"
+)
+
+// AgentHop is one link in a run's agent ancestry: the sub-agent that was
+// invoked at that level.
+//
+// It is a struct rather than a bare name so a hop can grow without breaking
+// every caller. A child's location is not guaranteed — the in-process
+// AgentSource is the degenerate co-located case, and constraint A7 states the
+// general case is a child on another host, provider, or model. When that
+// arrives a hop gains where it ran; adding a field here is a minor change,
+// while widening []string to []AgentHop later would not have been.
+type AgentHop struct {
+	// Name is the sub-agent's registered name, as given to AgentSource,
+	// FanOutSource, Team, or AgentPool.
+	Name string `json:"name"`
+}
+
+// AgentPath is a run's agent ancestry, outermost first: who invoked whom to
+// reach the code reading it. Empty at the top level.
+//
+// Read it as a stack trace rather than a graph path. Each entry is a frame,
+// which is why a cycle needs no special handling: an agent that reaches itself
+// appears twice, exactly as recursion shows repeated frames, and the per-source
+// depth cap (DefaultMaxAgentDepth) bounds how far that can go.
+type AgentPath []AgentHop
+
+// Depth reports how deep in the agent tree this path is: 0 at the top level.
+func (p AgentPath) Depth() int { return len(p) }
+
+// Contains reports whether name appears anywhere in the ancestry, which is the
+// exact form of "am I running under X".
+//
+// The reason this exists rather than callers matching on String: substring
+// matching against a joined path silently answers yes for "research" when the
+// ancestor is "researcher", and splitting a joined path is ambiguous because a
+// name may itself contain the separator.
+func (p AgentPath) Contains(name string) bool {
+	for _, h := range p {
+		if h.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// Child returns the path extended by one hop, without mutating the receiver.
+// This is what each source calls when it invokes a sub-agent.
+func (p AgentPath) Child(name string) AgentPath {
+	out := make(AgentPath, len(p), len(p)+1)
+	copy(out, p)
+	return append(out, AgentHop{Name: name})
+}
+
+// String renders the ancestry slash-joined ("researcher/summarizer") for
+// display, tracing, and Signal.Source. Lossy when a name contains a slash, so
+// use it to show a path and Contains to test one.
+func (p AgentPath) String() string {
+	if len(p) == 0 {
+		return ""
+	}
+	names := make([]string, len(p))
+	for i, h := range p {
+		names[i] = h.Name
+	}
+	return strings.Join(names, "/")
+}
+
+// TreeUsage is how much of a turn's aggregate TreeBudget has been consumed, so
+// an extension can back off before exhaustion rather than discovering it as
+// ErrTreeBudget, which aborts.
+//
+// A zero Max means that dimension is unbounded, which is also what an entirely
+// unbudgeted turn reports. Usage is only tracked for a dimension that has a
+// cap, so StepsUsed and TokensUsed read 0 when their Max does — the counter
+// exists to enforce a limit, and there is none to enforce.
+//
+// Both counts are post-hoc for the same reason TreeBudget.MaxTokens is: usage
+// is known only after a model call, so a reading can be one step stale.
+type TreeUsage struct {
+	StepsUsed  int `json:"stepsUsed"`
+	MaxSteps   int `json:"maxSteps"`
+	TokensUsed int `json:"tokensUsed"`
+	MaxTokens  int `json:"maxTokens"`
+}
+
+// RunScope is what a call knows about the run it belongs to, beyond its own
+// arguments: where it sits in the agent tree and what the tree has spent.
+//
+// It exists because the Extension seam and the run's own state pulled against
+// each other. A middleware received only its call, so a checkpoint extension
+// could not tell it was running inside a sub-agent and snapshotted on every
+// nested call, and a budget-aware extension could not read how much tree
+// budget remained.
+//
+// Read-only by construction. Every field is a value the Runner owns; setting
+// depth or budget stays with the Runner and the sub-agent sources.
+//
+// Values only, and wire-serializable, for the same reason Event is (constraint
+// A2): a scope may cross a parent/child boundary that a pointer cannot, and
+// A7 forbids handing a child a handle to parent state.
+//
+// Deliberately absent: the signal sinks. They are a control mechanism rather
+// than a fact about the run, and exposing one would let an extension raise a
+// signal as though it came from a child — the forgery the non-referential
+// signal design exists to prevent. The pending Team handoff is out for the
+// same reason: it is in-flight control, not scope.
+type RunScope struct {
+	// Path is the agent ancestry, empty at the top level.
+	Path AgentPath `json:"path,omitempty"`
+
+	// CallBudget is the sub-agent invocations remaining under
+	// WithAgentCallBudget, shared across the whole tree. -1 when unbounded.
+	CallBudget int `json:"callBudget"`
+
+	// Tree is the aggregate TreeBudget consumption for this turn.
+	Tree TreeUsage `json:"tree"`
+}
+
+// Depth reports how deep in the agent tree the call is, 0 at the top level.
+// Shorthand for Path.Depth(), which is the check most callers want.
+func (s RunScope) Depth() int { return s.Path.Depth() }
+
+// ScopeFrom reads the run scope a context carries. A context that never
+// crossed a Runner returns the zero scope with CallBudget -1, so a caller
+// outside a run sees "top level, nothing bounded" rather than a false limit.
+//
+// Middleware does not need this: ToolCallInfo.Scope is already populated. It
+// is here for a tool implementation, which receives only a context.
+func ScopeFrom(ctx context.Context) RunScope {
+	s := RunScope{Path: agentScope(ctx), CallBudget: -1, Tree: treeBudgetFrom(ctx).usage()}
+	if b := agentCallBudget(ctx); b != nil {
+		s.CallBudget = int(b.Load())
+	}
+	return s
+}

--- a/agent/runscope_test.go
+++ b/agent/runscope_test.go
@@ -1,0 +1,350 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+func TestAgentPathBasics(t *testing.T) {
+	var p AgentPath
+	if p.Depth() != 0 || p.String() != "" {
+		t.Fatalf("zero path = depth %d, %q", p.Depth(), p.String())
+	}
+
+	child := p.Child("researcher").Child("summarizer")
+	if child.Depth() != 2 {
+		t.Fatalf("depth = %d, want 2", child.Depth())
+	}
+	if got := child.String(); got != "researcher/summarizer" {
+		t.Fatalf("String() = %q", got)
+	}
+	if !child.Contains("researcher") || !child.Contains("summarizer") {
+		t.Fatalf("Contains missed an ancestor: %v", child)
+	}
+	if p.Depth() != 0 {
+		t.Fatal("Child mutated the receiver")
+	}
+}
+
+// TestAgentPathContainsIsExact is why hops are a list rather than a joined
+// string: substring matching answers yes for a name that merely shares a
+// prefix, which would silently mis-scope a middleware.
+func TestAgentPathContainsIsExact(t *testing.T) {
+	p := AgentPath{}.Child("researcher")
+	if p.Contains("research") {
+		t.Fatal(`Contains("research") matched the ancestor "researcher"`)
+	}
+	if strings.Contains(p.String(), "research") == false {
+		t.Fatal("precondition: the joined form does contain the prefix, which is the trap")
+	}
+}
+
+// TestAgentPathToleratesSeparatorInName pins the other half: a name carrying a
+// slash cannot forge an extra level, which splitting a joined path would.
+func TestAgentPathToleratesSeparatorInName(t *testing.T) {
+	p := AgentPath{}.Child("a/b").Child("c")
+	if p.Depth() != 2 {
+		t.Fatalf("depth = %d, want 2 — a slash in a name must not add a level", p.Depth())
+	}
+	if !p.Contains("a/b") {
+		t.Fatal(`Contains("a/b") failed`)
+	}
+	if p.Contains("a") || p.Contains("b") {
+		t.Fatal("a slash in a name leaked as separate hops")
+	}
+}
+
+// TestRunScopeRoundTrip is the A2 obligation: a scope may cross a parent/child
+// boundary, so it has to survive encoding/json unchanged.
+func TestRunScopeRoundTrip(t *testing.T) {
+	want := RunScope{
+		Path:       AgentPath{}.Child("researcher").Child("summarizer"),
+		CallBudget: 3,
+		Tree:       TreeUsage{StepsUsed: 2, MaxSteps: 10, TokensUsed: 500, MaxTokens: 2000},
+	}
+	raw, err := json.Marshal(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got RunScope
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("round-trip drift:\n got %+v\nwant %+v", got, want)
+	}
+}
+
+// TestScopeFromBareContext pins the outside-a-run reading: top level, nothing
+// bounded. CallBudget must be -1 rather than 0, which would read as exhausted.
+func TestScopeFromBareContext(t *testing.T) {
+	s := ScopeFrom(context.Background())
+	if s.Depth() != 0 || len(s.Path) != 0 {
+		t.Fatalf("bare ctx scope = %+v, want empty path", s)
+	}
+	if s.CallBudget != -1 {
+		t.Fatalf("CallBudget = %d, want -1 (unbounded)", s.CallBudget)
+	}
+}
+
+// scopeProbe records the scope every tool call was dispatched with, keyed by
+// tool name, so a test can compare a parent's view with its child's.
+type scopeProbe struct {
+	mu   sync.Mutex
+	seen map[string]RunScope
+}
+
+func newScopeProbe() *scopeProbe { return &scopeProbe{seen: map[string]RunScope{}} }
+
+func (p *scopeProbe) middleware() ToolMiddleware {
+	return func(ctx context.Context, info ToolCallInfo, next ToolCallFunc) (*core.ToolResult, error) {
+		p.mu.Lock()
+		p.seen[info.Call.Name] = info.Scope
+		p.mu.Unlock()
+		return next(ctx, info)
+	}
+}
+
+func (p *scopeProbe) get(tool string) RunScope {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.seen[tool]
+}
+
+// TestScopeDepthInsideSubAgent is the ticket's named acceptance: a middleware
+// running inside a sub-agent reads a non-empty path while the parent's reads
+// empty. Without it a checkpoint extension snapshots on every nested call.
+func TestScopeDepthInsideSubAgent(t *testing.T) {
+	probe := newScopeProbe()
+
+	childTools := NewFuncSource()
+	if err := AddFunc(childTools, "child_tool", "runs in the child", func(context.Context, struct{}) (string, error) {
+		return "ok", nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	child, err := NewRunner(RunnerConfig{
+		Provider: NewStubProvider(
+			StubTurn{ToolCalls: []ToolCall{{ID: "k1", Name: "child_tool", Args: core.NewRawJSON([]byte(`{}`))}}},
+			StubTurn{Text: "child done"},
+		),
+		Tools:          childTools,
+		ToolMiddleware: []ToolMiddleware{probe.middleware()},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sub, err := NewAgentSource(AgentSourceConfig{
+		Name: "researcher", Description: "researches", Runner: child,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	parentTools := NewMultiSource()
+	if err := parentTools.Add("sub", sub); err != nil {
+		t.Fatal(err)
+	}
+	own := NewFuncSource()
+	if err := AddFunc(own, "parent_tool", "runs at the top", func(context.Context, struct{}) (string, error) {
+		return "ok", nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := parentTools.Add("own", own); err != nil {
+		t.Fatal(err)
+	}
+
+	parent, err := NewRunner(RunnerConfig{
+		Provider: NewStubProvider(
+			StubTurn{ToolCalls: []ToolCall{{ID: "p1", Name: "parent_tool", Args: core.NewRawJSON([]byte(`{}`))}}},
+			StubTurn{ToolCalls: []ToolCall{{ID: "p2", Name: "researcher", Args: core.NewRawJSON([]byte(`{"task":"go"}`))}}},
+			StubTurn{Text: "parent done"},
+		),
+		Tools:          parentTools,
+		ToolMiddleware: []ToolMiddleware{probe.middleware()},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := parent.Run(context.Background(), nil, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	top := probe.get("parent_tool")
+	if top.Depth() != 0 {
+		t.Fatalf("top-level call saw depth %d, want 0 (path %v)", top.Depth(), top.Path)
+	}
+	nested := probe.get("child_tool")
+	if nested.Depth() != 1 {
+		t.Fatalf("sub-agent call saw depth %d, want 1 (path %v)", nested.Depth(), nested.Path)
+	}
+	if !nested.Path.Contains("researcher") {
+		t.Fatalf("sub-agent path = %v, want it to contain the persona name", nested.Path)
+	}
+}
+
+// TestScopeCallBudgetVisible pins that an extension can read the remaining
+// sub-agent budget, which is what lets it back off before exhaustion instead
+// of discovering ErrTreeBudget.
+func TestScopeCallBudgetVisible(t *testing.T) {
+	probe := newScopeProbe()
+	src := NewFuncSource()
+	if err := AddFunc(src, "t", "a tool", func(context.Context, struct{}) (string, error) { return "ok", nil }); err != nil {
+		t.Fatal(err)
+	}
+	r, err := NewRunner(RunnerConfig{
+		Provider: NewStubProvider(
+			StubTurn{ToolCalls: []ToolCall{{ID: "c1", Name: "t", Args: core.NewRawJSON([]byte(`{}`))}}},
+			StubTurn{Text: "done"},
+		),
+		Tools:          src,
+		ToolMiddleware: []ToolMiddleware{probe.middleware()},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := WithAgentCallBudget(context.Background(), 5)
+	if _, err := r.Run(ctx, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	if got := probe.get("t").CallBudget; got != 5 {
+		t.Fatalf("CallBudget = %d, want 5", got)
+	}
+}
+
+// TestScopeTreeUsageVisible pins the other half of budget awareness: caps and
+// consumption both reach the middleware.
+func TestScopeTreeUsageVisible(t *testing.T) {
+	probe := newScopeProbe()
+	src := NewFuncSource()
+	if err := AddFunc(src, "t", "a tool", func(context.Context, struct{}) (string, error) { return "ok", nil }); err != nil {
+		t.Fatal(err)
+	}
+	r, err := NewRunner(RunnerConfig{
+		Provider: NewStubProvider(
+			StubTurn{ToolCalls: []ToolCall{{ID: "c1", Name: "t", Args: core.NewRawJSON([]byte(`{}`))}}},
+			StubTurn{Text: "done"},
+		),
+		Tools:          src,
+		ToolMiddleware: []ToolMiddleware{probe.middleware()},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := WithTreeBudget(context.Background(), TreeBudget{MaxSteps: 10, MaxTokens: 9999})
+	if _, err := r.Run(ctx, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	got := probe.get("t").Tree
+	if got.MaxSteps != 10 || got.MaxTokens != 9999 {
+		t.Fatalf("caps not surfaced: %+v", got)
+	}
+	if got.StepsUsed <= 0 {
+		t.Fatalf("StepsUsed = %d, want the step already consumed to be visible", got.StepsUsed)
+	}
+}
+
+// TestScopeUnbudgetedReadsUnbounded pins that a turn with no TreeBudget
+// reports zero caps rather than a false limit an extension might respect.
+func TestScopeUnbudgetedReadsUnbounded(t *testing.T) {
+	probe := newScopeProbe()
+	src := NewFuncSource()
+	if err := AddFunc(src, "t", "a tool", func(context.Context, struct{}) (string, error) { return "ok", nil }); err != nil {
+		t.Fatal(err)
+	}
+	r, err := NewRunner(RunnerConfig{
+		Provider: NewStubProvider(
+			StubTurn{ToolCalls: []ToolCall{{ID: "c1", Name: "t", Args: core.NewRawJSON([]byte(`{}`))}}},
+			StubTurn{Text: "done"},
+		),
+		Tools:          src,
+		ToolMiddleware: []ToolMiddleware{probe.middleware()},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Run(context.Background(), nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	s := probe.get("t")
+	if s.Tree.MaxSteps != 0 || s.Tree.MaxTokens != 0 {
+		t.Fatalf("unbudgeted turn reported caps: %+v", s.Tree)
+	}
+	if s.CallBudget != -1 {
+		t.Fatalf("CallBudget = %d, want -1", s.CallBudget)
+	}
+}
+
+// TestScopeFanOutMembersAreIndependent is the aliasing check that AgentPath.Child
+// exists for. Fan-out members run concurrently off one parent context; if Child
+// appended into a shared backing array, two members would see each other's hop
+// or race on the same slice. Run under -race.
+func TestScopeFanOutMembersAreIndependent(t *testing.T) {
+	probe := newScopeProbe()
+
+	member := func(name, tool string) *AgentSource {
+		t.Helper()
+		src := NewFuncSource()
+		if err := AddFunc(src, tool, "member tool", func(context.Context, struct{}) (string, error) {
+			return "ok", nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+		r, err := NewRunner(RunnerConfig{
+			Provider: NewStubProvider(
+				StubTurn{ToolCalls: []ToolCall{{ID: "m", Name: tool, Args: core.NewRawJSON([]byte(`{}`))}}},
+				StubTurn{Text: "member done"},
+			),
+			Tools:          src,
+			ToolMiddleware: []ToolMiddleware{probe.middleware()},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		as, err := NewAgentSource(AgentSourceConfig{Name: name, Description: name, Runner: r})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return as
+	}
+
+	fan, err := NewFanOutSource(FanOutConfig{
+		Name: "ensemble", Description: "broadcasts",
+		Members: []*AgentSource{member("alpha", "alpha_tool"), member("beta", "beta_tool")},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parent, err := NewRunner(RunnerConfig{
+		Provider: NewStubProvider(
+			StubTurn{ToolCalls: []ToolCall{{ID: "f1", Name: "ensemble", Args: core.NewRawJSON([]byte(`{"task":"go"}`))}}},
+			StubTurn{Text: "parent done"},
+		),
+		Tools: fan,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := parent.Run(context.Background(), nil, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	a, b := probe.get("alpha_tool"), probe.get("beta_tool")
+	if a.Depth() != 1 || b.Depth() != 1 {
+		t.Fatalf("member depths = %d and %d, want 1 each", a.Depth(), b.Depth())
+	}
+	if !a.Path.Contains("alpha") || a.Path.Contains("beta") {
+		t.Fatalf("alpha saw path %v — a member must not see a sibling's hop", a.Path)
+	}
+	if !b.Path.Contains("beta") || b.Path.Contains("alpha") {
+		t.Fatalf("beta saw path %v — a member must not see a sibling's hop", b.Path)
+	}
+}

--- a/agent/signal.go
+++ b/agent/signal.go
@@ -209,7 +209,7 @@ func RaiseSignal(ctx context.Context, sig Signal) bool {
 		return false
 	}
 	if sig.Source == "" {
-		sig.Source = agentScope(ctx)
+		sig.Source = agentScope(ctx).String()
 	}
 	sink.raise(sig)
 	return true

--- a/agent/toolmiddleware.go
+++ b/agent/toolmiddleware.go
@@ -61,6 +61,15 @@ type ToolCallInfo struct {
 	// Bind for typed inspection without a second parse.
 	Call ToolCall
 
+	// Scope is where in the run this call sits: the agent ancestry, the
+	// remaining sub-agent call budget, and the turn tree's usage against its
+	// caps. Populated by the Runner at dispatch; see RunScope.
+	//
+	// A middleware needs it to behave correctly at depth — a checkpoint that
+	// ignores it snapshots once per nested call, and a budget-aware one
+	// cannot back off before exhaustion.
+	Scope RunScope
+
 	// ReadOnly reflects the tool's readOnlyHint annotation, false when the
 	// tool declares none. It is a hint from the server, not a guarantee that
 	// the call is free of side effects.

--- a/agent/tree_budget.go
+++ b/agent/tree_budget.go
@@ -86,3 +86,24 @@ func (st *treeBudgetState) addTokens(n int) {
 		st.tokensUsed.Add(int64(n))
 	}
 }
+
+// usage snapshots consumption against the caps for RunScope. A nil state (no
+// budget installed) reports all zeros, which RunScope documents as unbounded.
+//
+// Steps are stored as a remaining count and reported as a used one, so the two
+// dimensions read the same way. Both are only tracked when their cap is set —
+// consumeStep and addTokens skip an uncapped dimension because there is
+// nothing to enforce — so an uncapped dimension reports 0 used.
+func (st *treeBudgetState) usage() TreeUsage {
+	if st == nil {
+		return TreeUsage{}
+	}
+	u := TreeUsage{MaxSteps: int(st.maxSteps), MaxTokens: int(st.maxTokens)}
+	if st.maxSteps > 0 {
+		u.StepsUsed = int(st.maxSteps - st.stepsLeft.Load())
+	}
+	if st.maxTokens > 0 {
+		u.TokensUsed = int(st.tokensUsed.Load())
+	}
+	return u
+}


### PR DESCRIPTION
Closes #1259.

## What changes

`ToolCallInfo` gains `Scope RunScope` — the agent ancestry, remaining sub-agent call budget, and the turn tree's usage against its caps — plus `ScopeFrom(ctx)` for tool implementations that only have a context. All read-only; the Runner still owns every field.

## ELI15

A tool call today is like a phone call with no caller ID. You know what's being asked, and nothing about who's on the line or how you got connected.

That's fine until something has to behave differently depending on the chain. A checkpoint feature wants to snapshot files before a write — but if the write comes from a sub-agent three levels down, it should skip, because the top-level snapshot already covers it. Without caller ID it snapshots every time. Similarly, a feature that wants to wind down as a token budget runs low can't, because there's no way to ask how much is left; the only signal is the error you get when it's already gone.

The interesting decision is the shape of the chain. The obvious move is a string — `"researcher/summarizer"` — which is how it was stored internally. That works while nobody reads it, and breaks the moment somebody does. Asking "am I under the researcher?" becomes substring matching, which also says yes inside `"researching-agent"`. Splitting it back apart assumes no agent is ever named with a slash in it, and nothing enforces that. So the chain ships as a **list of hops**, where those two questions have exact answers.

Worth knowing: this is a stack trace, not a route. An agent that reaches itself just appears twice, the way recursion shows repeated frames — so cycles need no special handling, and the existing depth cap already bounds them.

## Reviewer's guide

1. [agent/runscope.go](https://github.com/panyam/mcpkit/pull/1264/files#diff-96c4ba04657e9ecc5d029809602ca0584d4cc93f6c6e87148df076bc014ad05c) — the whole surface. `AgentHop` / `AgentPath` / `TreeUsage` / `RunScope` / `ScopeFrom`.
2. [agent/runscope_test.go](https://github.com/panyam/mcpkit/pull/1264/files#diff-1d5984008874bf148cbb6f0b7ab2ef1f37693b2ee4caa71d685af59cf19389e5) — acceptance, including the aliasing and JSON cases.
3. [agent/agent_source.go](https://github.com/panyam/mcpkit/pull/1264/files#diff-cb9651df111cfad72b6d4ca30ae061405bedefa4b107cd0a6d36cd53a089bb8d) — the accessor pair changes type; the prefixing becomes `Child`.
4. [agent/runner.go](https://github.com/panyam/mcpkit/pull/1264/files#diff-6d787b427ac08cd61669af7e34ff0b747c4264d20b31b21b681a2ec2c826d9f0) — one line, the single dispatch site.
5. [agent/tree_budget.go](https://github.com/panyam/mcpkit/pull/1264/files#diff-a738765fbe624c6aaea795f7d21f1d35f5fa1bda06727f978a5a20f11ada42b5) — the usage snapshot.

Skim: `agent_pool.go`, `async_agent_source.go`, `signal.go`, `toolmiddleware.go` — mechanical.

## How it works

```
dispatch(call):
    info.Scope = ScopeFrom(ctx):
        Path       = agentScope(ctx)              # []AgentHop, empty at top level
        CallBudget = agentCallBudget(ctx) or -1   # -1 = unbounded
        Tree       = treeBudgetFrom(ctx).usage()  # zeros when unbudgeted

AgentSource / AgentPool / AsyncAgentSource, invoking a child:
    childPath = agentScope(ctx).Child(name)   # copies; never appends in place
```

The copy in `Child` is load-bearing. Fan-out members run concurrently off one parent context, so appending into a shared backing array would let two siblings see each other's hop, or race. `TestScopeFanOutMembersAreIndependent` pins it under `-race`.

## Decision log

- **`[]AgentHop`, not `[]string`.** A hop has one field today. Adding a field to it later is a minor change; widening `[]string` to `[]AgentHop` later is breaking — and A7 already states a child's location isn't guaranteed, so a hop gaining *where it ran* is a question of when, not if.
- **`Depth` derived, not stored.** Path and the depth ctx value are set together at all three construction sites (fan-out reuses `AgentSource` wholesale), so a stored copy could only drift from the path. `RunScope.Depth()` reads `len(Path)`.
- **`SubAgentEvent.Scope` stays a string.** It's a display field the surfaces render, so the path joins at that boundary rather than rippling a type change into host and web.
- **`TreeUsage` reports steps *used*, not remaining,** so both dimensions read alike — the internal counter stores steps as a countdown and tokens as a count-up.
- **Uncapped dimensions report 0 used, documented rather than fixed.** `consumeStep` and `addTokens` only track a dimension they can enforce. Making them count when unbounded is a behaviour change to a shared counter and deserves its own reasoning, not a drive-by.
- **Signal sinks and the Team handoff stay unexported.** A sink is in-flight control, not a fact about the run, and exposing one would let an extension raise a signal as though it came from a child — precisely the forgery the non-referential signal design prevents. Recorded on the type so it reads as deliberate.

## Before / after

```go
// before — a checkpoint middleware, unable to tell where it is
agent.BeforeToolCall(func(ctx context.Context, info *agent.ToolCallInfo) error {
    if isWrite(info.Call.Name) {
        saveSnapshot()        // also fires for every nested sub-agent call
    }
    return nil
})

// after
agent.BeforeToolCall(func(ctx context.Context, info *agent.ToolCallInfo) error {
    if info.Scope.Depth() > 0 {
        return nil            // children write inside the parent's snapshot
    }
    if isWrite(info.Call.Name) {
        saveSnapshot()
    }
    return nil
})

// and backing off before exhaustion, rather than meeting ErrTreeBudget
if t := info.Scope.Tree; t.MaxTokens > 0 && t.TokensUsed > t.MaxTokens*8/10 {
    return agent.DenyTool("tree budget nearly spent — wrap up")
}
```

## Risk

- **Affects:** `agent/` only. No `core`/`server`/`client` changes and no new requires, so A1 and A10 hold. `ToolCallInfo` gains a field, which is source-compatible for keyed construction (every site in-tree is keyed).
- **Be paranoid about:** the internal representation change from `string` to `AgentPath`. Four call sites moved; `signal.go` now joins at the boundary via `.String()`, so `Signal.Source` is unchanged in form. Worth checking nothing else compared a scope as a string.
- **Tests:** 9 new, 49 assertions. Zero existing tests modified, zero assertions weakened.

## Out of scope

- `MaxCost` as a budget dimension → #1261
- `Destructive` / `Idempotent` on `ToolCallInfo` → #1260
- `Hint.Scope`, which consumes this → #1263

## Testing

`make test` and `make test-agent` clean; `agent` green under `-race`, which matters here for the concurrent fan-out case.

