### PR TITLE
feat(agent/ext/files): anchored edit engine that rejects stale or ambiguous edits

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,6 +79,9 @@ jobs:
       - name: Run agent/ext/checkpoint tests
         run: cd agent/ext/checkpoint && go test ./... -v -race
 
+      - name: Run agent/ext/files tests
+        run: cd agent/ext/files && go test ./... -v -race
+
       - name: Run agent/surfaces shared-module tests
         run: cd agent/surfaces && go test ./... -v
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 # experimental events modules were added once they shipped their own go.mod.
 SUB_MODS_TO_TAG := \
 	agent agent/host agent/surfaces agent/surfaces/web agent/surfaces/chat agent/store/redis agent/store/gorm \
-	agent/ext/checkpoint \
+	agent/ext/checkpoint agent/ext/files \
 	ext/auth ext/otel ext/ui ext/tasks ext/skills \
 	stores/redis \
 	experimental/ext/agents experimental/ext/agents/clients/go \
@@ -164,6 +164,7 @@ test-agent: ## Run agent sub-module tests
 	cd agent/store/redis && go test ./... -count=1 -timeout 60s
 	cd agent/store/gorm && go test ./... -count=1 -timeout 60s
 	cd agent/ext/checkpoint && go test ./... -count=1 -timeout 60s
+	cd agent/ext/files && go test ./... -count=1 -timeout 60s
 	cd agent/host && go test ./... -count=1 -timeout 60s
 	cd agent/surfaces && go test ./... -count=1 -timeout 60s
 	cd agent/surfaces/web && go test ./... -count=1 -timeout 90s

