### PR TITLE
ci: enforce C4 extension isolation with a real gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,12 @@ jobs:
       - name: No committed binaries
         run: ./scripts/check-no-binaries.sh
 
+      # C4: extension modules stay independent of each other. Same reasoning as
+      # the gate above — fast, unambiguous, and pointless if it only runs when
+      # someone remembers to paste a snippet out of CONSTRAINTS.md.
+      - name: No cross-extension requires
+        run: ./scripts/check-ext-isolation.sh
+
       - name: Run unit tests
         run: go test ./... -v
 

--- a/CONSTRAINTS.md
+++ b/CONSTRAINTS.md
@@ -60,25 +60,11 @@ If a future SEP explicitly cross-cuts two extensions, document the SEP reference
 
 A cross-extension reference is a violation **only** when the referenced module is neither the importing module itself nor an ancestor of it. Nested intra-extension submodules (e.g., `experimental/ext/events/stores/redis` depending on its parent `experimental/ext/events`) are intentional and allowed.
 
-**Verify:** the script below catches `require`/`replace` lines pointing at another extension after subtracting (a) the module's own path and (b) any ancestor of it. It walks every `go.mod` under `ext/` and `experimental/ext/`, including nested submodules. Must print nothing.
+**`agent/ext/` is in scope**, alongside `ext/` and `experimental/ext/`. Those modules all already depend on `agent/` and `agent/host`, which makes them less independent of each other by construction than `ext/*` modules are, and that is an argument about shared *ancestors* rather than a licence for siblings to couple. Both failure modes above are about module layering, and neither becomes benign because the tree sits under `agent/`. Membership is derived from the module path (any path segment named `ext`), so a new extension tree is covered when it appears rather than when someone remembers to add it.
 
-```bash
-bash -c '
-for m in $(find ext experimental/ext -name go.mod); do
-  mod=$(grep -E "^module " "$m" | awk "{print \$2}")
-  refs=$(grep -E "github\.com/panyam/mcpkit/(ext|experimental/ext)/" "$m" \
-    | grep -vE "^module " \
-    | grep -oE "github\.com/panyam/mcpkit/(ext|experimental/ext)/[a-zA-Z0-9_/-]+" \
-    | sort -u)
-  for ref in $refs; do
-    case "$mod" in
-      "$ref"|"$ref"/*) continue;;
-    esac
-    echo "VIOLATION $m: $ref"
-  done
-done
-'
-```
+**Only direct requires count.** A `replace` with no matching require is path resolution for a multi-module repo and changes no build, so it is not a dependency edge. An `// indirect` require is transitive: every `agent/ext/*` module pulls `ext/auth` and friends through `agent/host`, and treating that as a violation would report 16 non-problems and teach everyone to ignore the check.
+
+**Verify:** `make check-ext-isolation`, run in CI by the `No cross-extension requires` step in `.github/workflows/test.yml`. The rationale for each rule lives in `scripts/check-ext-isolation.sh`'s header. Must exit 0.
 
 ## C5: Multi-replica notification delivery requires explicit Pattern B wiring
 

--- a/Makefile
+++ b/Makefile
@@ -467,6 +467,9 @@ setup-hooks: ## Install git hooks (pre-push runs tests; pre-commit rejects compi
 check-no-binaries: ## CI gate — fail if any tracked file is a compiled executable
 	@./scripts/check-no-binaries.sh
 
+check-ext-isolation: ## CI gate — fail if one extension module requires another (C4)
+	@./scripts/check-ext-isolation.sh
+
 setup: setup-tools setup-hooks ## Full development setup
 
 help: ## Show this help

