### PR TITLE
feat(agent): reversibility as an approval axis distinct from readOnlyHint

### DIFF
--- a/agent/approval.go
+++ b/agent/approval.go
@@ -23,6 +23,17 @@ const (
 	// ModeReadOnlyAuto auto-allows calls whose tool declares readOnlyHint
 	// and asks for the rest. The "read-only → auto-edit" rung of the ladder.
 	ModeReadOnlyAuto
+	// ModeReversibleAuto auto-allows a call that reads, and a call that
+	// writes something the tool declares it can undo, asking only when the
+	// effect is irreversible. The rung above ModeReadOnlyAuto: it separates
+	// "does this write?" from "can this be taken back?", so an editing tool
+	// stops prompting while a send or a delete still does.
+	//
+	// It keys on ToolCallInfo.Destructive, so a tool that annotates nothing
+	// is asked about rather than assumed reversible. Against servers that
+	// skip destructiveHint entirely this behaves exactly like ModeAlwaysAsk,
+	// which is the intended failure direction.
+	ModeReversibleAuto
 	// ModeAlwaysAllow runs every uncovered call without asking (full-auto /
 	// "yolo"). Per-tool Deny rules still apply on top.
 	ModeAlwaysAllow
@@ -154,6 +165,11 @@ func (t *TieredApproval) WrapToolCall(ctx context.Context, info ToolCallInfo, ne
 		return next(ctx, info)
 	case ModeReadOnlyAuto:
 		if info.ReadOnly {
+			return next(ctx, info)
+		}
+		return t.doAsk(ctx, info, next)
+	case ModeReversibleAuto:
+		if info.ReadOnly || !info.Destructive {
 			return next(ctx, info)
 		}
 		return t.doAsk(ctx, info, next)

--- a/agent/approval_test.go
+++ b/agent/approval_test.go
@@ -43,6 +43,17 @@ func req(tool string, readOnly bool) ToolCallInfo {
 	return ToolCallInfo{Call: ToolCall{Name: tool}, ReadOnly: readOnly}
 }
 
+func reqHints(tool string, readOnly, destructive bool) ToolCallInfo {
+	return ToolCallInfo{Call: ToolCall{Name: tool}, ReadOnly: readOnly, Destructive: destructive}
+}
+
+// resolved builds the info the way the Runner does, so a mode test exercises
+// the annotation defaults rather than hand-picked field values.
+func resolved(tool core.ToolDef) ToolCallInfo {
+	ro, d, i := toolHints([]core.ToolDef{tool}, tool.Name)
+	return ToolCallInfo{Call: ToolCall{Name: tool.Name}, ReadOnly: ro, Destructive: d, Idempotent: i}
+}
+
 func TestTieredApprovalModes(t *testing.T) {
 
 	t.Run("always-allow skips the ask", func(t *testing.T) {
@@ -159,16 +170,120 @@ func TestTieredApprovalDeclineAndNoUI(t *testing.T) {
 	})
 }
 
-func TestToolReadOnly(t *testing.T) {
+func TestReversibleAutoMode(t *testing.T) {
+	t.Run("allows read-only without asking", func(t *testing.T) {
+		ask, n := countingAsk(false)
+		p := NewTieredApproval(WithDefaultMode(ModeReversibleAuto), WithAsk(ask))
+		allowed, _, _ := gate(p, reqHints("list_files", true, false))
+		if !allowed || *n != 0 {
+			t.Fatalf("read-only should auto-allow: allowed=%v asks=%d", allowed, *n)
+		}
+	})
+
+	t.Run("allows a write the tool declares reversible", func(t *testing.T) {
+		ask, n := countingAsk(false)
+		p := NewTieredApproval(WithDefaultMode(ModeReversibleAuto), WithAsk(ask))
+		allowed, _, _ := gate(p, reqHints("edit_file", false, false))
+		if !allowed || *n != 0 {
+			t.Fatalf("reversible write should auto-allow: allowed=%v asks=%d", allowed, *n)
+		}
+	})
+
+	t.Run("asks on an irreversible write", func(t *testing.T) {
+		ask, n := countingAsk(true)
+		p := NewTieredApproval(WithDefaultMode(ModeReversibleAuto), WithAsk(ask))
+		allowed, _, _ := gate(p, reqHints("send_email", false, true))
+		if !allowed || *n != 1 {
+			t.Fatalf("destructive write should ask: allowed=%v asks=%d", allowed, *n)
+		}
+	})
+
+	// The conservative pin, through the Runner's own resolution path rather
+	// than hand-set fields: a tool that annotates nothing must reach the ask.
+	// Getting this backwards would silently widen what runs unattended.
+	t.Run("asks for an unannotated tool", func(t *testing.T) {
+		ask, n := countingAsk(true)
+		p := NewTieredApproval(WithDefaultMode(ModeReversibleAuto), WithAsk(ask))
+		allowed, _, _ := gate(p, resolved(core.ToolDef{Name: "shell"}))
+		if !allowed || *n != 1 {
+			t.Fatalf("unannotated tool should ask: allowed=%v asks=%d", allowed, *n)
+		}
+	})
+
+	t.Run("read-only-auto is unchanged by a reversible annotation", func(t *testing.T) {
+		ask, n := countingAsk(true)
+		p := NewTieredApproval(WithDefaultMode(ModeReadOnlyAuto), WithAsk(ask))
+		allowed, _, _ := gate(p, reqHints("edit_file", false, false))
+		if !allowed || *n != 1 {
+			t.Fatalf("read-only-auto should still ask on any write: allowed=%v asks=%d", allowed, *n)
+		}
+	})
+
+	t.Run("per-tool rules override the mode in both directions", func(t *testing.T) {
+		ask, n := countingAsk(true)
+		p := NewTieredApproval(
+			WithDefaultMode(ModeReversibleAuto),
+			WithToolRule("send_email", RuleAllow),
+			WithToolRule("edit_file", RuleAsk),
+			WithToolRule("rm_rf", RuleDeny),
+			WithAsk(ask),
+		)
+		if allowed, _, _ := gate(p, reqHints("send_email", false, true)); !allowed || *n != 0 {
+			t.Fatalf("RuleAllow should beat a destructive hint: allowed=%v asks=%d", allowed, *n)
+		}
+		if allowed, _, _ := gate(p, reqHints("edit_file", false, false)); !allowed || *n != 1 {
+			t.Fatalf("RuleAsk should beat a reversible hint: allowed=%v asks=%d", allowed, *n)
+		}
+		if allowed, reason, _ := gate(p, reqHints("rm_rf", false, false)); allowed || reason == "" {
+			t.Fatalf("RuleDeny should refuse: allowed=%v reason=%q", allowed, reason)
+		}
+	})
+}
+
+func TestToolHints(t *testing.T) {
 	tools := []core.ToolDef{
 		{Name: "list", Annotations: map[string]any{"readOnlyHint": true}},
 		{Name: "write", Annotations: map[string]any{"readOnlyHint": false}},
 		{Name: "plain"},
+		{Name: "edit", Annotations: map[string]any{"readOnlyHint": false, "destructiveHint": false}},
+		{Name: "send", Annotations: map[string]any{"readOnlyHint": false, "destructiveHint": true}},
+		{Name: "put", Annotations: map[string]any{"destructiveHint": false, "idempotentHint": true}},
+		// Contradictory: the spec says the other two are meaningful only
+		// when a tool writes, so read-only wins and this reports safe.
+		{Name: "contradictory", Annotations: map[string]any{"readOnlyHint": true, "destructiveHint": true, "idempotentHint": false}},
 	}
-	cases := map[string]bool{"list": true, "write": false, "plain": false, "unknown": false}
+	type hints struct{ readOnly, destructive, idempotent bool }
+	cases := map[string]hints{
+		"list":          {true, false, true},
+		"write":         {false, true, false},
+		"plain":         {false, true, false},
+		"edit":          {false, false, false},
+		"send":          {false, true, false},
+		"put":           {false, false, true},
+		"contradictory": {true, false, true},
+		"unknown":       {false, true, false},
+	}
 	for name, want := range cases {
-		if got := toolReadOnly(tools, name); got != want {
-			t.Errorf("toolReadOnly(%q) = %v, want %v", name, got, want)
+		ro, d, i := toolHints(tools, name)
+		if got := (hints{ro, d, i}); got != want {
+			t.Errorf("toolHints(%q) = %+v, want %+v", name, got, want)
+		}
+	}
+}
+
+// An absent destructiveHint must resolve to destructive, which is the one
+// default that inverts the Go zero value and so the one a refactor can quietly
+// flip.
+func TestToolHintsUnannotatedIsDestructive(t *testing.T) {
+	for _, tool := range []core.ToolDef{
+		{Name: "t"},
+		{Name: "t", Annotations: map[string]any{}},
+		{Name: "t", Annotations: map[string]any{"readOnlyHint": false}},
+		{Name: "t", Annotations: map[string]any{"idempotentHint": true}},
+		{Name: "t", Annotations: map[string]any{"destructiveHint": "not-a-bool"}},
+	} {
+		if _, destructive, _ := toolHints([]core.ToolDef{tool}, "t"); !destructive {
+			t.Errorf("annotations %v resolved to non-destructive", tool.Annotations)
 		}
 	}
 }

--- a/agent/host/commands.go
+++ b/agent/host/commands.go
@@ -237,7 +237,7 @@ func (a *App) registerBuiltinCommands() {
 			return CmdResult{Kind: CmdTasks, Tasks: a.snapshotTasks()}, nil
 		}})
 
-	r.Register(&Command{Name: "approve", Help: "show or set approval mode (allow | read-only-auto | ask)",
+	r.Register(&Command{Name: "approve", Help: "show or set approval mode (allow | reversible-auto | read-only-auto | ask)",
 		Run: func(_ context.Context, args string) (CmdResult, error) {
 			if args != "" && a.approval != nil {
 				mode := parseApprovalMode(args)

--- a/agent/host/config.go
+++ b/agent/host/config.go
@@ -368,8 +368,10 @@ func (c *OffloadConfig) toAgent() agent.OffloadConfig {
 type ApprovalConfig struct {
 	// Mode is the default disposition for calls no rule covers: "ask"
 	// (default), "read-only-auto" (auto-allow tools that declare the
-	// readOnlyHint annotation, ask for the rest), or "allow" (run
-	// everything, "yolo"). An unknown value falls back to "ask".
+	// readOnlyHint annotation, ask for the rest), "reversible-auto" (also
+	// auto-allow a write the tool declares non-destructive, ask on the rest),
+	// or "allow" (run everything, "yolo"). An unknown value falls back to
+	// "ask".
 	Mode string `json:"mode,omitempty"`
 
 	// Rules pins per-tool overrides that win over Mode: tool name ->
@@ -429,8 +431,10 @@ func parseApprovalMode(s string) agent.ApprovalMode {
 	switch strings.ToLower(strings.TrimSpace(s)) {
 	case "allow", "yolo", "auto", "full-auto":
 		return agent.ModeAlwaysAllow
-	case "read-only-auto", "readonly", "read-only", "auto-edit":
+	case "read-only-auto", "readonly", "read-only":
 		return agent.ModeReadOnlyAuto
+	case "reversible-auto", "reversible", "auto-edit":
+		return agent.ModeReversibleAuto
 	default:
 		return agent.ModeAlwaysAsk
 	}
@@ -443,6 +447,8 @@ func approvalModeName(m agent.ApprovalMode) string {
 		return "allow"
 	case agent.ModeReadOnlyAuto:
 		return "read-only-auto"
+	case agent.ModeReversibleAuto:
+		return "reversible-auto"
 	default:
 		return "ask"
 	}

--- a/agent/host/config_test.go
+++ b/agent/host/config_test.go
@@ -1,6 +1,10 @@
 package host
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/panyam/mcpkit/agent"
+)
 
 func TestConfigValidate_ConnectionsSupersedeModel(t *testing.T) {
 	// connections-only config is valid without a Model block
@@ -17,5 +21,39 @@ func TestConfigValidate_ConnectionsSupersedeModel(t *testing.T) {
 	empty := &Config{Servers: []ServerConfig{{ID: "s", URL: "http://x/mcp"}}}
 	if err := empty.Validate(); err == nil {
 		t.Fatal("config with neither model nor connections should error")
+	}
+}
+
+func TestParseApprovalMode(t *testing.T) {
+	cases := map[string]agent.ApprovalMode{
+		"ask":             agent.ModeAlwaysAsk,
+		"":                agent.ModeAlwaysAsk,
+		"nonsense":        agent.ModeAlwaysAsk,
+		"read-only-auto":  agent.ModeReadOnlyAuto,
+		"readonly":        agent.ModeReadOnlyAuto,
+		"  Read-Only  ":   agent.ModeReadOnlyAuto,
+		"reversible-auto": agent.ModeReversibleAuto,
+		"reversible":      agent.ModeReversibleAuto,
+		// "auto-edit" named the read-only tier before a reversible tier
+		// existed, where it never auto-allowed an edit. It points at the
+		// mode it always described.
+		"auto-edit": agent.ModeReversibleAuto,
+		"allow":     agent.ModeAlwaysAllow,
+		"yolo":      agent.ModeAlwaysAllow,
+	}
+	for in, want := range cases {
+		if got := parseApprovalMode(in); got != want {
+			t.Errorf("parseApprovalMode(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestApprovalModeNameRoundTrips(t *testing.T) {
+	for _, m := range []agent.ApprovalMode{
+		agent.ModeAlwaysAsk, agent.ModeReadOnlyAuto, agent.ModeReversibleAuto, agent.ModeAlwaysAllow,
+	} {
+		if got := parseApprovalMode(approvalModeName(m)); got != m {
+			t.Errorf("round-trip of %v via %q = %v", m, approvalModeName(m), got)
+		}
 	}
 }

--- a/agent/runner.go
+++ b/agent/runner.go
@@ -738,19 +738,40 @@ func (r *Runner) dispatch(ctx context.Context, step int, calls []ToolCall, tools
 	return results, sink.drain()
 }
 
-// toolReadOnly reports whether the named tool declares the readOnlyHint
-// annotation in the step's offered set. It is the signal the read-only-auto
-// approval tier keys on; an unknown tool or an absent hint is treated as
-// not read-only (fail-safe: a tool that does not promise read-only gets the
-// stricter path).
-func toolReadOnly(tools []core.ToolDef, name string) bool {
+// toolHints reads the named tool's safety annotations from the step's offered
+// set, applying the spec's defaults so every caller sees one resolved answer
+// rather than re-deriving them from a raw map.
+//
+// The defaults are not symmetric. An absent readOnlyHint means not read-only
+// and an absent idempotentHint means not idempotent, so both fall to the Go
+// zero value. An absent destructiveHint means DESTRUCTIVE, which does not, and
+// that asymmetry is the whole reason this defaulting lives in one place: a
+// caller that read the annotation map directly and took the zero value would
+// silently treat every unannotated tool as safe to run.
+//
+// readOnlyHint wins over the other two, which the spec says are meaningful
+// only when a tool writes. A read-only tool therefore reports non-destructive
+// and idempotent whatever else it declared, rather than passing a
+// contradiction through to policy.
+//
+// An unknown tool gets the strictest reading, since a name not in the offered
+// set has made no promises at all.
+func toolHints(tools []core.ToolDef, name string) (readOnly, destructive, idempotent bool) {
 	for _, t := range tools {
-		if t.Name == name {
-			ro, _ := t.Annotations["readOnlyHint"].(bool)
-			return ro
+		if t.Name != name {
+			continue
 		}
+		if ro, _ := t.Annotations["readOnlyHint"].(bool); ro {
+			return true, false, true
+		}
+		destructive = true
+		if d, ok := t.Annotations["destructiveHint"].(bool); ok {
+			destructive = d
+		}
+		idempotent, _ = t.Annotations["idempotentHint"].(bool)
+		return false, destructive, idempotent
 	}
-	return false
+	return false, true, false
 }
 
 // callTool executes one call and renders the text fed back to the model.
@@ -806,11 +827,14 @@ func (r *Runner) callTool(ctx context.Context, parent context.Context, step int,
 		}
 		return r.cfg.Tools.Call(ctx, info.Call.Name, args)
 	}
+	readOnly, destructive, idempotent := toolHints(tools, call.Name)
 	res, err := chainToolMiddleware(r.cfg.ToolMiddleware, dispatch)(ctx, ToolCallInfo{
-		Step:     step,
-		Call:     call,
-		Scope:    ScopeFrom(ctx),
-		ReadOnly: toolReadOnly(tools, call.Name),
+		Step:        step,
+		Call:        call,
+		Scope:       ScopeFrom(ctx),
+		ReadOnly:    readOnly,
+		Destructive: destructive,
+		Idempotent:  idempotent,
 	})
 	if err != nil {
 		// A denial is a decision, not a failure: the model is told the call

--- a/agent/toolmiddleware.go
+++ b/agent/toolmiddleware.go
@@ -74,6 +74,27 @@ type ToolCallInfo struct {
 	// tool declares none. It is a hint from the server, not a guarantee that
 	// the call is free of side effects.
 	ReadOnly bool
+
+	// Destructive reports whether the call's effect is irreversible or hard
+	// to undo, from the tool's destructiveHint annotation. It is a hint from
+	// the server, not a guarantee.
+	//
+	// True when the tool declares nothing, because the spec's default for an
+	// absent destructiveHint on a writing tool is destructive. That inverts
+	// the Go zero value, so a hand-built ToolCallInfo{} reads as
+	// non-destructive: only a value the Runner populated carries a meaningful
+	// answer. Normalized against ReadOnly, which the spec says wins — a
+	// read-only tool reports false whatever it annotated.
+	Destructive bool
+
+	// Idempotent reports whether repeating the call with the same arguments
+	// has no additional effect, from the tool's idempotentHint annotation. It
+	// is a hint from the server, not a guarantee.
+	//
+	// False when the tool declares nothing, matching the spec default, so the
+	// zero value is the conservative reading here rather than the inverted
+	// one. Read-only tools report true.
+	Idempotent bool
 }
 
 // ToolDeniedError is how a middleware refuses a call. The Runner unwraps it


### PR DESCRIPTION
Closes #1260.

## What changes

`ToolCallInfo` gains `Destructive` and `Idempotent`, read from the `destructiveHint` and `idempotentHint` annotations the protocol already carries and `client/` already surfaces. A new `ModeReversibleAuto` approval tier keys on them: it auto-allows a read, and a write the tool declares it can undo, and asks only when the effect is irreversible. No protocol surface, no spec change, nothing outside `agent/`.

## ELI15

A hospital consent form asks two different questions about a procedure, and they are not the same question. "Does this change anything?" and "can it be undone?" A blood draw changes nothing. A filling changes something and can be redone. An amputation changes something and cannot. Sort those three by the first question and you get one safe case and two that need a signature. Sort by the second and the filling moves, which is the whole point.

The approval ladder here read only the first question. `readOnlyHint` says whether a tool writes, so `git commit`, `send_email`, and `rm -rf /` were indistinguishable: all three write, so all three prompt. A user who wants their agent to edit files unattended had no setting that also stopped it emailing a customer, because the one flag the policy could see does not separate them.

The interesting part is the default. MCP already defines `destructiveHint`, and its default when absent is **true**, not false. That inverts Go's zero value, so the naive reading of a missing annotation is the dangerous one: take the zero value off the map and every tool that never annotated itself becomes "safe to run unattended." That asymmetry is why the resolution lives in exactly one function instead of at each call site. Get it backwards once and the mode silently widens what runs without asking, which is the failure you notice after it happens rather than before.

## Reviewer's guide

Read in this order:

1. [agent/runner.go](https://github.com/panyam/mcpkit/pull/1265/files#diff-6d787b427ac08cd61669af7e34ff0b747c4264d20b31b21b681a2ec2c826d9f0) — start here. `toolHints` replaces `toolReadOnly`, and it is where the asymmetric spec defaults are applied.
2. [agent/approval_test.go](https://github.com/panyam/mcpkit/pull/1265/files#diff-102f8eb8075887e0623581710f1cfa3a5a454f03f566f6d3601d00e1cabc73c7) — acceptance. `TestToolHintsUnannotatedIsDestructive` is the pin that matters.
3. [agent/toolmiddleware.go](https://github.com/panyam/mcpkit/pull/1265/files#diff-548b3929539e8d2eac363b7d1b40ad0e686478ac43948e6b9003cc0c6c6901d3) — the two new `ToolCallInfo` fields and their contracts.
4. [agent/approval.go](https://github.com/panyam/mcpkit/pull/1265/files#diff-11c4a6606bfa4e71640728dfdff9b37b317a21e7e704f5ed64763a11da5d6b71) — `ModeReversibleAuto` and its one branch in `WrapToolCall`.

Skim: [agent/host/config.go](https://github.com/panyam/mcpkit/pull/1265/files#diff-6aff502cc5cae4b9d9769752e8638899bab121e09de870b5d1320cc892c6bf2d), [agent/host/commands.go](https://github.com/panyam/mcpkit/pull/1265/files#diff-d44c9aac08cff5c51623cc064ae8e0dbbef19ba85d048cf9996ed8f99b61ac39), [agent/host/config_test.go](https://github.com/panyam/mcpkit/pull/1265/files#diff-58173ccd2844a83fbc046cda86d3cf3277dc9dc3b2ffe2e93e28b06ca345da09) — mode string plumbing.

## How it works

```
toolHints(tools, name):
    find name in the step's offered set; not found -> (false, DESTRUCTIVE, false)

    if readOnlyHint is true:
        return (true, non-destructive, idempotent)     # read-only wins outright

    destructive = true                                 # the spec default, not the zero value
    if destructiveHint is present and is a bool:
        destructive = that value
    idempotent = idempotentHint, absent -> false
    return (false, destructive, idempotent)

ModeReversibleAuto, for a call no per-tool rule covers:
    if ReadOnly or not Destructive: run it
    else: ask
```

Two things a reviewer would otherwise pause on. The type assertion is `ok`-checked only for `destructiveHint`, because that is the one field whose absent-value differs from its zero-value; a non-bool `destructiveHint` therefore falls back to destructive rather than to false. And a read-only tool returns early with `idempotent = true` instead of reading the annotation, since the spec says both write-related hints are meaningful only when a tool writes, and passing a server's self-contradiction through to policy is worse than normalizing it.

## Decision log

- **Computed bool over a tri-state (`*bool` / a `Hint` enum).** The defaulting is spec-mandated rather than invented, so the Runner is the honest place for it. A tri-state would make a hand-built `ToolCallInfo{}` read correctly as "unknown", but it adds a type to a struct that is about to freeze and a nil-check at every read. The cost of the chosen shape is that a hand-built zero value reads as non-destructive; that is stated on the field and pinned by testing the resolution path rather than hand-set fields.
- **Kept the MCP annotation names** rather than renaming to `KnownReversible` / `KnownIdempotent`. The safer-by-construction names were tempting for exactly the zero-value reason above, but they stop matching the wire name a reader greps for.
- **Inserted `ModeReversibleAuto` mid-`iota`** rather than appending, so the constants stay in ladder order by permissiveness. Safe because no `ApprovalMode` int is ever serialized; the host round-trips through the string names only.
- **`"auto-edit"` now resolves to the new mode.** It previously aliased `ModeReadOnlyAuto`, where it asked on every edit, so the name described a behavior that did not exist. This is a real behavior change for anyone with `"auto-edit"` configured, from ask-on-write to auto-allow-reversible-writes, and it is called out here rather than left to be discovered.
- **Shipped `Idempotent` with no in-tree consumer.** The issue asks for it and it is data read off an annotation rather than a mechanism, but nothing reads it yet; a retry policy would be the first caller.

## Risk / blast radius

- **Affects:** `agent/` and `agent/host` only. No `core`/`server`/`client` changes and no new requires, so A1 and A10 hold (`agent/go.mod` still has its two direct requires).
- **Be paranoid about:** the `"auto-edit"` alias remapping, which is the only behavior change to an existing configuration. Also worth pressure-testing that `ModeReadOnlyAuto` is genuinely untouched: it still ignores `Destructive` entirely, pinned by `read-only-auto is unchanged by a reversible annotation`.
- **Tests:** 36 assertions added across 5 test functions, 0 existing assertions removed or weakened. `TestToolReadOnly` was replaced by `TestToolHints`, which covers its four cases plus four more and checks three fields where it checked one. Red-before-green verified by mutating the `destructive` default to `false`, which fails `TestToolHints`, `TestToolHintsUnannotatedIsDestructive`, and `TestReversibleAutoMode/asks_for_an_unannotated_tool`.

## Before / after

Captured by running the real policy over the same six tools under each mode:

```
tool           readOnly  destructive   read-only-auto   reversible-auto
read_file      true      false         auto-allow       auto-allow
edit_file      false     false         ASK              auto-allow
git_commit     false     false         ASK              auto-allow
send_email     false     true          ASK              ASK
delete_bucket  false     true          ASK              ASK
shell          false     true          ASK              ASK
```

The middle two rows are the change. `shell` is the conservative case: it annotates nothing, so it resolves to destructive and keeps asking. Against a server that skips `destructiveHint` entirely, every row reads `ASK` and the new mode behaves exactly like `ask`, which is the intended failure direction.

## Out of scope

- `openWorldHint`, the fourth MCP annotation, is provenance-shaped and belongs with #1262.
- A retry policy that would consume `Idempotent`.
- Per-hunk approval rendering, which #1252 needs and which gates on #1253.