--- a/agent/ext/files/edit.go
+++ b/agent/ext/files/edit.go
@@ -1,0 +1,157 @@
+// Package files edits text by anchoring to the content being replaced, so an
+// edit built against a stale view of a file fails instead of applying.
+//
+// The failure it exists to prevent: an agent reads a file, decides on a
+// change, and writes it back. In between, the file changed underneath. A
+// formatter ran, a sibling tool wrote it, the user saved in their editor. An
+// edit addressed by line number applies anyway and silently discards that
+// change, and nothing reports it, because nothing noticed.
+//
+// Two mechanisms answer two different questions. An anchor (the exact text
+// being replaced) says WHERE a change goes, and survives the line numbers
+// moving. A content hash says WHETHER the file is still the one the caller
+// looked at. Neither substitutes for the other: an anchor can still match
+// uniquely in a file that was reformatted underneath, which is precisely the
+// case where applying it is wrong, and a hash cannot locate anything.
+//
+// Nothing here is specific to code. It needs a filesystem and text, not a
+// language, so a data file, a prose draft, and a source file are the same
+// problem to it.
+package files
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// The conditions under which an edit refuses to apply. Each is a distinct
+// question the caller has to answer differently, which is why they are
+// separate sentinels rather than one generic failure: a stale file wants
+// re-reading, an ambiguous anchor wants more surrounding context, and a
+// missing anchor means the assumed text was never there.
+//
+// Errors wrap these with the specifics, so match with errors.Is and read the
+// message for which hunk and how many matches.
+var (
+	// ErrStale means the content did not match ExpectHash. The file changed
+	// after the caller read it, so every anchor in the edit was written
+	// against a view that no longer exists.
+	ErrStale = errors.New("file changed since it was read")
+
+	// ErrAnchorNotFound means a hunk's Old text does not appear at all.
+	ErrAnchorNotFound = errors.New("anchor not found")
+
+	// ErrAnchorAmbiguous means a hunk's Old text appears more than once, so
+	// there is no single place the edit belongs. Resolved by extending the
+	// anchor with surrounding lines until it is unique, never by picking one.
+	ErrAnchorAmbiguous = errors.New("anchor is not unique")
+
+	// ErrOverlap means two hunks matched regions that share characters, so
+	// their replacements would contradict each other.
+	ErrOverlap = errors.New("hunks overlap")
+
+	// ErrEmptyAnchor means a hunk has no Old text. An empty anchor matches at
+	// every position rather than none, so it is rejected as malformed instead
+	// of being reported as ambiguous.
+	ErrEmptyAnchor = errors.New("hunk has an empty anchor")
+
+	// ErrNoHunks means an Edit carried no hunks. Applying it would be a no-op,
+	// which is more likely a caller that built the edit wrong than a caller
+	// that meant to change nothing.
+	ErrNoHunks = errors.New("edit has no hunks")
+)
+
+// Hunk is one replacement, located by the text it replaces.
+type Hunk struct {
+	// Old is the exact text to replace. It must appear exactly once in the
+	// content. Matching is byte-exact: no whitespace normalization, no fuzzy
+	// or nearest match. Approximate matching is the mechanism that produces
+	// silently wrong edits, which is the failure this package exists to
+	// prevent, so a caller whose anchor does not match gets an error and a
+	// chance to look again.
+	Old string
+
+	// New is what replaces Old. Empty deletes the anchored text.
+	New string
+}
+
+// Edit is a set of hunks applied to one file's content as a single unit.
+type Edit struct {
+	// ExpectHash is the Hash of the content this edit was written against.
+	// Empty skips the check, which is the right choice only when the caller
+	// has some other guarantee that nothing changed in between; without it an
+	// edit can still apply cleanly to a file it was never meant for.
+	ExpectHash string
+
+	// Hunks are applied together or not at all. Each anchor is matched
+	// against the original content rather than against the result of earlier
+	// hunks, so the order they are listed in does not change the outcome.
+	Hunks []Hunk
+}
+
+// Apply returns src with every hunk applied, or an error and no partial result.
+//
+// All or nothing, and order-independent. Every anchor is resolved against the
+// original src before anything is spliced, so a hunk cannot match text an
+// earlier hunk introduced, and a failure on the last hunk leaves the caller
+// exactly where it started. Both properties follow from the same reason: the
+// caller wrote all these hunks while looking at one version of the content, so
+// that version is what they should be interpreted against.
+func (e Edit) Apply(src string) (string, error) {
+	if e.ExpectHash != "" {
+		if got := Hash(src); got != e.ExpectHash {
+			return "", fmt.Errorf("%w: expected %s, found %s; re-read it before editing", ErrStale, e.ExpectHash, got)
+		}
+	}
+	if len(e.Hunks) == 0 {
+		return "", ErrNoHunks
+	}
+
+	type span struct {
+		start, end int
+		replace    string
+	}
+	spans := make([]span, 0, len(e.Hunks))
+	for i, h := range e.Hunks {
+		if h.Old == "" {
+			return "", fmt.Errorf("hunk %d: %w", i, ErrEmptyAnchor)
+		}
+		switch n := strings.Count(src, h.Old); {
+		case n == 0:
+			return "", fmt.Errorf("hunk %d: %w: %s", i, ErrAnchorNotFound, quote(h.Old))
+		case n > 1:
+			return "", fmt.Errorf("hunk %d: %w: %s matches %d places; extend it until it matches one", i, ErrAnchorAmbiguous, quote(h.Old), n)
+		}
+		start := strings.Index(src, h.Old)
+		spans = append(spans, span{start: start, end: start + len(h.Old), replace: h.New})
+	}
+
+	sort.Slice(spans, func(i, j int) bool { return spans[i].start < spans[j].start })
+	for i := 1; i < len(spans); i++ {
+		if spans[i].start < spans[i-1].end {
+			return "", fmt.Errorf("%w: two hunks both cover offset %d", ErrOverlap, spans[i].start)
+		}
+	}
+
+	var b strings.Builder
+	prev := 0
+	for _, s := range spans {
+		b.WriteString(src[prev:s.start])
+		b.WriteString(s.replace)
+		prev = s.end
+	}
+	b.WriteString(src[prev:])
+	return b.String(), nil
+}
+
+// quote renders an anchor for an error message, shortened so a hunk spanning
+// half the file does not bury the rest of the message.
+func quote(s string) string {
+	const max = 60
+	if len(s) > max {
+		s = s[:max] + "..."
+	}
+	return fmt.Sprintf("%q", s)
+}

