### PR TITLE
fix(agent/ext/checkpoint): refuse to restore a path that changed shape

### DIFF
--- a/agent/ext/checkpoint/README.md
+++ b/agent/ext/checkpoint/README.md
@@ -61,7 +61,7 @@ cp.Add("/work/src/a.go", "/work/src/b.go")   // captures current content
 cp.Restore()                                  // back to what Add saw
 ```
 
-Three behaviours worth knowing:
+Four behaviours worth knowing:
 
 - **First capture wins.** Re-adding a path already in the checkpoint is a
   no-op, so the checkpoint holds the state at the start of the turn. Capturing
@@ -74,9 +74,48 @@ Three behaviours worth knowing:
   place. A failure during the rename phase leaves a mix. The fix is to run it
   again: restoring the same checkpoint twice reaches the same state, and the
   manifest is never consumed.
+- **A path that changed shape is refused, not restored.** See below.
 
 Paths are absolute, so a checkpoint is valid on the machine that took it and
 is not portable off it.
+
+## Restoring only what is still the thing that was captured
+
+A checkpoint records what it found at each path: a regular file's content, that
+the path was missing, or that it was something else. Restore compares that
+against what is there now, and declines any path where the two disagree.
+
+The gap this closes is unusually wide. Capture happens at the top of a turn and
+a restore happens whenever someone types `/undo`, so a path has minutes or
+hours in which to become a symlink pointing somewhere else. Renaming onto it
+writes the old content to the link's target, and for a path captured as absent
+the restore is an `os.Remove`, which deletes that target outright. Neither is a
+race in any tight sense; both are just what happens next if nothing looks.
+
+```
+turn-7: 3 file(s) restored
+
+1 path(s) REFUSED (not restored):
+  /work/notes.md — is now a symlink, was regular at capture
+```
+
+A refusal is per path, so one tampered file does not cost you the rest of the
+turn. It is deliberately not a containment check: this package has no workspace
+root and does not want one, because a checkpointed tool may legitimately write
+to a cache or temp directory outside any single tree. Confining paths is the
+**tool's** job, and `agent/ext/files` is the worked example of doing it with an
+`os.Root` handle. What this adds is narrower and needs no root: restoring
+through a thing that is not what you captured is not something any caller
+wants, whatever their layout.
+
+Capture uses `Lstat`, so a path that is *already* a symlink is recorded as
+unsupported rather than followed. Following it would copy the target's content
+into the blob store and set up a restore that writes back to a file the caller
+never named.
+
+Through the `Reversal` seam a refusal surfaces as an **error**, because the
+harness runs restores unattended (constraint A11) and has nowhere to put
+detail. `/undo` calls `Restore` directly and prints each refusal in full.
 
 ## What this does not cover
 

--- a/agent/ext/checkpoint/extension.go
+++ b/agent/ext/checkpoint/extension.go
@@ -234,10 +234,11 @@ func (e *Extension) runUndo(ctx context.Context, args string) (host.CmdResult, e
 	if err != nil {
 		return host.CmdResult{}, fmt.Errorf("checkpoint: no such checkpoint %q: %w", id, err)
 	}
-	if err := cp.Restore(); err != nil {
+	res, err := cp.Restore()
+	if err != nil {
 		return host.CmdResult{}, err
 	}
-	report := e.undoReport(cp)
+	report := e.undoReport(cp, res)
 	if extra := e.offerProposals(ctx, e.gaps()); extra != "" {
 		report += "\n\n" + extra
 	}
@@ -304,10 +305,22 @@ func (e *Extension) gaps() []Gap {
 // GitHub issue reports "3 files restored" under any design that only knows
 // about what it captured, and the issue goes unmentioned. A safety net with an
 // unreported hole is worse than none, because it stops being checked.
-func (e *Extension) undoReport(cp *Checkpoint) string {
+//
+// There are two kinds of hole and they are listed separately, because the
+// reader can act on them differently. A call with no reverser was never
+// undoable and the answer is a proposed offset. A refused path WAS captured
+// and would have been restored, except that it is not the thing that was
+// captured any more, and the answer is to go and look at it.
+func (e *Extension) undoReport(cp *Checkpoint, res RestoreResult) string {
 	var b strings.Builder
-	paths := cp.Paths()
-	fmt.Fprintf(&b, "%s: %d file(s) restored", cp.ID(), len(paths))
+	fmt.Fprintf(&b, "%s: %d file(s) restored", cp.ID(), len(res.Restored))
+
+	if len(res.Refused) > 0 {
+		fmt.Fprintf(&b, "\n\n%d path(s) REFUSED (not restored):", len(res.Refused))
+		for _, r := range res.Refused {
+			fmt.Fprintf(&b, "\n  %s — %s", r.Path, r.Reason)
+		}
+	}
 
 	e.mu.Lock()
 	gaps := append([]Gap(nil), e.unreversed...)

--- a/agent/ext/checkpoint/filestore.go
+++ b/agent/ext/checkpoint/filestore.go
@@ -7,18 +7,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
 	"sync"
 	"time"
 )
-
-// absent is the manifest hash for a path that did not exist when it was
-// captured. Restoring it deletes the file, which is what undoing a create
-// means. A sha256 hex string is never empty, so the sentinel cannot collide
-// with a real blob.
-const absent = ""
 
 // Store is a content-addressed snapshot of files, on disk under one root.
 //
@@ -59,7 +54,7 @@ type Checkpoint struct {
 	created time.Time
 
 	mu    sync.Mutex
-	files map[string]string
+	files map[string]entry
 }
 
 // Info is a checkpoint's header, for listing without loading the manifest
@@ -70,11 +65,84 @@ type Info struct {
 	Files   int       `json:"files"`
 }
 
-type manifest struct {
-	ID      string            `json:"id"`
-	Created time.Time         `json:"created"`
-	Files   map[string]string `json:"files"`
+// kind is what Add found at a path, which decides what restoring it means and
+// whether restoring it is safe at all.
+type kind string
+
+const (
+	// kindRegular is an ordinary file whose content was captured.
+	kindRegular kind = "regular"
+
+	// kindAbsent is a path that did not exist. Restoring it deletes whatever
+	// the call went on to create, which is what undoing a creation means.
+	kindAbsent kind = "absent"
+
+	// kindUnsupported is anything else at capture time: a symlink, a
+	// directory, a device. No content is captured and restoring is refused.
+	//
+	// Recorded rather than skipped, because a path the caller asked to protect
+	// and that was silently never protected is the failure A11's corollary is
+	// about. Naming it at /undo time is what lets someone notice.
+	kindUnsupported kind = "unsupported"
+)
+
+// entry is what one captured path holds. It is a struct rather than a bare
+// hash because the hash alone cannot express "this was not a regular file",
+// and C2 rules out carrying that in a second map keyed by the same paths.
+type entry struct {
+	// Hash names the blob, and is empty for every kind but kindRegular.
+	Hash string `json:"hash,omitempty"`
+
+	// Kind is what was there at capture. Restore compares it against what is
+	// there now, and refuses when they disagree.
+	Kind kind `json:"kind"`
 }
+
+// manifestVersion is the on-disk format. Version 1 replaced a bare
+// path-to-hash map, which could not distinguish a file that was absent from
+// one that was a symlink, so a restore wrote through the link.
+//
+// Checkpoints are per-session artifacts under a working directory rather than
+// durable state, so an older manifest is reported and ignored rather than
+// migrated.
+const manifestVersion = 1
+
+type manifest struct {
+	Version int              `json:"version"`
+	ID      string           `json:"id"`
+	Created time.Time        `json:"created"`
+	Files   map[string]entry `json:"files"`
+}
+
+// Refusal is one path Restore declined to touch, and why.
+type Refusal struct {
+	// Path is the captured path, as recorded at capture time.
+	Path string
+
+	// Reason is a sentence for a human, naming what changed. It is meant to
+	// be read in a /undo report, not matched on.
+	Reason string
+}
+
+// RestoreResult reports what a Restore did and, more importantly, what it did
+// not.
+//
+// Restore returns this rather than a bare error because a partial restore is
+// a normal outcome here, not a failure: one tampered path should not block
+// recovering the rest of the turn. But a caller that only learned "no error"
+// would believe the turn was fully reversed, and constraint A11's corollary
+// is precisely that a reversal path must report what it could not reverse.
+type RestoreResult struct {
+	// Restored lists the paths returned to their captured state, sorted.
+	Restored []string
+
+	// Refused lists the paths left alone, sorted by path. Empty means the
+	// restore was complete.
+	Refused []Refusal
+}
+
+// Complete reports whether every captured path was restored.
+func (r RestoreResult) Complete() bool { return len(r.Refused) == 0 }
 
 // Open returns the checkpoint with this id, loading it if it already exists.
 // Reopening is how a turn that spans several tool calls keeps adding to one
@@ -90,7 +158,7 @@ func (s *Store) Open(id string) (*Checkpoint, error) {
 	if !os.IsNotExist(err) {
 		return nil, err
 	}
-	return &Checkpoint{store: s, id: id, created: time.Now().UTC(), files: map[string]string{}}, nil
+	return &Checkpoint{store: s, id: id, created: time.Now().UTC(), files: map[string]entry{}}, nil
 }
 
 // Load reads an existing checkpoint. The error satisfies os.IsNotExist when no
@@ -100,12 +168,26 @@ func (s *Store) Load(id string) (*Checkpoint, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Version is read first so a manifest from the previous format reports
+	// what it is. Unmarshalling it as the current one fails on a type error
+	// and would be reported as corruption, sending someone to look for a
+	// truncated write that never happened.
+	var probe struct {
+		Version int `json:"version"`
+	}
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		return nil, fmt.Errorf("checkpoint: manifest %q is corrupt: %w", id, err)
+	}
+	if probe.Version != manifestVersion {
+		return nil, fmt.Errorf("checkpoint: manifest %q is format v%d, this build writes v%d; delete it or keep using the mcpkit that wrote it", id, probe.Version, manifestVersion)
+	}
+
 	var m manifest
 	if err := json.Unmarshal(raw, &m); err != nil {
 		return nil, fmt.Errorf("checkpoint: manifest %q is corrupt: %w", id, err)
 	}
 	if m.Files == nil {
-		m.Files = map[string]string{}
+		m.Files = map[string]entry{}
 	}
 	return &Checkpoint{store: s, id: m.ID, created: m.Created, files: m.Files}, nil
 }
@@ -173,11 +255,11 @@ func (c *Checkpoint) Add(paths ...string) error {
 		if _, seen := c.files[abs]; seen {
 			continue
 		}
-		hash, err := c.store.putFile(abs)
+		e, err := c.store.capture(abs)
 		if err != nil {
 			return err
 		}
-		c.files[abs] = hash
+		c.files[abs] = e
 		changed = true
 	}
 	if !changed {
@@ -199,52 +281,110 @@ func (c *Checkpoint) Add(paths ...string) error {
 // restoring the same checkpoint twice reaches the same state, so a restore
 // that fails halfway is fixed by running it again rather than by manual
 // repair. The manifest is never consumed, so retrying is always possible.
-func (c *Checkpoint) Restore() error {
+func (c *Checkpoint) Restore() (RestoreResult, error) {
 	c.mu.Lock()
-	files := make(map[string]string, len(c.files))
-	for p, h := range c.files {
-		files[p] = h
+	files := make(map[string]entry, len(c.files))
+	for p, e := range c.files {
+		files[p] = e
 	}
 	c.mu.Unlock()
 
 	type staged struct{ tmp, dst string }
 	var writes []staged
 	var deletes []string
+	var result RestoreResult
 
 	cleanup := func() {
 		for _, w := range writes {
 			os.Remove(w.tmp)
 		}
 	}
+	refuse := func(path, reason string) {
+		result.Refused = append(result.Refused, Refusal{Path: path, Reason: reason})
+	}
 
-	for dst, hash := range files {
-		if hash == absent {
-			deletes = append(deletes, dst)
+	for _, dst := range sortedKeys(files) {
+		e := files[dst]
+
+		// What is there NOW, without following a link. The gap between
+		// capture and /undo is a user deciding to type it, so this is not a
+		// tight race: minutes or hours in which a path can become something
+		// else entirely.
+		now, err := os.Lstat(dst)
+		switch {
+		case err != nil && !os.IsNotExist(err):
+			cleanup()
+			return RestoreResult{}, fmt.Errorf("checkpoint: inspect %s: %w", dst, err)
+		case err == nil && !now.Mode().IsRegular():
+			// Covers both directions that matter: writing back through a
+			// symlink that appeared, and deleting through one.
+			refuse(dst, fmt.Sprintf("is now a %s, was %s at capture", describe(now.Mode()), e.Kind))
 			continue
 		}
-		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-			cleanup()
-			return fmt.Errorf("checkpoint: prepare %s: %w", dst, err)
+
+		switch e.Kind {
+		case kindUnsupported:
+			refuse(dst, "was not a regular file at capture; checkpoint restores regular files only")
+		case kindAbsent:
+			deletes = append(deletes, dst)
+		case kindRegular:
+			if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+				cleanup()
+				return RestoreResult{}, fmt.Errorf("checkpoint: prepare %s: %w", dst, err)
+			}
+			tmp, err := c.store.stage(e.Hash, dst)
+			if err != nil {
+				cleanup()
+				return RestoreResult{}, err
+			}
+			writes = append(writes, staged{tmp: tmp, dst: dst})
+		default:
+			refuse(dst, fmt.Sprintf("unknown capture kind %q", e.Kind))
 		}
-		tmp, err := c.store.stage(hash, dst)
-		if err != nil {
-			cleanup()
-			return err
-		}
-		writes = append(writes, staged{tmp: tmp, dst: dst})
 	}
 
 	for _, w := range writes {
 		if err := os.Rename(w.tmp, w.dst); err != nil {
-			return fmt.Errorf("checkpoint: restore %s (partially applied, safe to retry): %w", w.dst, err)
+			return result, fmt.Errorf("checkpoint: restore %s (partially applied, safe to retry): %w", w.dst, err)
 		}
+		result.Restored = append(result.Restored, w.dst)
 	}
 	for _, dst := range deletes {
 		if err := os.Remove(dst); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("checkpoint: remove %s (partially applied, safe to retry): %w", dst, err)
+			return result, fmt.Errorf("checkpoint: remove %s (partially applied, safe to retry): %w", dst, err)
 		}
+		result.Restored = append(result.Restored, dst)
 	}
-	return nil
+	sort.Strings(result.Restored)
+	return result, nil
+}
+
+// describe names a file type for a refusal message, since "is now a mode
+// 0xa000" tells the reader nothing about what to go and look at.
+func describe(m fs.FileMode) string {
+	switch {
+	case m&fs.ModeSymlink != 0:
+		return "symlink"
+	case m.IsDir():
+		return "directory"
+	case m&fs.ModeDevice != 0:
+		return "device"
+	case m&fs.ModeNamedPipe != 0:
+		return "named pipe"
+	case m&fs.ModeSocket != 0:
+		return "socket"
+	default:
+		return "non-regular file"
+	}
+}
+
+func sortedKeys(m map[string]entry) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // Reversal presents this checkpoint through the seam, so a file-touching tool
@@ -252,11 +392,28 @@ func (c *Checkpoint) Restore() error {
 // outside the machine, which is exactly the property that makes it safe for
 // the harness to run unattended.
 func (c *Checkpoint) Reversal() Reversal {
-	return Reversal{Restore: func(context.Context) error { return c.Restore() }}
+	return Reversal{Restore: func(context.Context) error {
+		res, err := c.Restore()
+		if err != nil {
+			return err
+		}
+		// A refusal is an error at this seam even though Restore treats it as
+		// a normal partial outcome. The seam's caller is the harness running
+		// unattended (A11), and it has no channel to report detail on: the
+		// only thing it can tell a human is that the reversal did not fully
+		// happen. Swallowing it here is exactly the unreported hole A11's
+		// corollary names. /undo goes through Restore directly and reports
+		// each refusal in full.
+		if !res.Complete() {
+			return fmt.Errorf("checkpoint: %d of %d path(s) could not be restored: %s",
+				len(res.Refused), len(res.Refused)+len(res.Restored), res.Refused[0].Reason)
+		}
+		return nil
+	}}
 }
 
 func (c *Checkpoint) save() error {
-	m := manifest{ID: c.id, Created: c.created, Files: c.files}
+	m := manifest{Version: manifestVersion, ID: c.id, Created: c.created, Files: c.files}
 	raw, err := json.MarshalIndent(m, "", "  ")
 	if err != nil {
 		return fmt.Errorf("checkpoint: encode manifest %q: %w", c.id, err)
@@ -281,14 +438,40 @@ func (s *Store) blobPath(hash string) string {
 	return filepath.Join(s.root, "blobs", hash[:2], hash[2:])
 }
 
-// putFile stores a file's content and returns its hash, or absent when the
-// file does not exist. An already-stored blob is left alone, which is where
-// the dedup comes from.
+// capture records what is at a path right now: its content if it is a regular
+// file, that it was missing, or that it was something restoring cannot
+// faithfully undo.
+//
+// The kind is recorded rather than inferred later because "what was here"
+// stops being knowable the moment the tool runs, and it is the only thing
+// Restore can compare against to notice a path changed shape underneath it.
+func (s *Store) capture(path string) (entry, error) {
+	// Lstat, not Stat: a symlink here must be recorded as one rather than
+	// followed. Following it captures the target's content and, worse, makes
+	// the restore write back through the link to a file the caller never
+	// named.
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return entry{Kind: kindAbsent}, nil
+	}
+	if err != nil {
+		return entry{}, fmt.Errorf("checkpoint: inspect %s: %w", path, err)
+	}
+	if !info.Mode().IsRegular() {
+		return entry{Kind: kindUnsupported}, nil
+	}
+
+	hash, err := s.putFile(path)
+	if err != nil {
+		return entry{}, err
+	}
+	return entry{Hash: hash, Kind: kindRegular}, nil
+}
+
+// putFile stores a file's content and returns its hash. An already-stored
+// blob is left alone, which is where the dedup comes from.
 func (s *Store) putFile(path string) (string, error) {
 	data, err := os.ReadFile(path)
-	if os.IsNotExist(err) {
-		return absent, nil
-	}
 	if err != nil {
 		return "", fmt.Errorf("checkpoint: read %s: %w", path, err)
 	}

--- a/agent/ext/checkpoint/filestore_test.go
+++ b/agent/ext/checkpoint/filestore_test.go
@@ -51,7 +51,7 @@ func TestRestoreReturnsModifiedContent(t *testing.T) {
 	}
 	write(t, f, "clobbered")
 
-	if err := cp.Restore(); err != nil {
+	if _, err := cp.Restore(); err != nil {
 		t.Fatal(err)
 	}
 	if got := read(t, f); got != "original" {
@@ -75,7 +75,7 @@ func TestRestoreDeletesCreatedFile(t *testing.T) {
 	}
 	write(t, f, "created by the agent")
 
-	if err := cp.Restore(); err != nil {
+	if _, err := cp.Restore(); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(f); !os.IsNotExist(err) {
@@ -99,7 +99,7 @@ func TestRestoreRecreatesDeletedFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := cp.Restore(); err != nil {
+	if _, err := cp.Restore(); err != nil {
 		t.Fatal(err)
 	}
 	if got := read(t, f); got != "original" {
@@ -129,7 +129,7 @@ func TestAddFirstCaptureWins(t *testing.T) {
 	}
 	write(t, f, "v3")
 
-	if err := cp.Restore(); err != nil {
+	if _, err := cp.Restore(); err != nil {
 		t.Fatal(err)
 	}
 	if got := read(t, f); got != "v1" {
@@ -156,7 +156,7 @@ func TestRestoreIsIdempotent(t *testing.T) {
 	write(t, created, "new")
 
 	for i := range 3 {
-		if err := cp.Restore(); err != nil {
+		if _, err := cp.Restore(); err != nil {
 			t.Fatalf("restore %d: %v", i, err)
 		}
 		if got := read(t, kept); got != "original" {
@@ -248,7 +248,7 @@ func TestReopenAccumulates(t *testing.T) {
 
 	write(t, a, "a2")
 	write(t, b, "b2")
-	if err := second.Restore(); err != nil {
+	if _, err := second.Restore(); err != nil {
 		t.Fatal(err)
 	}
 	if read(t, a) != "a1" || read(t, b) != "b1" {

--- a/agent/ext/checkpoint/integrity_test.go
+++ b/agent/ext/checkpoint/integrity_test.go
@@ -1,0 +1,332 @@
+package checkpoint
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// symlinkOrSkip creates a link, skipping the test where the platform will not
+// allow one rather than reporting a failure that says nothing about the code.
+func symlinkOrSkip(t *testing.T, target, link string) {
+	t.Helper()
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+}
+
+func captured(t *testing.T, s *Store, id string, paths ...string) *Checkpoint {
+	t.Helper()
+	cp, err := s.Open(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cp.Add(paths...); err != nil {
+		t.Fatal(err)
+	}
+	return cp
+}
+
+// TestRestoreRefusesToWriteThroughASymlink is the case this file exists for.
+// The gap between capture and /undo is a person deciding to type it, so a path
+// has minutes or hours in which to become a link pointing somewhere else. The
+// content is right there in the blob store and the rename would succeed.
+func TestRestoreRefusesToWriteThroughASymlink(t *testing.T) {
+	s, work := newStore(t)
+	outside := filepath.Join(t.TempDir(), "important.conf")
+	write(t, outside, "do not touch\n")
+
+	f := filepath.Join(work, "a.txt")
+	write(t, f, "original")
+	cp := captured(t, s, "turn-1", f)
+
+	if err := os.Remove(f); err != nil {
+		t.Fatal(err)
+	}
+	symlinkOrSkip(t, outside, f)
+
+	res, err := cp.Restore()
+	if err != nil {
+		t.Fatalf("Restore() error = %v, want a refusal rather than an error", err)
+	}
+	if len(res.Refused) != 1 {
+		t.Fatalf("Refused = %+v, want exactly one", res.Refused)
+	}
+	if got := read(t, outside); got != "do not touch\n" {
+		t.Errorf("wrote through the symlink: %q", got)
+	}
+	if !strings.Contains(res.Refused[0].Reason, "symlink") {
+		t.Errorf("reason should name what it found, got %q", res.Refused[0].Reason)
+	}
+}
+
+// TestRestoreRefusesToDeleteThroughASymlink covers the absent case, which is
+// the more destructive of the two: undoing a creation means os.Remove, and a
+// path that became a link would delete someone else's file outright.
+func TestRestoreRefusesToDeleteThroughASymlink(t *testing.T) {
+	s, work := newStore(t)
+	outside := filepath.Join(t.TempDir(), "important.conf")
+	write(t, outside, "do not delete\n")
+
+	created := filepath.Join(work, "new.txt")
+	cp := captured(t, s, "turn-1", created) // absent at capture
+
+	symlinkOrSkip(t, outside, created)
+
+	res, err := cp.Restore()
+	if err != nil {
+		t.Fatalf("Restore() error = %v", err)
+	}
+	if len(res.Refused) != 1 {
+		t.Fatalf("Refused = %+v, want exactly one", res.Refused)
+	}
+	if _, err := os.Stat(outside); err != nil {
+		t.Fatalf("deleted through the symlink: %v", err)
+	}
+}
+
+// TestOneRefusalDoesNotBlockTheRest is the partial-restore choice. A single
+// tampered path should not cost the user the rest of the turn.
+func TestOneRefusalDoesNotBlockTheRest(t *testing.T) {
+	s, work := newStore(t)
+	outside := filepath.Join(t.TempDir(), "elsewhere")
+	write(t, outside, "untouched\n")
+
+	good := filepath.Join(work, "good.txt")
+	bad := filepath.Join(work, "bad.txt")
+	write(t, good, "original good")
+	write(t, bad, "original bad")
+	cp := captured(t, s, "turn-1", good, bad)
+
+	write(t, good, "clobbered good")
+	if err := os.Remove(bad); err != nil {
+		t.Fatal(err)
+	}
+	symlinkOrSkip(t, outside, bad)
+
+	res, err := cp.Restore()
+	if err != nil {
+		t.Fatalf("Restore() error = %v", err)
+	}
+	if got := read(t, good); got != "original good" {
+		t.Errorf("the untampered path should still be restored, got %q", got)
+	}
+	if len(res.Restored) != 1 || res.Restored[0] != good {
+		t.Errorf("Restored = %v, want just the good path", res.Restored)
+	}
+	if len(res.Refused) != 1 || res.Refused[0].Path != bad {
+		t.Errorf("Refused = %+v, want just the tampered path", res.Refused)
+	}
+	if res.Complete() {
+		t.Error("Complete() must be false when anything was refused")
+	}
+}
+
+// TestSymlinkAtCaptureIsNotFollowed guards the other end. Capturing through a
+// link would store the target's content and set up a restore that writes back
+// through it, so the link is recorded as unsupported instead.
+func TestSymlinkAtCaptureIsNotFollowed(t *testing.T) {
+	s, work := newStore(t)
+	outside := filepath.Join(t.TempDir(), "target")
+	write(t, outside, "target content\n")
+
+	link := filepath.Join(work, "link.txt")
+	symlinkOrSkip(t, outside, link)
+
+	cp := captured(t, s, "turn-1", link)
+	write(t, outside, "changed since capture\n")
+
+	res, err := cp.Restore()
+	if err != nil {
+		t.Fatalf("Restore() error = %v", err)
+	}
+	if len(res.Refused) != 1 {
+		t.Fatalf("Refused = %+v, want exactly one", res.Refused)
+	}
+	if got := read(t, outside); got != "changed since capture\n" {
+		t.Errorf("restored through a link captured as a link: %q", got)
+	}
+}
+
+// TestCaptureThroughASymlinkDoesNotStoreTheTarget isolates the capture side.
+// Its sibling above cannot: with a link still in place at restore time the
+// restore-side guard refuses either way, so that test passes even if capture
+// followed the link.
+//
+// Replacing the link with a real file removes that guard. If capture followed
+// it, the checkpoint holds the target's content under a regular-file kind, and
+// the restore writes a file the caller never named into a path that now looks
+// perfectly ordinary.
+func TestCaptureThroughASymlinkDoesNotStoreTheTarget(t *testing.T) {
+	s, work := newStore(t)
+	outside := filepath.Join(t.TempDir(), "target")
+	write(t, outside, "secret target content\n")
+
+	p := filepath.Join(work, "innocent.txt")
+	symlinkOrSkip(t, outside, p)
+
+	cp := captured(t, s, "turn-1", p)
+
+	// The link becomes an ordinary file, so nothing at restore time looks
+	// suspicious any more.
+	if err := os.Remove(p); err != nil {
+		t.Fatal(err)
+	}
+	write(t, p, "a real file now\n")
+
+	res, err := cp.Restore()
+	if err != nil {
+		t.Fatalf("Restore() error = %v", err)
+	}
+	if got := read(t, p); got == "secret target content\n" {
+		t.Fatal("capture followed the symlink and restored the target's content")
+	}
+	if got := read(t, p); got != "a real file now\n" {
+		t.Errorf("file should have been left alone, got %q", got)
+	}
+	if len(res.Refused) != 1 {
+		t.Errorf("Refused = %+v, want the unsupported capture refused", res.Refused)
+	}
+}
+
+// TestReversalReportsARefusalAsAnError pins the seam's half of A11. The
+// harness runs a Reversal unattended and has nowhere to put detail, so a
+// partial restore has to reach it as a failure rather than as a silent
+// success.
+func TestReversalReportsARefusalAsAnError(t *testing.T) {
+	s, work := newStore(t)
+	outside := filepath.Join(t.TempDir(), "elsewhere")
+	write(t, outside, "untouched\n")
+
+	f := filepath.Join(work, "a.txt")
+	write(t, f, "original")
+	cp := captured(t, s, "turn-1", f)
+
+	if err := os.Remove(f); err != nil {
+		t.Fatal(err)
+	}
+	symlinkOrSkip(t, outside, f)
+
+	rev := cp.Reversal()
+	if !rev.Reversible() {
+		t.Fatal("a checkpoint reversal must still offer a Restore")
+	}
+	if err := rev.Restore(context.Background()); err == nil {
+		t.Fatal("Reversal.Restore must report a refusal as an error")
+	}
+}
+
+func TestReversalSucceedsWhenNothingIsRefused(t *testing.T) {
+	s, work := newStore(t)
+	f := filepath.Join(work, "a.txt")
+	write(t, f, "original")
+	cp := captured(t, s, "turn-1", f)
+	write(t, f, "clobbered")
+
+	if err := cp.Reversal().Restore(context.Background()); err != nil {
+		t.Fatalf("Reversal.Restore() error = %v, want nil", err)
+	}
+	if got := read(t, f); got != "original" {
+		t.Errorf("restore gave %q", got)
+	}
+}
+
+// TestUndoReportNamesRefusedPaths is A11's corollary at the surface a person
+// actually reads. A refusal that only reached the Restored count would be an
+// unreported hole, and an unreported hole stops being checked.
+func TestUndoReportNamesRefusedPaths(t *testing.T) {
+	e := &Extension{}
+	cp := &Checkpoint{id: "turn-7"}
+	res := RestoreResult{
+		Restored: []string{"/work/a.txt", "/work/b.txt", "/work/c.txt"},
+		Refused: []Refusal{{
+			Path:   "/work/notes.md",
+			Reason: "is now a symlink, was regular at capture",
+		}},
+	}
+
+	report := e.undoReport(cp, res)
+	if !strings.Contains(report, "3 file(s) restored") {
+		t.Errorf("report should count what was actually restored:\n%s", report)
+	}
+	for _, want := range []string{"REFUSED", "/work/notes.md", "is now a symlink"} {
+		if !strings.Contains(report, want) {
+			t.Errorf("report is missing %q:\n%s", want, report)
+		}
+	}
+}
+
+// TestRestoredCountExcludesRefusals is the specific lie worth preventing: the
+// report used to count captured paths, so a refused path was announced as
+// restored.
+func TestRestoredCountExcludesRefusals(t *testing.T) {
+	e := &Extension{}
+	cp := &Checkpoint{id: "turn-7"}
+	res := RestoreResult{
+		Restored: []string{"/work/a.txt"},
+		Refused:  []Refusal{{Path: "/work/b.txt", Reason: "is now a directory, was regular at capture"}},
+	}
+	if report := e.undoReport(cp, res); !strings.Contains(report, "1 file(s) restored") {
+		t.Errorf("want 1 restored, not 2:\n%s", report)
+	}
+}
+
+// TestOldManifestIsNamedNotCalledCorrupt keeps an upgrade from sending someone
+// to look for a truncated write. The previous format stored a bare
+// path-to-hash map, which unmarshals into the current one as a type error.
+func TestOldManifestIsNamedNotCalledCorrupt(t *testing.T) {
+	s, _ := newStore(t)
+	old := map[string]any{
+		"id":      "turn-1",
+		"created": "2026-08-10T00:00:00Z",
+		"files":   map[string]string{"/work/a.txt": "deadbeef"},
+	}
+	raw, err := json.Marshal(old)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(s.manifestPath("turn-1"), raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = s.Load("turn-1")
+	if err == nil {
+		t.Fatal("loading a v0 manifest should fail")
+	}
+	if strings.Contains(err.Error(), "corrupt") {
+		t.Errorf("an old format is not corruption: %v", err)
+	}
+	if !strings.Contains(err.Error(), "format v0") {
+		t.Errorf("error should name the format found: %v", err)
+	}
+}
+
+func TestManifestRoundTripsKinds(t *testing.T) {
+	s, work := newStore(t)
+	present := filepath.Join(work, "present.txt")
+	write(t, present, "hello")
+	missing := filepath.Join(work, "missing.txt")
+
+	cp := captured(t, s, "turn-1", present, missing)
+	_ = cp
+
+	reloaded, err := s.Load("turn-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := reloaded.files[present].Kind; got != kindRegular {
+		t.Errorf("present path kind = %q, want %q", got, kindRegular)
+	}
+	if got := reloaded.files[missing].Kind; got != kindAbsent {
+		t.Errorf("missing path kind = %q, want %q", got, kindAbsent)
+	}
+	if reloaded.files[present].Hash == "" {
+		t.Error("a regular capture should carry a blob hash")
+	}
+	if reloaded.files[missing].Hash != "" {
+		t.Error("an absent capture should carry no blob hash")
+	}
+}


### PR DESCRIPTION
## What changes

`Checkpoint.Restore` now checks that each captured path is still the thing that was captured, and declines the ones that are not. Previously it renamed and removed at whatever absolute paths the manifest held, without looking.

Closes #1281.

## ELI15

A locksmith takes an impression of your front door lock so they can put it back the way it was. They come back a week later, and the impression still fits, so they fit it. Except the door is now the neighbour's door, because in between someone moved the number plate.

That is the shape of the bug. A checkpoint records a file's contents at the start of a turn so `/undo` can put them back. The path it recorded is just a name, and a name is a poor way to identify a thing over time. If someone replaces that name with a **symlink** pointing at a different file, the restore happily writes the old contents through the link and into a file nobody asked it to touch. For a path the checkpoint recorded as "this did not exist yet", undoing means *deleting* it, so the same trick deletes the file on the other end of the link.

The window here is not the microsecond kind you need a stopwatch to exploit. Capture happens when a turn starts; the restore happens whenever a person decides to type `/undo`. That is minutes, and often hours.

So the checkpoint now writes down *what it saw*, not just the contents: a real file, a missing path, or something else. At restore it looks again, and if the answer changed it leaves that path alone and says so. The thing it is emphatically **not** doing is deciding which directories are allowed, because a tool may have perfectly good reasons to write to a cache folder somewhere else, and a checkpoint that second-guessed that would break honest callers to stop a dishonest one. It only refuses to put something back into a thing that is no longer what it copied.

## Reviewer's guide

Read in this order:

1. [agent/ext/checkpoint/filestore.go](https://github.com/panyam/mcpkit/pull/1283/files#diff-78559f76694eef6d80eff090f1bd17930f235fb8db77affac82caa1eab4b7f79) — start at `Restore`, then `capture` above it. Those two are the change; everything else in the file follows from the manifest entry gaining a `Kind`.
2. [agent/ext/checkpoint/integrity_test.go](https://github.com/panyam/mcpkit/pull/1283/files#diff-caf3c7b35d8d5bc70e2f73b5bf70c21aacf7a0ea473e732b38f0af96620546aa) — acceptance. `TestRestoreRefusesToWriteThroughASymlink` and `TestCaptureThroughASymlinkDoesNotStoreTheTarget` are the two ends of it.
3. [agent/ext/checkpoint/extension.go](https://github.com/panyam/mcpkit/pull/1283/files#diff-bdbe30d4ed9bc16fb266dd9f56f56c5c746e0bdb90992c71ad9fdba3f37279ec) — `undoReport` gains a refusal section and now counts what was restored rather than what was captured.
4. [agent/ext/checkpoint/README.md](https://github.com/panyam/mcpkit/pull/1283/files#diff-6efce74a8c63e2d8b719072d89fdf5052d04e49890914d6a51b8ae0b1e6d2ca6) — the new section states the containment/integrity line.
5. [agent/ext/checkpoint/filestore_test.go](https://github.com/panyam/mcpkit/pull/1283/files#diff-d6b3481ae1b6366c6b35ae07c6e3af1558032444b5885821c91da036c93cc203) — mechanical, `err :=` becomes `_, err :=` at six call sites. No assertion changed.

## How it works

```
capture(path):                       # at the top of a turn
    info = Lstat(path)               # Lstat: a symlink is recorded, not followed
    missing      -> {kind: absent}
    regular file -> {kind: regular, hash: store the content}
    anything else-> {kind: unsupported}          # no blob, restoring it is refused

