### PR TITLE
feat(agent/host): derive spotlight provenance from a tool's source

### DIFF
--- a/agent/host/app.go
+++ b/agent/host/app.go
@@ -117,6 +117,13 @@ type App struct {
 	// so per-turn lifecycle (TurnStart) can reach them.
 	extensions []Extension
 
+	// toolOrigins records what each source id IS, so spotlight provenance is
+	// derived from where a tool came from rather than restated in config.
+	// Recorded where sources are added, because that is the only place the
+	// distinction is still known: a server id and an extension name are both
+	// arbitrary strings by the time anything reads them back.
+	toolOrigins map[string]agent.Provenance
+
 	// commands is the slash-command registry every surface dispatches
 	// through (Dispatch / Commands). Built in NewApp.
 	commands *CommandRegistry
@@ -244,6 +251,7 @@ func (a *App) registerServerTools(sc ServerConfig, c *client.Client) {
 	// Outermost: map an unreachable-server transport error on any call to a
 	// non-fatal ErrNotAvailableNow miss (docs/AGENT_SERVER_STATE.md).
 	src = newAvailabilitySource(src, sc.ID)
+	a.recordOrigin(sc.ID, agent.ProvenanceServer)
 	if err := a.sources.Add(sc.ID, src); err != nil {
 		a.emit(HostEvent{Kind: HostSessionWarn, Err: fmt.Sprintf("register tools for %s: %v", sc.ID, err)})
 		return
@@ -589,7 +597,7 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 	}
 	// Spotlighting goes before the gate: the gate decides on unmarked
 	// arguments, and a call it denies never produces a result to mark.
-	if mw := cfg.Spotlight.build(); mw != nil {
+	if mw := cfg.Spotlight.build(app); mw != nil {
 		runnerCfg.ToolMiddleware = append(runnerCfg.ToolMiddleware, mw)
 	}
 	// Built-in commands register before extensions so an extension naming a

--- a/agent/host/config.go
+++ b/agent/host/config.go
@@ -393,8 +393,13 @@ type SpotlightConfig struct {
 	// Tools labels a tool's output by where it came from: "operator"
 	// (computed in-process, the only label that reaches the model unmarked),
 	// "server" (relayed by a server the operator runs), "world" (fetched
-	// from outside), or "agent" (produced by a sub-agent). A tool not listed
-	// is "world".
+	// from outside), or "agent" (produced by a sub-agent).
+	//
+	// An entry here OVERRIDES what the host derives from the tool's source,
+	// so most deployments need none: a connected server's tools are already
+	// "server" and a sub-agent's are already "agent". Reach for it to vouch
+	// for something the host will not vouch for on its own — an extension's
+	// tools, or a server that returns only output you compute.
 	//
 	// Prefer listing as little as possible as "operator": marking output
 	// that did not need it costs a few tokens, while vouching for output
@@ -405,24 +410,20 @@ type SpotlightConfig struct {
 }
 
 // build turns the config into the middleware, or nil when spotlighting is off.
-func (c *SpotlightConfig) build() agent.ToolMiddleware {
+//
+// The classifier is always installed, even with no Tools entries, because
+// derivation from the tool's source is the default rather than an opt-in. Nil
+// would fall back to labelling everything world, which still marks but throws
+// away the distinction Mark exists to act on.
+func (c *SpotlightConfig) build(a *App) agent.ToolMiddleware {
 	if c == nil {
 		return nil
 	}
-	var classify func(agent.ToolCallInfo) agent.Provenance
-	if len(c.Tools) > 0 {
-		labels := make(map[string]agent.Provenance, len(c.Tools))
-		for name, label := range c.Tools {
-			labels[name] = parseProvenance(label)
-		}
-		classify = func(info agent.ToolCallInfo) agent.Provenance {
-			if p, ok := labels[info.Call.Name]; ok {
-				return p
-			}
-			return agent.ProvenanceWorld
-		}
+	labels := make(map[string]agent.Provenance, len(c.Tools))
+	for name, label := range c.Tools {
+		labels[name] = parseProvenance(label)
 	}
-	return agent.Spotlight(agent.SpotlightConfig{Classify: classify})
+	return agent.Spotlight(agent.SpotlightConfig{Classify: a.classifyTool(labels)})
 }
 
 // parseProvenance maps a config label to a provenance, defaulting to world.

--- a/agent/host/extension.go
+++ b/agent/host/extension.go
@@ -171,6 +171,10 @@ func (a *App) applyExtensions(exts []Extension) ([]agent.ToolMiddleware, error) 
 			return nil, fmt.Errorf("host: extension %q tools: %w", name, err)
 		}
 		if src != nil {
+			// Deliberately not recorded as operator. An extension is
+			// arbitrary code that may shell out or fetch, so the host has no
+			// standing to vouch for its output; config must say so
+			// explicitly. See derivedProvenance.
 			if err := a.sources.Add(name, src); err != nil {
 				return nil, fmt.Errorf("host: extension %q tools: %w", name, err)
 			}

--- a/agent/host/provenance.go
+++ b/agent/host/provenance.go
@@ -1,0 +1,110 @@
+package host
+
+import (
+	"context"
+	"time"
+
+	"github.com/panyam/mcpkit/agent"
+)
+
+// Built-in source ids whose output the host vouches for. These are the only
+// sources that derive ProvenanceOperator, and the list is closed on purpose.
+//
+// Operator means the process computed the output rather than relaying it, and
+// the host can only honestly claim that for its own in-repo, non-relaying
+// tools. An extension is arbitrary code that may shell out or fetch, so it is
+// never vouched for by derivation — config has to say so explicitly. Getting
+// this backwards is the one mistake that silently disables the mitigation
+// rather than making it noisy.
+const (
+	sourceHost          = "host"
+	sourceRunnerControl = "runner-control"
+)
+
+// Prefixes the host uses when adding sources that are themselves agents. A
+// sub-agent's output is a relay of whatever it read, so it is marked, but it
+// is worth distinguishing from open-web content when a Mark renders it.
+var agentSourcePrefixes = []string{"subagent:", "fanout:", "serveragents:"}
+
+// ownerLookupTimeout bounds the source lookup a classification does. Short
+// because the index is memoized and the common path does no I/O at all; the
+// timeout only bites when a re-list has to reach a server that is not
+// answering, and marking is the right answer in that case anyway.
+const ownerLookupTimeout = 2 * time.Second
+
+// recordOrigin notes what a source id is, for provenance derivation. Called
+// where the source is added, since a server id and an extension name are
+// indistinguishable strings afterwards.
+func (a *App) recordOrigin(id string, p agent.Provenance) {
+	if a.toolOrigins == nil {
+		a.toolOrigins = map[string]agent.Provenance{}
+	}
+	a.toolOrigins[id] = p
+}
+
+// derivedProvenance maps a source id to a label, or "" when the host has no
+// honest claim to make.
+//
+// The recorded map wins, then the built-in allowlist, then the agent prefixes.
+// Anything else — an extension, a source added by a path that forgot to
+// record — falls through to "" and the caller defaults it to world. Unknown
+// resolving to marked is the safe direction; the alternative is a source
+// nobody classified reaching the model unfenced.
+func (a *App) derivedProvenance(id string) agent.Provenance {
+	if p, ok := a.toolOrigins[id]; ok {
+		return p
+	}
+	switch id {
+	case sourceHost, sourceRunnerControl:
+		return agent.ProvenanceOperator
+	}
+	for _, prefix := range agentSourcePrefixes {
+		if len(id) >= len(prefix) && id[:len(prefix)] == prefix {
+			return agent.ProvenanceAgent
+		}
+	}
+	return ""
+}
+
+// classifyTool is the spotlight classifier: explicit config first, then
+// derivation from the source the call resolves to, then world.
+//
+// It resolves through MultiSource.OwnerOf rather than matching the tool name
+// itself, because the name the model called may be the qualified
+// "sourceID_name" form that collision handling produces. Re-deriving that
+// mapping here would be a second copy of resolution logic that drifts from the
+// one Call uses.
+//
+// Evaluated per call rather than snapshotted at construction, so a server
+// connected later, or an extension registered after the middleware was built,
+// is classified rather than silently treated as unknown.
+//
+// The lookup is bounded by ownerLookupTimeout because agent.SpotlightConfig's
+// Classify takes no context, and a miss against the memoized index makes
+// MultiSource re-list every source — which reaches the network. An unreachable
+// server must not be able to stall tool dispatch; a timeout resolves to world,
+// which marks.
+func (a *App) classifyTool(labels map[string]agent.Provenance) func(agent.ToolCallInfo) agent.Provenance {
+	return func(info agent.ToolCallInfo) agent.Provenance {
+		if p, ok := labels[info.Call.Name]; ok {
+			return p
+		}
+		if a.sources == nil {
+			return agent.ProvenanceWorld
+		}
+		args := map[string]any{}
+		if info.Call.Args.Len() > 0 {
+			_ = info.Call.Args.Bind(&args)
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), ownerLookupTimeout)
+		defer cancel()
+		id, found := a.sources.OwnerOf(ctx, info.Call.Name, args)
+		if !found {
+			return agent.ProvenanceWorld
+		}
+		if p := a.derivedProvenance(id); p != "" {
+			return p
+		}
+		return agent.ProvenanceWorld
+	}
+}

--- a/agent/host/spotlight_test.go
+++ b/agent/host/spotlight_test.go
@@ -165,3 +165,136 @@ func TestSpotlightDoesNotMarkDeniedCalls(t *testing.T) {
 		t.Fatalf("expected the denial to reach the model: %q", toolMsg.Text)
 	}
 }
+
+// classifierFor builds an App's classifier over a set of recorded origins, so
+// derivation is testable without standing up every source kind.
+func classifierFor(t *testing.T, origins map[string]agent.Provenance, labels map[string]string) func(agent.ToolCallInfo) agent.Provenance {
+	t.Helper()
+	app := &App{sources: agent.NewMultiSource()}
+	for id, p := range origins {
+		app.recordOrigin(id, p)
+	}
+	parsed := map[string]agent.Provenance{}
+	for name, label := range labels {
+		parsed[name] = parseProvenance(label)
+	}
+	return app.classifyTool(parsed)
+}
+
+func addSource(t *testing.T, m *agent.MultiSource, id string, tools ...string) {
+	t.Helper()
+	src := agent.NewFuncSource()
+	for _, name := range tools {
+		if err := src.AddToolFunc(core.ToolDef{Name: name, Description: "d"},
+			func(context.Context, map[string]any) (*core.ToolResult, error) { return &core.ToolResult{}, nil }); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := m.Add(id, src); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func infoFor(tool string) agent.ToolCallInfo {
+	return agent.ToolCallInfo{Call: agent.ToolCall{Name: tool}}
+}
+
+// TestProvenanceDerivedFromSource is the point of the feature: an operator who
+// configures nothing still gets meaningful labels, instead of everything
+// defaulting to world and the distinction Mark acts on never being used.
+func TestProvenanceDerivedFromSource(t *testing.T) {
+	app := &App{sources: agent.NewMultiSource()}
+	app.recordOrigin("prod-api", agent.ProvenanceServer)
+	addSource(t, app.sources, "prod-api", "db_query")
+	addSource(t, app.sources, "host", "remember")
+	addSource(t, app.sources, "runner-control", "spawn")
+	addSource(t, app.sources, "subagent:researcher", "delegate")
+	addSource(t, app.sources, "fanout:panel", "broadcast")
+	addSource(t, app.sources, "my-extension", "checkpoint_undo")
+
+	classify := app.classifyTool(nil)
+	cases := map[string]agent.Provenance{
+		"db_query":        agent.ProvenanceServer,
+		"remember":        agent.ProvenanceOperator,
+		"spawn":           agent.ProvenanceOperator,
+		"delegate":        agent.ProvenanceAgent,
+		"broadcast":       agent.ProvenanceAgent,
+		"checkpoint_undo": agent.ProvenanceWorld,
+	}
+	for tool, want := range cases {
+		if got := classify(infoFor(tool)); got != want {
+			t.Errorf("%s derived %q, want %q", tool, got, want)
+		}
+	}
+}
+
+// TestExtensionToolIsNeverDerivedOperator is the safety pin. An extension is
+// arbitrary code that may shell out or fetch, so the host has no standing to
+// vouch for it. Deriving operator here would silently unfence output the
+// mitigation exists to fence.
+func TestExtensionToolIsNeverDerivedOperator(t *testing.T) {
+	app := &App{sources: agent.NewMultiSource()}
+	addSource(t, app.sources, "my-extension", "shell_out")
+	if got := app.classifyTool(nil)(infoFor("shell_out")); got == agent.ProvenanceOperator {
+		t.Fatal("an extension tool was vouched for by derivation")
+	}
+}
+
+// TestUnknownToolResolvesToWorld pins the fail-closed direction: a name that
+// resolves to nothing gets marked rather than passed through.
+func TestUnknownToolResolvesToWorld(t *testing.T) {
+	app := &App{sources: agent.NewMultiSource()}
+	addSource(t, app.sources, "host", "remember")
+	if got := app.classifyTool(nil)(infoFor("never_registered")); got != agent.ProvenanceWorld {
+		t.Fatalf("unknown tool classified %q, want world", got)
+	}
+}
+
+// TestCollidingServersResolveToTheirOwnSource is the disambiguation case:
+// two servers advertising one name must not borrow each other's provenance.
+func TestCollidingServersResolveToTheirOwnSource(t *testing.T) {
+	app := &App{sources: agent.NewMultiSource()}
+	app.recordOrigin("vendor-api", agent.ProvenanceServer)
+	addSource(t, app.sources, "vendor-api", "search")
+	addSource(t, app.sources, "subagent:scout", "search")
+
+	classify := app.classifyTool(nil)
+	if got := classify(infoFor("vendor-api/search")); got != agent.ProvenanceServer {
+		t.Errorf("qualified server tool = %q, want server", got)
+	}
+	if got := classify(infoFor("subagent:scout/search")); got != agent.ProvenanceAgent {
+		t.Errorf("qualified sub-agent tool = %q, want agent", got)
+	}
+	// The bare name is ambiguous with no resolver, so no source is claimed
+	// and it falls to world rather than to whichever registered first.
+	if got := classify(infoFor("search")); got != agent.ProvenanceWorld {
+		t.Errorf("ambiguous bare name = %q, want world", got)
+	}
+}
+
+// TestConfigOverridesDerivation pins that an explicit label wins in both
+// directions: vouching for something the host would mark, and marking
+// something the host would vouch for.
+func TestConfigOverridesDerivation(t *testing.T) {
+	app := &App{sources: agent.NewMultiSource()}
+	app.recordOrigin("prod-api", agent.ProvenanceServer)
+	addSource(t, app.sources, "prod-api", "db_query")
+	addSource(t, app.sources, "host", "remember")
+
+	classify := app.classifyTool(map[string]agent.Provenance{
+		"db_query": agent.ProvenanceOperator,
+		"remember": agent.ProvenanceWorld,
+	})
+	if got := classify(infoFor("db_query")); got != agent.ProvenanceOperator {
+		t.Errorf("config did not override derivation upward: %q", got)
+	}
+	if got := classify(infoFor("remember")); got != agent.ProvenanceWorld {
+		t.Errorf("config did not override derivation downward: %q", got)
+	}
+}
+
+func TestClassifierWithNoSourcesIsWorld(t *testing.T) {
+	if got := classifierFor(t, nil, nil)(infoFor("anything")); got != agent.ProvenanceWorld {
+		t.Fatalf("classified %q with no sources, want world", got)
+	}
+}

--- a/agent/multi_source.go
+++ b/agent/multi_source.go
@@ -22,7 +22,7 @@ type ToolOwner struct {
 
 // Resolver picks which source handles an ambiguous bare-name call. Returning
 // an empty string (or an error) fails the call; the caller can always reach a
-// specific candidate via the qualified "sourceID_name" form instead.
+// specific candidate via the qualified "sourceID/name" form instead.
 type Resolver func(name string, candidates []ToolOwner, args map[string]any) (sourceID string, err error)
 
 // MultiSource aggregates ToolSources under stable source IDs, mirroring the
@@ -30,7 +30,7 @@ type Resolver func(name string, candidates []ToolOwner, args map[string]any) (so
 //
 //   - Unique names are exposed and callable as-is.
 //   - Colliding names are exposed to the model ONLY in qualified form
-//     ("sourceID_name" for every claimant), so the model-facing list never
+//     ("sourceID/name" for every claimant), so the model-facing list never
 //     contains duplicates and every tool stays reachable.
 //   - A bare-name Call that hits a collision consults the Resolver if one is
 //     configured, else fails with an error naming the qualified forms.
@@ -172,7 +172,7 @@ func (m *MultiSource) SourceTools(ctx context.Context, id string) (defs []core.T
 }
 
 // Call dispatches by bare or qualified name. Resolution order: exact unique
-// bare name; qualified "sourceID_name"; ambiguous bare name via Resolver.
+// bare name; qualified "sourceID/name"; ambiguous bare name via Resolver.
 // A name miss against the memoized index triggers exactly one fresh gather
 // before failing, so tools registered after the last listing stay reachable.
 func (m *MultiSource) Call(ctx context.Context, name string, args map[string]any) (*core.ToolResult, error) {
@@ -182,18 +182,52 @@ func (m *MultiSource) Call(ctx context.Context, name string, args map[string]any
 		m.mu.Unlock()
 		return nil, err
 	}
-	src, bare, resolveErr := m.resolveLocked(claims, name, args)
+	id, bare, resolveErr := m.resolveLocked(claims, name, args)
 	if errors.Is(resolveErr, ErrUnknownTool) {
 		m.index = nil
 		if claims, _, err = m.indexLocked(ctx); err == nil {
-			src, bare, resolveErr = m.resolveLocked(claims, name, args)
+			id, bare, resolveErr = m.resolveLocked(claims, name, args)
 		}
 	}
+	src := m.sources[id]
 	m.mu.Unlock()
 	if resolveErr != nil {
 		return nil, resolveErr
 	}
 	return src.Call(ctx, bare, args)
+}
+
+// OwnerOf reports which source would handle a call to name, without making it.
+//
+// It exists so a caller can key policy on where a tool came from — the host
+// derives spotlight provenance this way — and it takes args because resolution
+// does: an ambiguous bare name goes through the Resolver, which may inspect
+// them. Passing the same name and args Call would receive is what makes the
+// answer the one Call would act on, rather than a plausible guess at it.
+//
+// found is false for an unknown tool, for an ambiguity no Resolver settled,
+// and for a listing error. Callers get a single "no answer" signal because
+// every one of those means the same thing to a policy: do not claim to know
+// where this came from.
+func (m *MultiSource) OwnerOf(ctx context.Context, name string, args map[string]any) (sourceID string, found bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	claims, _, err := m.indexLocked(ctx)
+	if err != nil {
+		return "", false
+	}
+	id, _, resolveErr := m.resolveLocked(claims, name, args)
+	if errors.Is(resolveErr, ErrUnknownTool) {
+		m.index = nil
+		if claims, _, err = m.indexLocked(ctx); err != nil {
+			return "", false
+		}
+		id, _, resolveErr = m.resolveLocked(claims, name, args)
+	}
+	if resolveErr != nil {
+		return "", false
+	}
+	return id, true
 }
 
 // indexLocked returns the memoized claims index, gathering it if absent.
@@ -210,38 +244,42 @@ func (m *MultiSource) indexLocked(ctx context.Context) (map[string][]ToolOwner, 
 	return claims, orderNames, nil
 }
 
-func (m *MultiSource) resolveLocked(claims map[string][]ToolOwner, name string, args map[string]any) (ToolSource, string, error) {
+// resolveLocked maps a called name to the source id that owns it and the bare
+// name to dispatch. It returns the id rather than the source so callers that
+// need to know WHERE a tool came from (OwnerOf) share one resolution path with
+// the caller that only needs to dispatch (Call).
+func (m *MultiSource) resolveLocked(claims map[string][]ToolOwner, name string, args map[string]any) (sourceID, bare string, err error) {
 	if owners, ok := claims[name]; ok {
 		if len(owners) == 1 {
-			return m.sources[owners[0].SourceID], name, nil
+			return owners[0].SourceID, name, nil
 		}
 		if m.resolver != nil {
 			id, err := m.resolver(name, owners, args)
 			if err != nil {
-				return nil, "", err
+				return "", "", err
 			}
-			if src, ok := m.sources[id]; ok {
-				return src, name, nil
+			if _, ok := m.sources[id]; ok {
+				return id, name, nil
 			}
-			return nil, "", fmt.Errorf("agent: resolver returned unknown source %q for tool %q", id, name)
+			return "", "", fmt.Errorf("agent: resolver returned unknown source %q for tool %q", id, name)
 		}
 		var forms []string
 		for _, o := range owners {
 			forms = append(forms, qualifiedName(o.SourceID, name))
 		}
-		return nil, "", fmt.Errorf("agent: tool %q is ambiguous; use one of: %s", name, strings.Join(forms, ", "))
+		return "", "", fmt.Errorf("agent: tool %q is ambiguous; use one of: %s", name, strings.Join(forms, ", "))
 	}
 
-	if id, bare, ok := splitQualified(name); ok {
-		if src, exists := m.sources[id]; exists {
-			for _, o := range claims[bare] {
+	if id, bareName, ok := splitQualified(name); ok {
+		if _, exists := m.sources[id]; exists {
+			for _, o := range claims[bareName] {
 				if o.SourceID == id {
-					return src, bare, nil
+					return id, bareName, nil
 				}
 			}
 		}
 	}
-	return nil, "", fmt.Errorf("%w: %q", ErrUnknownTool, name)
+	return "", "", fmt.Errorf("%w: %q", ErrUnknownTool, name)
 }
 
 func (m *MultiSource) gatherLocked(ctx context.Context) (map[string][]ToolOwner, []string, error) {

--- a/agent/toolsource_test.go
+++ b/agent/toolsource_test.go
@@ -482,3 +482,87 @@ func TestAddAsyncFuncAckThenComplete(t *testing.T) {
 		t.Fatal("completion event never delivered")
 	}
 }
+
+func TestMultiSourceOwnerOf(t *testing.T) {
+	m := NewMultiSource()
+	if err := m.Add("alpha", &fakeSource{defs: defsNamed("one", "shared")}); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Add("beta", &fakeSource{defs: defsNamed("two", "shared")}); err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	cases := map[string]struct {
+		want  string
+		found bool
+	}{
+		"one":          {"alpha", true},
+		"two":          {"beta", true},
+		"alpha/shared": {"alpha", true},
+		"beta/shared":  {"beta", true},
+		// Ambiguous with no Resolver: not found, because a policy keying on
+		// this must not pick a claimant the dispatcher would not have picked.
+		"shared":       {"", false},
+		"nope":         {"", false},
+		"alpha/nope":   {"", false},
+		"gamma/shared": {"", false},
+	}
+	for name, want := range cases {
+		id, found := m.OwnerOf(ctx, name, nil)
+		if id != want.want || found != want.found {
+			t.Errorf("OwnerOf(%q) = (%q, %v), want (%q, %v)", name, id, found, want.want, want.found)
+		}
+	}
+}
+
+// TestMultiSourceOwnerOfMatchesCall pins that OwnerOf answers with the source
+// Call would actually reach, including through a Resolver that inspects args.
+// Two copies of resolution that disagree is the failure this shares one path
+// to avoid.
+func TestMultiSourceOwnerOfMatchesCall(t *testing.T) {
+	alpha := &fakeSource{defs: defsNamed("shared")}
+	beta := &fakeSource{defs: defsNamed("shared")}
+	m := NewMultiSource(WithResolver(func(_ string, _ []ToolOwner, args map[string]any) (string, error) {
+		if args["pick"] == "beta" {
+			return "beta", nil
+		}
+		return "alpha", nil
+	}))
+	if err := m.Add("alpha", alpha); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Add("beta", beta); err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		args map[string]any
+		want string
+	}{
+		{map[string]any{"pick": "beta"}, "beta"},
+		{map[string]any{"pick": "alpha"}, "alpha"},
+	} {
+		id, found := m.OwnerOf(ctx, "shared", tc.args)
+		if !found || id != tc.want {
+			t.Fatalf("OwnerOf with %v = (%q, %v), want %q", tc.args, id, found, tc.want)
+		}
+		if _, err := m.Call(ctx, "shared", tc.args); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(alpha.calls) != 1 || len(beta.calls) != 1 {
+		t.Fatalf("Call went elsewhere than OwnerOf said: alpha=%v beta=%v", alpha.calls, beta.calls)
+	}
+}
+
+func TestMultiSourceOwnerOfListErrorIsNotFound(t *testing.T) {
+	m := NewMultiSource()
+	if err := m.Add("alpha", &fakeSource{listErr: errors.New("server down")}); err != nil {
+		t.Fatal(err)
+	}
+	if id, found := m.OwnerOf(context.Background(), "one", nil); found {
+		t.Fatalf("a listing failure reported an owner %q; policy must get no answer", id)
+	}
+}


### PR DESCRIPTION
Closes #1268.

## What changes

The host derives a tool's spotlight provenance from the source it came from — a connected server's tools are `server`, a sub-agent's are `agent`, the host's own meta-tools are `operator` — and `spotlight.tools` in config overrides that rather than being the only input. `MultiSource` gains `OwnerOf`, which answers which source would handle a call without making it.

## ELI15

A hotel switchboard can tell you where a call came from, and a receptionist writing it down by hand cannot keep up. The switchboard already knows which line rang; the receptionist only knows what she was told last time someone updated the list. Both produce a log. Only one of them is still right after the hotel adds a floor.

Provenance labelling shipped in #1262 with the receptionist's version: an operator listed each tool and what to call it. That is correct exactly as long as someone maintains it. Connect a new MCP server and every tool it advertises quietly defaults to `world` — still marked, so nothing becomes unsafe, but the labels stop distinguishing anything and the differentiated fencing the feature exists for never gets used. The information was never missing. The host adds each source under an id and knows what that source is; it was just throwing the knowledge away and asking config to restate it.

The subtlety is that you cannot map a tool back to its source by looking at its name. When two sources claim the same name, the model is offered the qualified `sourceID/name` form instead, so the name arriving at the classifier may be either shape. Working that out a second time, in the classifier, would be a copy of resolution logic that drifts from the one dispatch actually uses — and a classifier that disagrees with the dispatcher labels output from the wrong source, which is worse than not labelling it. So the lookup goes through the same resolution path `Call` uses.

## Reviewer's guide

Read in this order:

1. [agent/host/provenance.go](https://github.com/panyam/mcpkit/pull/1274/files#diff-e1e42546b8642dd997e0b4dda53af6c0e0d9b73a108001da6f129795f72c7043) — start here. The derivation table, and why `operator` is a closed list.
2. [agent/host/spotlight_test.go](https://github.com/panyam/mcpkit/pull/1274/files#diff-05b06467e99485d5b3ba98f3921e941218debc9c005501be4ef9763de810012e) — acceptance. `TestExtensionToolIsNeverDerivedOperator` and `TestCollidingServersResolveToTheirOwnSource` are the two that matter.
3. [agent/multi_source.go](https://github.com/panyam/mcpkit/pull/1274/files#diff-49e8e5b153ea9a7a286eb82e1eb7d4c0565a6e81db15aa44417f1a7236f6f06d) — `OwnerOf`, plus the `resolveLocked` refactor that lets it share one path with `Call`.
4. [agent/toolsource_test.go](https://github.com/panyam/mcpkit/pull/1274/files#diff-ca90ce7de1d3630b728ec6294a04f150ecbbe3d8f42d650751b2ee1fc8290f85) — `TestMultiSourceOwnerOfMatchesCall` pins the two against each other.

Skim: [agent/host/app.go](https://github.com/panyam/mcpkit/pull/1274/files#diff-89fb8e04b6e1e9d5f7f76958490ef158dee40e2cae92d87c04b408d893c84361), [agent/host/config.go](https://github.com/panyam/mcpkit/pull/1274/files#diff-6aff502cc5cae4b9d9769752e8638899bab121e09de870b5d1320cc892c6bf2d), [agent/host/extension.go](https://github.com/panyam/mcpkit/pull/1274/files#diff-985592cc5a0e6e0c3b925b74b96eee4d2eccfb9049a8dbc9638c2a995e705e89) — recording and wiring.

## How it works

```
classifyTool(configLabels)(info):
    if configLabels[info.Call.Name] exists:  return it        # config always wins
    id, found = sources.OwnerOf(ctx, info.Call.Name, args)    # same resolution Call uses
    if not found:                            return world     # unknown -> marked
    return derivedProvenance(id) or world

derivedProvenance(id):
    recorded at Add time?          -> that            # servers
    "host" | "runner-control"      -> operator        # in-repo, non-relaying
    "subagent:*" "fanout:*" "serveragents:*" -> agent
    anything else (extensions)     -> ""  -> world

OwnerOf(ctx, name, args):
    resolve against the memoized claims index, one re-gather on a miss
    unknown / ambiguous-with-no-resolver / listing error -> not found
```

Two things a reviewer would otherwise pause on. `OwnerOf` takes `args` because resolution does — an ambiguous bare name goes through the `Resolver`, which may inspect them — so passing what `Call` would receive is what makes the answer the one `Call` would act on. And the lookup is bounded by a 2s timeout: `SpotlightConfig.Classify` takes no context, and an index miss makes `MultiSource` re-list every source, which reaches the network. An unreachable server must not be able to stall tool dispatch, and a timeout resolving to `world` marks.

## Decision log

- **`OwnerOf` on `MultiSource` rather than a name→origin map in the host.** The host would have had to reimplement bare-vs-qualified resolution. `resolveLocked` now returns the source id instead of the source, so `Call` and `OwnerOf` share one path; `TestMultiSourceOwnerOfMatchesCall` asserts they agree, including through a `Resolver`.
- **`operator` is a closed allowlist.** Only `host` and `runner-control` — the host's own in-repo, non-relaying sources. #1268's acceptance says `operator` is never derived for anything that relays, and this is the one mistake that silently *disables* the mitigation rather than making it noisy.
- **An extension is not `operator`.** It is arbitrary code that may shell out or fetch. It falls to `world`, and config vouches for it explicitly if the operator wants to.
- **Ambiguity is "not found", not a guess.** A bare name two sources claim, with no `Resolver`, gets no label. Picking the first claimant would attribute output to a source that would not have served the call.
- **The classifier is always installed**, even with no config entries, because derivation is now the default rather than an opt-in. A nil `Classify` would label everything `world`, which marks but throws away the distinction `Mark` exists to act on.
- **Evaluated per call, not snapshotted.** A server connected later, or an extension registered after the middleware was built, is classified rather than treated as unknown.

## Drive-by, called out rather than buried

Three doc comments in `agent/multi_source.go` described the qualified form as `"sourceID_name"`. The code has always joined with `/` (`qualifiedName`, and `Add` rejects `/` in a source id *because* it is the separator), and the neighbouring comment says underscores are fine in an id — so the three were both wrong and self-contradicting. I fixed the strings rather than filing it, because this PR builds directly on that contract and a wrong doc misdirects more than a missing one. It cost me one red test to discover.

## Risk / blast radius

- **Affects:** `agent/host` and one additive method plus an internal refactor in `agent`. No new requires; `agent/go.mod` still has its two direct requires (A10).
- **Behaviour change:** a deployment with spotlighting on and no `tools` config previously marked everything with the `world` fence; now the fence names the real origin. Marking is unchanged — the same calls are fenced, only the wording differs — except that `host` and `runner-control` meta-tools now pass through unmarked, which is the intended derivation and the one case where *less* is marked. Worth a reviewer's eye.
- **Be paranoid about:** `derivedProvenance`'s fallthrough. Any source id that reaches it unmatched must return `""` so the caller marks. An accidental `operator` there is invisible until someone reads a transcript.
- **Tests:** 9 new (4 in `agent`, 5 in `agent/host`), 0 existing assertions removed or weakened — `TestSpotlightOperatorLabelOptOut` and `TestSpotlightNonOperatorLabelsStillMark` from #1262 pass untouched, which is the main regression pin. Red-before-green verified by three mutations:
  - deriving `operator` for extensions fails `TestExtensionToolIsNeverDerivedOperator` and `TestProvenanceDerivedFromSource`
  - dropping the agent-source prefixes fails `TestProvenanceDerivedFromSource` and `TestCollidingServersResolveToTheirOwnSource`
  - making `OwnerOf` guess the first claimant on ambiguity fails 5 tests across both modules, including two pre-existing `Call` tests

## Before / after

Captured by running the real classifier over four sources with **no config at all**:

```
tool               source id              before       after
db_query           prod-api               world        server
remember           host                   world        operator
delegate           subagent:researcher    world        agent
checkpoint_undo    my-extension           world        world
```

The last row is the deliberate one: an extension stays `world` because the host will not vouch for arbitrary in-process code.

```mermaid
flowchart LR
    subgraph before["before — config is the only input"]
        B1["spotlight.tools<br/>{fetch_url: world}"] --> B2{"listed?"}
        B2 -->|yes| B3["that label"]
        B2 -->|no| B4["world"]
    end
    subgraph after["after — config overrides derivation"]
        A1["spotlight.tools"] --> A2{"listed?"}
        A2 -->|yes| A3["that label"]
        A2 -->|no| A4["OwnerOf -> source id"]
        A4 --> A5{"what is that source?"}
        A5 -->|MCP server| A6["server"]
        A5 -->|"subagent / fanout"| A7["agent"]
        A5 -->|"host meta-tools"| A8["operator"]
        A5 -->|"extension / unknown"| A9["world"]
    end
```

## Out of scope

- **The fence wording for in-process extension tools** — `world` reads "fetched from outside this system", which is the right marking decision and the wrong sentence. Filed as #1273 with four options, since fixing it means either widening the enum #1262 just settled or letting an extension label itself.
- Provenance as an approval key → #1269.
- Per-server labelling in config (keying `spotlight.tools` by source id as well as tool name) — derivation already handles the common case, so this would be a second keying dimension for a rare override.