--- a/agent/ext/files/edit_test.go
+++ b/agent/ext/files/edit_test.go
@@ -1,0 +1,201 @@
+package files
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+const src = `package main
+
+func greet() string {
+	return "hello"
+}
+
+func farewell() string {
+	return "goodbye"
+}
+`
+
+// TestStaleContentIsRejected is the property the package exists for. The
+// anchor still matches, so every mechanism that only locates text would apply
+// this edit happily; only the hash knows the caller was looking at something
+// else.
+func TestStaleContentIsRejected(t *testing.T) {
+	e := Edit{
+		ExpectHash: Hash("the file as it was read"),
+		Hunks:      []Hunk{{Old: `"hello"`, New: `"hi"`}},
+	}
+	got, err := e.Apply(src)
+	if !errors.Is(err, ErrStale) {
+		t.Fatalf("Apply() error = %v, want ErrStale", err)
+	}
+	if got != "" {
+		t.Errorf("Apply() returned %q on failure, want no partial result", got)
+	}
+}
+
+func TestMatchingHashApplies(t *testing.T) {
+	e := Edit{
+		ExpectHash: Hash(src),
+		Hunks:      []Hunk{{Old: `"hello"`, New: `"hi"`}},
+	}
+	got, err := e.Apply(src)
+	if err != nil {
+		t.Fatalf("Apply() error = %v, want nil", err)
+	}
+	if !strings.Contains(got, `return "hi"`) {
+		t.Errorf("Apply() did not apply the hunk:\n%s", got)
+	}
+}
+
+func TestEmptyExpectHashSkipsTheCheck(t *testing.T) {
+	e := Edit{Hunks: []Hunk{{Old: `"hello"`, New: `"hi"`}}}
+	if _, err := e.Apply(src); err != nil {
+		t.Fatalf("Apply() error = %v, want nil", err)
+	}
+}
+
+// TestAmbiguousAnchorIsRejected pins that a repeated anchor is an error rather
+// than a first-match-wins guess. Picking one would apply the edit somewhere the
+// caller did not look at.
+func TestAmbiguousAnchorIsRejected(t *testing.T) {
+	e := Edit{Hunks: []Hunk{{Old: "string {", New: "string { // edited"}}}
+	_, err := e.Apply(src)
+	if !errors.Is(err, ErrAnchorAmbiguous) {
+		t.Fatalf("Apply() error = %v, want ErrAnchorAmbiguous", err)
+	}
+	if !strings.Contains(err.Error(), "2 places") {
+		t.Errorf("error should report how many matches, got: %v", err)
+	}
+}
+
+func TestUniqueMultilineAnchorApplies(t *testing.T) {
+	e := Edit{Hunks: []Hunk{{
+		Old: "func farewell() string {\n\treturn \"goodbye\"\n}",
+		New: "func farewell() string {\n\treturn \"bye\"\n}",
+	}}}
+	got, err := e.Apply(src)
+	if err != nil {
+		t.Fatalf("Apply() error = %v, want nil", err)
+	}
+	if !strings.Contains(got, `return "bye"`) || strings.Contains(got, `return "goodbye"`) {
+		t.Errorf("Apply() did not replace the block:\n%s", got)
+	}
+}
+
+func TestMissingAnchorIsRejected(t *testing.T) {
+	e := Edit{Hunks: []Hunk{{Old: `"never in the file"`, New: "x"}}}
+	if _, err := e.Apply(src); !errors.Is(err, ErrAnchorNotFound) {
+		t.Fatalf("Apply() error = %v, want ErrAnchorNotFound", err)
+	}
+}
+
+// TestOneBadHunkAbandonsTheWholeEdit is the all-or-nothing property. The first
+// hunk is perfectly valid; applying it and reporting the second as failed would
+// leave the file in a state no caller asked for.
+func TestOneBadHunkAbandonsTheWholeEdit(t *testing.T) {
+	e := Edit{Hunks: []Hunk{
+		{Old: `"hello"`, New: `"hi"`},
+		{Old: `"not present"`, New: "x"},
+	}}
+	got, err := e.Apply(src)
+	if !errors.Is(err, ErrAnchorNotFound) {
+		t.Fatalf("Apply() error = %v, want ErrAnchorNotFound", err)
+	}
+	if got != "" {
+		t.Errorf("Apply() returned %q on failure, want no partial result", got)
+	}
+}
+
+// TestAnchorsResolveAgainstTheOriginal guards order-independence at its root.
+// The second anchor exists only in what the first hunk produces, so a
+// sequential implementation would apply it and this would pass silently.
+func TestAnchorsResolveAgainstTheOriginal(t *testing.T) {
+	e := Edit{Hunks: []Hunk{
+		{Old: `"hello"`, New: `"aloha"`},
+		{Old: `"aloha"`, New: `"ciao"`},
+	}}
+	if _, err := e.Apply(src); !errors.Is(err, ErrAnchorNotFound) {
+		t.Fatalf("Apply() error = %v, want ErrAnchorNotFound", err)
+	}
+}
+
+func TestHunkOrderDoesNotChangeTheResult(t *testing.T) {
+	first := Hunk{Old: `"hello"`, New: `"hi"`}
+	second := Hunk{Old: `"goodbye"`, New: `"bye"`}
+
+	forward, err := Edit{Hunks: []Hunk{first, second}}.Apply(src)
+	if err != nil {
+		t.Fatalf("forward order error = %v", err)
+	}
+	reverse, err := Edit{Hunks: []Hunk{second, first}}.Apply(src)
+	if err != nil {
+		t.Fatalf("reverse order error = %v", err)
+	}
+	if forward != reverse {
+		t.Errorf("order changed the result:\n%q\nvs\n%q", forward, reverse)
+	}
+	if !strings.Contains(forward, `"hi"`) || !strings.Contains(forward, `"bye"`) {
+		t.Errorf("both hunks should have applied:\n%s", forward)
+	}
+}
+
+func TestOverlappingHunksAreRejected(t *testing.T) {
+	e := Edit{Hunks: []Hunk{
+		{Old: `return "hello"`, New: `return "hi"`},
+		{Old: `"hello"`, New: `"aloha"`},
+	}}
+	if _, err := e.Apply(src); !errors.Is(err, ErrOverlap) {
+		t.Fatalf("Apply() error = %v, want ErrOverlap", err)
+	}
+}
+
+// TestIdenticalHunksOverlap covers the degenerate case of the same edit listed
+// twice: both resolve to the one occurrence, so they collide with each other.
+func TestIdenticalHunksOverlap(t *testing.T) {
+	h := Hunk{Old: `"hello"`, New: `"hi"`}
+	if _, err := (Edit{Hunks: []Hunk{h, h}}).Apply(src); !errors.Is(err, ErrOverlap) {
+		t.Fatalf("Apply() error = %v, want ErrOverlap", err)
+	}
+}
+
+func TestEmptyNewDeletesTheAnchor(t *testing.T) {
+	e := Edit{Hunks: []Hunk{{Old: "\nfunc farewell() string {\n\treturn \"goodbye\"\n}\n"}}}
+	got, err := e.Apply(src)
+	if err != nil {
+		t.Fatalf("Apply() error = %v, want nil", err)
+	}
+	if strings.Contains(got, "farewell") {
+		t.Errorf("Apply() should have deleted the block:\n%s", got)
+	}
+}
+
+// TestEmptyAnchorIsMalformedNotAmbiguous separates the two: an empty string is
+// found at every offset, so reporting it as ambiguous would send the caller off
+// to add context to an anchor that does not exist.
+func TestEmptyAnchorIsMalformedNotAmbiguous(t *testing.T) {
+	e := Edit{Hunks: []Hunk{{Old: "", New: "x"}}}
+	if _, err := e.Apply(src); !errors.Is(err, ErrEmptyAnchor) {
+		t.Fatalf("Apply() error = %v, want ErrEmptyAnchor", err)
+	}
+}
+
+func TestNoHunksIsRejected(t *testing.T) {
+	if _, err := (Edit{}).Apply(src); !errors.Is(err, ErrNoHunks) {
+		t.Fatalf("Apply() error = %v, want ErrNoHunks", err)
+	}
+}
+
+// TestStaleIsCheckedBeforeAnchors keeps the reported cause the actionable one.
+// Both faults are present; if anchors were resolved first the caller would be
+// told to fix an anchor that is fine in the file they have not read yet.
+func TestStaleIsCheckedBeforeAnchors(t *testing.T) {
+	e := Edit{
+		ExpectHash: Hash("something else"),
+		Hunks:      []Hunk{{Old: "not present either", New: "x"}},
+	}
+	if _, err := e.Apply(src); !errors.Is(err, ErrStale) {
+		t.Fatalf("Apply() error = %v, want ErrStale", err)
+	}
+}