Restore():                           # whenever someone types /undo
    for each captured path, sorted:
        now = Lstat(path)                        # look again, do not follow
        if now exists and is not a regular file:
            refuse "is now a <symlink|directory|device>, was <kind> at capture"

        kind == unsupported -> refuse
        kind == absent      -> queue a delete
        kind == regular     -> stage content to a temp file beside the target

    rename each staged temp into place    # staging first, so a missing blob
    remove each queued delete             # fails before anything is touched

    return {Restored: [...], Refused: [...]}
```

The one thing worth pausing on: **the `Lstat` at capture and the `Lstat` at restore catch different attacks, and each has a case the other misses.** At restore it stops writing through a link that appeared since. At capture it stops the checkpoint copying a link target's contents into the blob store in the first place. If capture followed the link and the link were later replaced by an ordinary file, restore would see a perfectly normal regular file and write the wrong contents into it. That case is the reason `TestCaptureThroughASymlinkDoesNotStoreTheTarget` exists, and it is discussed under red-before-green because a weaker test looked like it covered this and did not.

## Decision log

- **Integrity, not containment.** The issue laid out three options. Giving checkpoint a workspace root assumes every checkpointed tool lives in one tree, which a tool writing to a cache or temp directory does not. Leaving it entirely to tools is the status quo, and the `agent/ext/files` symlink escape earlier this week is evidence about how reliably that goes. Refusing to restore through something that is not what was captured needs no root and breaks no honest layout.
- **Per-path refusal, not aborting the restore.** One tampered path should not cost the user the rest of the turn. The staging phase already provides a clean all-or-nothing abort for genuine errors (a missing blob, an unwritable directory), so the blunt option was already covered where it belongs.
- **`Restore` returns a `RestoreResult`.** A partial restore is a normal outcome under the choice above, so `error` alone cannot express it, and a caller seeing `nil` would conclude the turn was fully reversed. That is exactly the unreported hole A11's corollary is about.
- **A refusal is an error through the `Reversal` seam,** even though `Restore` treats it as a normal outcome. The seam's caller is the harness running unattended; it has no channel for detail and the only useful thing it can say is that the reversal did not fully happen. `/undo` goes through `Restore` directly and prints everything.
- **A path that was already a symlink at capture is `unsupported`, not captured-and-restored.** Restoring a symlink faithfully would mean recreating the link, not writing its target, and nothing here needs that. Recording it beats skipping it silently: a path someone asked to protect that was never protected is the failure mode this whole file guards against.
- **The manifest gains a `version` and old ones are refused, not migrated.** Checkpoints are per-session artifacts under a working directory, not durable state. Without the version an old manifest fails to parse and gets reported as corruption, which sends the reader looking for a truncated write.
- **`entry` is a struct rather than a second map.** C2 requires it, and the hash alone genuinely cannot express "this was not a regular file".

## Risk / blast radius

- **Affects:** `agent/ext/checkpoint` only. `Checkpoint.Restore`'s signature changed; the only non-test caller in the tree is `runUndo`. No other module imports this one.
- **Behavior change for existing users:** on-disk checkpoints written by an earlier build are refused with a message rather than loaded. Since checkpoints live under a working directory and describe one session, the fix is deleting them.
- **Tests covering this:** 11 new in `integrity_test.go`, plus the existing suite unchanged. All under `-race`.
- **Be paranoid about:** `describe()` and the `Kind` comparison being the only thing standing between a restore and a write. Also worth pressure-testing: this checks the path's *type*, not its identity. A captured regular file swapped for a **different regular file** is still restored over, which is correct (that is the ordinary "the agent edited it" case and the entire point of a restore), but it means the check is narrower than "nothing changed".
- **Not covered:** a hardlink to a file outside the tree is a regular file by every check here and would be restored through. Closing that means comparing inode identity across a capture-to-undo gap that legitimately includes editors replacing files, which would refuse honest restores. Called out here rather than silently left.

## Red before green

Every behavior was verified by mutating the implementation and recording which tests fail, with build-failure detection in the harness from the start.

| Mutation | Caught by |
|---|---|
| `Restore` stops checking what is there now (the original bug) | `TestRestoreRefusesToWriteThroughASymlink`, `TestRestoreRefusesToDeleteThroughASymlink`, `TestOneRefusalDoesNotBlockTheRest`, `TestReversalReportsARefusalAsAnError` |
| `capture` uses `Stat` instead of `Lstat` | `TestCaptureThroughASymlinkDoesNotStoreTheTarget` |
| `Reversal` swallows refusals | `TestReversalReportsARefusalAsAnError` |
| `undoReport` drops the refused section | `TestUndoReportNamesRefusedPaths` |
| Report counts captured paths again instead of restored | `TestRestoredCountExcludesRefusals`, `TestUndoReportNamesRefusedPaths` |
| Manifest version check dropped | `TestOldManifestIsNamedNotCalledCorrupt` |

**Row two survived the first pass**, and the reason is worth flagging because it is the same trap that produced the bug this PR fixes. `TestSymlinkAtCaptureIsNotFollowed` leaves the symlink in place at restore time, so the restore-side guard refuses either way and the test passes whether or not capture followed the link. It reads like coverage of the capture side and is not. `TestCaptureThroughASymlinkDoesNotStoreTheTarget` removes that second guard by replacing the link with an ordinary file before restoring, which isolates the capture behaviour and does fail against the mutation.

Assertion sites added: 42, across 11 new tests. Removed or weakened: **0** — the six edits to `filestore_test.go` are `if err :=` becoming `if _, err :=` and change no assertion.

## Before / after

Captured from a throwaway harness: a turn edits three files, one of which becomes a symlink to a file outside the workspace before `/undo` runs.

```
BEFORE (on main)
turn-7: 3 file(s) restored
$ cat important.conf
original                      <-- the captured content, written through the link