--- a/scripts/check-ext-isolation.sh
+++ b/scripts/check-ext-isolation.sh
@@ -1,0 +1,83 @@
+#!/bin/sh
+# Fail if one extension module directly requires another (constraint C4).
+#
+# Extensions are independent surfaces: each consumes core/ abstractions, not
+# its siblings. Two things go wrong when that slips. A single import inverts
+# the layering, so the module everyone else depends on now depends on one of
+# them and version bumps entangle. And it implicitly stabilizes the imported
+# module's API for the importer's benefit, though no SEP says the two must
+# interoperate, so a later refactor of the callee breaks a caller nobody
+# expected to exist.
+#
+# This used to be a bash block pasted inside CONSTRAINTS.md that nothing ran.
+# A rule with an unrun verifier is a comment, and `agent/ext/` accumulated a
+# second module while the block still only walked `ext/` and
+# `experimental/ext/` (issue 1277).
+#
+# Membership is derived from the module path rather than a hardcoded list of
+# directories: any module under a path segment named `ext` is an extension, so
+# a new tree is covered the day it appears instead of the day someone
+# remembers to add it here.
+#
+# Only DIRECT requires count, which is the part the old block got wrong:
+#
+#   - `replace` lines are path resolution for a multi-module repo. A replace
+#     with no matching require changes no build and is not a dependency edge.
+#   - `// indirect` requires are transitive. In this repo every agent/ext
+#     module pulls ext/auth and friends through agent/host, and calling that a
+#     C4 violation would flag 16 non-problems and train everyone to ignore the
+#     check.
+#
+# The escape hatch for a genuine cross-extension test is unchanged: put it in
+# a separate top-level module (tests/<a>_<b>_e2e/) that imports both.
+#
+# Run locally with: make check-ext-isolation
+
+set -eu
+
+cd "$(dirname "$0")/.."
+
+# A module path is an extension when some segment after the repo root is
+# literally `ext`: github.com/panyam/mcpkit[/<area>]/ext/<name>[/<sub>...]
+ext_re='github\.com/panyam/mcpkit/([a-z0-9_-]+/)*ext/[a-zA-Z0-9_/-]+'
+
+status=0
+
+for gomod in $(find . -name go.mod -not -path '*/node_modules/*' | sort); do
+  mod=$(awk '/^module /{print $2; exit}' "$gomod")
+
+  # Not an extension module: nothing for C4 to say about what it requires.
+  echo "$mod" | grep -qE "^$ext_re$" || continue
+
+  # Direct requires only: inside a require block or on a require line, minus
+  # anything marked indirect. Replace directives never reach this.
+  refs=$(awk '
+      /^require \(/ { inblock = 1; next }
+      /^\)/         { inblock = 0 }
+      inblock       { print; next }
+      /^require /   { print }
+    ' "$gomod" \
+    | grep -v '// indirect' \
+    | grep -oE "$ext_re" \
+    | sort -u)
+
+  for ref in $refs; do
+    # Itself, or an ancestor of itself. A nested submodule depending on its
+    # own parent (experimental/ext/events/stores/redis -> experimental/ext/events)
+    # is intentional.
+    case "$mod" in
+      "$ref" | "$ref"/*) continue ;;
+    esac
+    echo "VIOLATION $gomod requires $ref"
+    status=1
+  done
+done
+
+if [ "$status" -ne 0 ]; then
+  echo ""
+  echo "C4: extension modules must not require each other. See CONSTRAINTS.md."
+  echo "For a test that genuinely needs both, add tests/<ext-a>_<ext-b>_e2e/."
+  exit 1
+fi
+
+echo "check-ext-isolation: no cross-extension requires."


### PR DESCRIPTION
## What changes

Turns constraint C4 from a documented rule into an enforced one. Its verifier was a bash block pasted inside `CONSTRAINTS.md` that nothing executed, and it only walked `ext/` and `experimental/ext/` while `agent/ext/` had quietly grown a second module. The check now lives in `scripts/check-ext-isolation.sh`, runs in CI beside the committed-binaries gate, and covers every extension tree.

Closes #1277.

## ELI15

A smoke detector you never put a battery in is not a smoke detector. It is a plastic disc on the ceiling that makes people feel safe enough to stop sniffing for smoke.

C4 says extension modules must not depend on each other, and it shipped with a shell script proving it. The script was correct. It was also printed in a document, and running it required someone to notice it, copy it out, and paste it into a terminal. Nobody ever did. So for as long as the rule existed, the thing that would have caught a violation was a paragraph.

The interesting part is what happened when the battery went in. The published script matched **every** line in a `go.mod` mentioning another extension, and once it walked `agent/ext/` too, that turned out to flag sixteen things that are all completely fine. Some were `replace` lines, which only tell Go where to find a module on disk and change nothing about what actually gets depended on. The rest were marked `indirect`, meaning nobody asked for them; they arrived because something else did. A detector that goes off sixteen times while you cook dinner does not get a battery replaced, it gets taken down. So the rule narrowed to the case that is genuinely a coupling: a module *deliberately* asking for a sibling. That one now fails the build.

## Reviewer's guide

Read in this order:

1. [scripts/check-ext-isolation.sh](https://github.com/panyam/mcpkit/pull/1282/files#diff-fe1494c21dbbf6394be4b275517620372b3bac068f8cd96bd649293ae3c32dfd) — the whole change. The header comment carries the reasoning; the logic under it is about 30 lines.
2. [CONSTRAINTS.md](https://github.com/panyam/mcpkit/pull/1282/files#diff-f2043ef583480706f62a74d47dae3d7ae2402f1b42cff01383b08fe8b37fdf3b) — C4's `Verify` now points at the script, and two new paragraphs record the scope decision and the direct-requires rule.
3. [.github/workflows/test.yml](https://github.com/panyam/mcpkit/pull/1282/files#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88), [Makefile](https://github.com/panyam/mcpkit/pull/1282/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52) — wiring, two lines each.

## How it works

```
for each go.mod in the repo:
    mod = its module path
    skip unless mod looks like  .../mcpkit[/<area>]/ext/<name>   # membership by path, not a list

    refs = extension module paths appearing in DIRECT requires
           (inside a require block or on a require line;
            `// indirect` dropped; replace directives never reach here)

    for each ref:
        skip if ref == mod or mod is under ref/     # nested submodule -> own parent is fine
        report a violation, exit 1
```

Two things a reviewer would otherwise have to reconstruct. **Membership is derived from the module path** (any segment named `ext`) rather than from `find ext experimental/ext agent/ext`, so the next extension tree is covered the day it appears rather than the day someone remembers this file. And **`replace` lines are deliberately unreachable** by the scan, which is a real narrowing from the published block, argued in the decision log.

## Decision log

- **`agent/ext/` is in C4's scope.** The counter-argument in the issue is that `agent/ext/*` modules all already depend on `agent/` and `agent/host`, so they are less independent by construction than `ext/*` modules. That is an argument about shared *ancestors*; it does not follow that siblings may couple. Both failure modes C4 names are about module layering and neither becomes benign under `agent/`.
- **Only direct requires count.** This is a genuine narrowing from the published script, which matched every line. A `replace` with no matching require changes no build and is not a dependency edge. An `// indirect` require is transitive rather than chosen. The alternative was to keep matching everything and add an exclusion list for the 16 current cases, which would need editing every time a module's transitive set shifts.
- **Membership by module path, not a directory list.** The bug being fixed *is* a stale hardcoded list. Replacing it with a slightly longer hardcoded list would have reproduced it.
- **A new script rather than extending an existing checker.** `check_dep_consistency.py` is about version alignment across modules; this is about which edges may exist. Different question, and `check-no-binaries.sh` sets the precedent for one small gate per rule.
- **Kept the script in `sh`,** matching `check-no-binaries.sh`, so it needs no interpreter beyond what CI already has.

## Risk / blast radius

- **Affects:** CI only. No Go code changes, no module graph changes. The gate fails a build only for a `go.mod` edge that C4 already forbade.
- **False-positive risk is the thing to weigh**, since a noisy gate gets disabled. Currently zero on the tree as it stands, and the two exclusion rules are the reason.
- **Be paranoid about:** the `ext_re` module-path pattern. It decides both what counts as an extension and what counts as a reference. A module named e.g. `.../extras/...` must not match; the `ext` segment is anchored by slashes on both sides, but it is worth a second read.
- **Not covered:** a code-level import with no `go.mod` edge cannot exist in Go (the build would fail), so scanning `go.mod` is sufficient. A cross-extension edge introduced via `go.work` would be missed; the repo does not use one.

## Red before green

The gate has to catch violations in each tree it claims to cover, and stay quiet on the shapes that are legitimate. Each row was produced by injecting the line into a real `go.mod`, running the script, and reverting.

| Injected into a real `go.mod` | Expected | Result |
|---|---|---|
| `agent/ext/files` requires `agent/ext/checkpoint` (the case in #1277) | caught | exit 1, names the pair |
| `ext/otel` requires `ext/skills` (the case the old block covered) | caught, no regression | exit 1, names the pair |
| `experimental/ext/events` requires `ext/auth` | caught | exit 1, names the pair |
| `experimental/ext/events/stores/redis` requires its own parent | **clean** | exit 0 |
| `ext/otel` requires `ext/skills` marked `// indirect` | **clean** | exit 0 |
| `ext/otel` gets a `replace` for `ext/skills` with no require | **clean** | exit 0 |

Tree restored and green after every probe. No Go tests were added, removed, or weakened: this PR contains no Go code.

## Before / after

```
$ make check-ext-isolation          # before: no such target; the check was a paragraph
make: *** No rule to make target `check-ext-isolation'.  Stop.

$ make check-ext-isolation          # after, clean tree
check-ext-isolation: no cross-extension requires.

$ make check-ext-isolation          # after, with agent/ext/files -> agent/ext/checkpoint
VIOLATION ./agent/ext/files/go.mod requires github.com/panyam/mcpkit/agent/ext/checkpoint

C4: extension modules must not require each other. See CONSTRAINTS.md.
For a test that genuinely needs both, add tests/<ext-a>_<ext-b>_e2e/.
```

```mermaid
flowchart LR
    subgraph after["after — one gate, derived membership"]
        S["scripts/check-ext-isolation.sh"]
        S --> E2["ext/*"]
        S --> X2["experimental/ext/*"]
        S --> A2["agent/ext/*"]
        S --> F2["any future */ext/*"]
        CI2["CI: test.yml"] --> S
        C2["CONSTRAINTS.md C4"] -. "points at" .-> S
    end
    subgraph before["before — a script in a document"]
        C1["CONSTRAINTS.md C4<br/>(bash block, inline)"] -.->|"only if a human<br/>copies it out"| R1["ext/*<br/>experimental/ext/*"]
        A1["agent/ext/*"]:::uncovered
    end
    classDef uncovered fill:#fee,stroke:#c66,stroke-dasharray: 4 3
```

## Out of scope (deliberately deferred)

- **Auditing the repo's other `Verify:` lines for the same problem.** C4 is not obviously the only constraint whose verifier is a snippet nobody runs; C1, C2 and C3 are `grep` one-liners in the same style, and C5 says outright that no automated check exists. Worth a sweep, but a sweep is its own change and would bury this one.
- **`agent/ext/checkpoint` path safety** → #1281, the sibling of this issue from the same session. Unrelated code, planned separately.