--- a/agent/ext/files/go.mod
+++ b/agent/ext/files/go.mod
@@ -1,0 +1,3 @@
+module github.com/panyam/mcpkit/agent/ext/files
+
+go 1.26.5

--- a/agent/ext/files/hash.go
+++ b/agent/ext/files/hash.go
@@ -1,0 +1,27 @@
+package files
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+// HashLen is the number of hex characters in a Hash, and so the width of the
+// precondition a caller echoes back on Edit.ExpectHash.
+const HashLen = 12
+
+// Hash fingerprints file content for staleness detection.
+//
+// It is a truncated sha256: 12 hex characters, 48 bits. The truncation is
+// deliberate. A model has to carry this value from a read to a later edit, and
+// a full 64-character digest costs tokens on every hop to answer a question
+// that only needs "is this the same content I was shown".
+//
+// 48 bits is not a security boundary and is not trying to be. The threat it
+// addresses is an accidental change: a formatter ran, a sibling tool wrote the
+// file, the user saved in their editor. Anyone positioned to search for a
+// collision already has write access to the file and can simply write what
+// they want, so a wider digest would buy nothing.
+func Hash(content string) string {
+	sum := sha256.Sum256([]byte(content))
+	return hex.EncodeToString(sum[:])[:HashLen]
+}