AFTER (this PR)
turn-7: 2 file(s) restored

1 path(s) REFUSED (not restored):
  /work/notes.md — is now a symlink, was regular at capture
$ cat important.conf
PRIVATE KEY MATERIAL          <-- untouched
```

Note the count as well as the refusal: `3 file(s) restored` was reported by counting *captured* paths, so before this change the one path it did not restore was announced as restored.

```mermaid
sequenceDiagram
    participant T as tool (turn start)
    participant C as checkpoint
    participant D as disk
    participant U as /undo (minutes or hours later)

    T->>C: Add(notes.md)
    C->>D: Lstat + read
    D-->>C: regular file, content
    Note over C: records {kind: regular, hash}<br/>(was: hash only)

    Note over D: someone replaces notes.md<br/>with a symlink to important.conf

    U->>C: Restore()
    C->>D: Lstat(notes.md)
    D-->>C: symlink
    alt kind disagrees with what is there now
        C-->>U: REFUSED, names the path and why
        Note over D: important.conf untouched
    else still a regular file
        C->>D: stage temp, rename into place
        C-->>U: restored
    end
```

## Out of scope (deliberately deferred)

- **A workspace root for checkpoint.** Option 1 in the issue. A larger change that assumes every checkpointed tool lives in one tree; the integrity check here is what does not require that assumption.
- **Hardlink identity**, described under Risk. Distinguishing it from an ordinary edit needs inode tracking across a gap that legitimately includes files being replaced.
- **The `Compensate`-versus-proposer overlap** noted in `agent/NOTES.md` as freeze material for #1240. Untouched here.