--- a/agent/ext/files/hash_test.go
+++ b/agent/ext/files/hash_test.go
@@ -1,0 +1,22 @@
+package files
+
+import "testing"
+
+func TestHashIsStableAndSensitive(t *testing.T) {
+	a := Hash("one line\n")
+	if a != Hash("one line\n") {
+		t.Error("Hash is not stable across calls")
+	}
+	if a == Hash("one line") {
+		t.Error("Hash ignored a trailing newline, which is a real difference on disk")
+	}
+	if a == Hash("") {
+		t.Error("Hash of content collided with Hash of empty")
+	}
+}
+
+func TestHashWidth(t *testing.T) {
+	if got := len(Hash("anything")); got != HashLen {
+		t.Errorf("len(Hash()) = %d, want HashLen (%d)", got, HashLen)
+	}
+}


### PR DESCRIPTION
## What changes

Adds `agent/ext/files`, a new dependency-free sub-module, containing the pure engine behind the edit primitive: hunks located by the exact text they replace, plus a content-hash precondition, applied as one unit or not at all. No filesystem, no `ToolSource`, no `App`. Those arrive in PR B; this half is pure functions and is testable without any of them.

First child of #1252 to land since file checkpoint / rewind. Closes #1275.

## ELI15

A hotel gives you a key card for room 412. Come back tomorrow and the card is refused, because the desk re-keyed the room when the previous guest checked out. That refusal is the useful part. A key cut to fit "room 412" forever would open a door that is now someone else's.

Editing a file has the same shape. If an edit says *"replace line 47"*, it is a key cut to a position. Any change that shifts the file makes it open the wrong door, and it opens it silently, because nothing checked. So this addresses edits by the text being replaced rather than by position, which survives lines moving around.

That alone is not enough, and the gap is the interesting bit. Suppose a formatter reflows the file after you read it. Your anchor text can still be sitting there, still unique, so the edit applies cleanly and is still wrong, because you decided on it while looking at a file that no longer exists. The anchor answers *where does this go*. It cannot answer *is this still the file I read*. So there is a second, separate check: a short fingerprint of the content you read, handed back with the edit and compared before anything is touched. Two questions, two mechanisms, and neither one covers for the other.

The last piece is refusing to guess. If the anchor text appears twice, this errors instead of picking the first one. Picking would mean editing a place nobody looked at, which is the exact failure the whole design is avoiding, arrived at by a different road.

## Reviewer's guide

Read in this order:

1. [agent/ext/files/edit.go](https://github.com/panyam/mcpkit/pull/1276/files#diff-502f65f7ce969dd9d0aea449f853e01fd263517a38335f946346c90edcf4cf31) — start here, top to bottom. The package doc states the failure being prevented; `Apply` is the whole algorithm and is about 40 lines.
2. [agent/ext/files/edit_test.go](https://github.com/panyam/mcpkit/pull/1276/files#diff-0fb007131cd703a2ffa486a4a8084697be787a2647ca1c377df614afe9acdbbb) — acceptance. `TestStaleContentIsRejected` and `TestAnchorsResolveAgainstTheOriginal` are the two that carry the design.
3. [agent/ext/files/hash.go](https://github.com/panyam/mcpkit/pull/1276/files#diff-c9d86db244fae48deccef9f52bcda300895a4cab38964ab99f8440984abbc872) — one function. The doc comment argues the truncation; that argument is the thing to pressure-test, not the code.
4. [Makefile](https://github.com/panyam/mcpkit/pull/1276/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52), [.github/workflows/test.yml](https://github.com/panyam/mcpkit/pull/1276/files#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88) — mechanical module registration.

## How it works

```
Apply(src, edit):
    if edit.ExpectHash is set and Hash(src) != edit.ExpectHash:
        reject as stale                      # checked first, see the decision log

    for each hunk:
        reject if its Old text is empty
        n = count of Old in src              # counted in src, never in a running result
        reject if n == 0 (not found) or n > 1 (ambiguous)
        record the matched span [start, end)

    sort spans by start
    reject if any span begins before the previous one ends   # overlap

    splice all spans into a new string in one pass
```

The load-bearing detail is that every anchor is counted and located in `src`, not in the partially-edited result. That single choice produces both properties worth having: listing order cannot change the outcome, and a hunk cannot accidentally match text an earlier hunk introduced. It is also why the overlap check has to exist at all, since two spans resolved independently can collide.

## Decision log

- **Two mechanisms, not one.** An anchor cannot detect staleness and a hash cannot locate a hunk. Shipping only the anchor would have left the reformat case applying silently, which is the case the primitive is for.
- **Anchors resolve against the original, not sequentially.** The caller wrote every hunk while looking at one version of the content, so that version is what they should be interpreted against. Sequential application also makes "all or nothing" unenforceable: by the time hunk 3 fails, hunks 1 and 2 are already in the result. Pinned by `TestAnchorsResolveAgainstTheOriginal`.
- **Ambiguity is an error, never first-match-wins.** Resolving it by picking one applies the edit somewhere the caller never looked.
- **No fuzzy or whitespace-normalized matching.** Approximate matching is the mechanism that produces silently wrong edits. A caller whose anchor does not match gets an error and a chance to look again.
- **Sentinel errors wrapped with `fmt.Errorf`, no custom error types.** An earlier draft had `StaleError` / `AnchorError` structs carrying hunk index and match count. The consumer is a model reading a sentence, and `errors.Is` already works through the wrap, so the structs were surface with no reader.
- **12-hex-character hash, not a full digest.** A model carries this value from a read to a later edit, and 64 characters costs tokens on every hop to answer a yes/no question. 48 bits is not a security boundary and does not need to be: the threat is an accidental change, and anyone able to search for a collision already has write access and can just write what they want. Argued in the `Hash` doc comment.
- **Named `files`, not `coding`.** Nothing in this is code-aware; it needs a filesystem and text, not a language. A data file, a prose draft, and a source file are the same problem to it. Filing it under a coding module would have put the general-purpose thing inside the specialist box. The genuinely code-aware children of #1252 (repo map, LSP-in-loop, test/build loop) stay separate.
- **No `checkpoint.Reverser`, and no import edge to `agent/ext/checkpoint`.** That module's integration point is `WriteSpec{Tool, Paths}`, supplied by the host wiring and keyed by tool name, so checkpointing an edit tool is a config declaration rather than a code dependency. PR B keeps it that way by exporting a plain `EditPaths` function for the wiring to hand over, leaving the struct owned by checkpoint.

## Risk / blast radius

- **Affects:** nothing existing. New module, no current consumer, no changes to any other package. The only edits outside it register the module in the two Makefile lists and the CI workflow.
- **Tests covering this:** 17 tests in the new module, all run under `-race` in CI.
- **Be paranoid about:** the hash-width argument in `hash.go`, which is a judgment call rather than a derivation. Also the zero-indexed `hunk 0` in error messages, which is consistent with the `Hunks` slice but will be read by a model in PR B.

## Red before green

Every load-bearing behavior was verified by mutating the implementation and recording which tests fail.

| Mutation | Tests that caught it |
|---|---|
| Drop the stale-hash check | `TestStaleContentIsRejected`, `TestStaleIsCheckedBeforeAnchors` |
| Ambiguity becomes first-match-wins | `TestAmbiguousAnchorIsRejected` |
| Drop the overlap check | `TestOverlappingHunksAreRejected` |
| Empty anchor falls through to the ambiguity path | `TestEmptyAnchorIsMalformedNotAmbiguous` |
| `Hash` returns the full digest | `TestHashWidth` |
| Hunks applied sequentially against the running result | `TestAnchorsResolveAgainstTheOriginal`, `TestOneBadHunkAbandonsTheWholeEdit`, `TestIdenticalHunksOverlap`, `TestOverlappingHunksAreRejected` |

Dropping the overlap check turned out not to produce a wrong result but a **panic**: two spans resolved independently can collide, and the splice then slices `src[51:44]`. The guard is load-bearing against a crash in a tool call, not only against bad output. That also explains why `TestIdenticalHunksOverlap` shows no failure in that row: the binary dies in the earlier test before reaching it.

Assertion call sites added: 28, across 17 tests. Assertions removed or weakened: 0 (nothing existing was touched).

## Before / after

There is no "before" to run, so here is the engine's actual output on the cases that matter, captured from a throwaway harness against a small document with two `todo:` lines.

```
stale file               REJECTED  file changed since it was read: expected dcf19a8dce4a, found 9dd516a4fd95; re-read it before editing
ambiguous anchor         REJECTED  hunk 0: anchor is not unique: "todo: write the" matches 2 places; extend it until it matches one
missing anchor           REJECTED  hunk 0: anchor not found: "todo: write the middle"
overlapping hunks        REJECTED  hunks overlap: two hunks both cover offset 15
good edit                applied   "# Notes\n\nThe intro.\n\ntodo: write the outro\n"
```

The stale case is the one worth dwelling on: that anchor is present and unique in the changed file. Every mechanism that only locates text would have applied it.

```mermaid
flowchart LR
    subgraph after["with this engine"]
        R2[read file] --> H2["content + hash"]
        H2 --> D2[decide edit]
        D2 --> E2{"hash still<br/>matches?"}
        E2 -->|no| X2["reject:<br/>re-read it"]
        E2 -->|yes| A2{"anchor unique?"}
        A2 -->|no| X3["reject:<br/>ambiguous"]
        A2 -->|yes| W2[apply all hunks]
    end
    subgraph before["addressing by position"]
        R1[read file] --> D1[decide edit]
        D1 --> W1["write line 47"]
        W1 --> S1["silently wrong<br/>if the file moved"]
    end
```

## Out of scope (deliberately deferred)

- **`read_file` / `edit_file` tools, the `host.Extension`, `EditPaths`, and the README** → PR B on #1275. Split by risk rather than size, following the 1270 / 1271 pattern: this half is pure and has no `App`, that half is wiring.
- **`write_file` and whole-file creation.** `Apply` operates on content it is given; a path that does not exist yet is the tool layer's problem.
- **C4's verify script does not walk `agent/ext/`.** It covers `ext/` and `experimental/ext/` only, so cross-imports between `agent/ext/*` modules are unchecked. Harmless when that tree held one module; this PR makes it two. Filed separately rather than widened into here.

