### PR TITLE
feat(agent/ext/files): list_files and search_files

### DIFF
--- a/agent/ext/files/README.md
+++ b/agent/ext/files/README.md
@@ -121,7 +121,58 @@ precisely to keep it that way. The alternative, this package declaring its own
 benefit with no design decision saying the two must interoperate, which is the
 coupling constraint C4 exists to prevent.
 
+## Finding things
+
+`list_files` walks the workspace; `search_files` matches lines and returns
+them as `path:line: text`.
+
+```
+$ list_files {"dir": "agent/ext"}
+agent/ext/files/edit.go
+agent/ext/files/tools.go
+...
+
+$ search_files {"query": "func Get\\w+"}
+a.go:12: func GetUser() (*User, error) {
+a.go:31: func GetOrder(id string) (*Order, error) {
+```
+
+**The query is a regex** (RE2, so no catastrophic backtracking). Pass
+`literal: true` for text containing `( ) [ ] . * + ? | \ $`. A pattern that
+does not compile comes back as a refusal naming it, never as zero matches:
+"no matches" and "your pattern was malformed" are answers you act on
+differently, and reporting the second as the first sends you looking for code
+that is sitting right there.
+
+**Both tools say what they left out.** A capped listing that stayed quiet about
+being capped reads as the complete contents of a directory, so it reports the
+cap, the directories it skipped, and the files it would not search:
+
+```
+showing 100 of 4312 match(es); narrow the query or raise limit
+
+3 file(s) not searched: 2 binary, 1 over 2 MiB, 0 unreadable
+1 directory was skipped: node_modules
+```
+
+Those limits bound the work a call does. They are **not** a context-window
+mechanism, and deliberately do not try to be: `agent.OffloadingSource` already
+stores oversized tool results out of band behind a `read_tool_result` stub, and
+a second truncation mechanism here would only disagree with it.
+
+`Config.Exclude` sets which directories are skipped, defaulting to
+`DefaultExclude` (`.git`, `node_modules`, `vendor`, and similar). A nil slice
+means the default; an explicitly empty one means exclude nothing. It does not
+read `.gitignore`, which is a different question: that file says what should
+not be *committed*, and a `.env` is ignored while sometimes being exactly what
+you need, while a vendored dependency is committed and is usually noise.
+
+Traversal uses the same root handle as everything else, so it cannot leave the
+workspace. A symlinked directory is listed as a name but never descended into,
+which also means a link cycle cannot hang a walk.
+
 ## Status
 
-Anchored edit engine, the two tools, and the host extension. Not yet here:
-whole-file creation and `write_file`, directory listing, and search.
+Anchored edit engine, four tools (`read_file`, `edit_file`, `list_files`,
+`search_files`), and the host extension. Not yet here: whole-file creation and
+`write_file`.

--- a/agent/ext/files/discover.go
+++ b/agent/ext/files/discover.go
@@ -1,0 +1,397 @@
+package files
+
+import (
+	"bytes"
+	"fmt"
+	"io/fs"
+	"path"
+	"regexp"
+	"strings"
+
+	"github.com/panyam/mcpkit/core"
+)
+
+// DefaultExclude is skipped by list_files and search_files unless a Config
+// overrides it.
+//
+// These are directories whose contents an agent almost never wants and which
+// are large enough to swamp a result set. Deliberately NOT sourced from
+// .gitignore: that file says what should not be committed, which is a
+// different question from what is worth reading. A .env is ignored and is
+// sometimes exactly what is needed; a vendored dependency is committed and is
+// usually noise. Neither set contains the other, so borrowing one for the
+// other quietly does the wrong thing in both directions.
+var DefaultExclude = []string{
+	".git", "node_modules", "vendor", "dist", "build", "target",
+	".venv", "__pycache__", ".next", ".cache",
+}
+
+// Default result limits. They bound the work a call does and the size of what
+// comes back; they are not a context-window mechanism. agent.OffloadingSource
+// already stores oversized results out of band, and duplicating that here
+// would give two truncation mechanisms disagreeing about the same output.
+const (
+	// DefaultListLimit caps paths returned by one list_files call.
+	DefaultListLimit = 500
+
+	// DefaultSearchLimit caps matches returned by one search_files call.
+	DefaultSearchLimit = 100
+
+	// maxSearchFileSize skips files larger than this when searching. A
+	// minified bundle or a checked-in dump matches noisily and reading it is
+	// most of the cost of a search.
+	maxSearchFileSize = 2 << 20 // 2 MiB
+
+	// binarySniffLen is how much of a file is examined for a NUL byte before
+	// treating it as binary.
+	binarySniffLen = 8192
+
+	// maxMatchLineLen truncates a single reported line, so one minified row
+	// cannot consume the whole result budget.
+	maxMatchLineLen = 300
+)
+
+// walkOpts is the shared traversal configuration for both discovery tools.
+type walkOpts struct {
+	dir     string
+	exclude []string
+	limit   int
+}
+
+// excluded reports whether a directory name is skipped.
+//
+// Matching is on the base name rather than the full path, because that is what
+// the default list means: `node_modules` anywhere, not only at the root. A
+// caller wanting a path-anchored rule can pass a pattern and it is matched with
+// path.Match against both forms.
+func excluded(patterns []string, name, rel string) bool {
+	for _, p := range patterns {
+		if p == name {
+			return true
+		}
+		if ok, err := path.Match(p, name); err == nil && ok {
+			return true
+		}
+		if ok, err := path.Match(p, rel); err == nil && ok {
+			return true
+		}
+	}
+	return false
+}
+
+// walkResult is what a traversal produced, including what it left out.
+//
+// The counts exist so the caller can say so. A truncated list that does not
+// admit it reads as a complete answer, which is the same class of failure as
+// an edit silently applying to a stale file.
+type walkResult struct {
+	paths      []string
+	skippedDir []string
+	truncated  bool
+	total      int
+}
+
+// walk traverses the root, honouring excludes and the limit.
+//
+// It walks fs.WalkDir over the Root's fs.FS rather than filepath.WalkDir over
+// a joined path. That is the confinement: the walk cannot leave the root, and
+// a symlinked directory is reported as a plain entry rather than descended
+// into, so neither an escape nor a cycle is reachable. A symlink is left in
+// the listing as a name, since knowing it exists is useful; what is refused is
+// reading through it.
+func (s *Source) walk(o walkOpts) (walkResult, error) {
+	var res walkResult
+	seenDir := map[string]bool{}
+
+	err := fs.WalkDir(s.root.FS(), o.dir, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			// One unreadable directory should not abort a listing of
+			// everything else. It is recorded as skipped rather than dropped.
+			if d != nil && d.IsDir() {
+				if !seenDir[p] {
+					seenDir[p] = true
+					res.skippedDir = append(res.skippedDir, p)
+				}
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if p == o.dir {
+			return nil
+		}
+		if d.IsDir() {
+			if excluded(o.exclude, d.Name(), p) {
+				if !seenDir[p] {
+					seenDir[p] = true
+					res.skippedDir = append(res.skippedDir, p)
+				}
+				return fs.SkipDir
+			}
+			return nil
+		}
+		res.total++
+		if len(res.paths) >= o.limit {
+			res.truncated = true
+			return nil
+		}
+		res.paths = append(res.paths, p)
+		return nil
+	})
+	if err != nil {
+		return walkResult{}, err
+	}
+	return res, nil
+}
+
+// isBinary reports whether content looks binary, by the presence of a NUL byte
+// in its leading bytes. It is the same heuristic grep uses, and it is a
+// heuristic: a UTF-16 text file trips it, and a binary with no early NUL does
+// not.
+func isBinary(b []byte) bool {
+	if len(b) > binarySniffLen {
+		b = b[:binarySniffLen]
+	}
+	return bytes.IndexByte(b, 0) >= 0
+}
+
+// compilePattern turns the query into a matcher.
+//
+// A pattern that does not compile is returned as an error naming it, never as
+// zero matches. "No matches" and "your pattern was malformed" are answers a
+// caller acts on completely differently, and a search that reports the second
+// as the first sends the model looking for code that is there.
+//
+// Go's regexp is RE2, so there is no backtracking and a pathological pattern
+// cannot hang the call.
+func compilePattern(query string, literal bool) (*regexp.Regexp, error) {
+	if query == "" {
+		return nil, fmt.Errorf("search_files needs a non-empty query")
+	}
+	expr := query
+	if literal {
+		expr = regexp.QuoteMeta(query)
+	}
+	re, err := regexp.Compile(expr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid regex %q: %v; pass literal:true to search for it as plain text", query, err)
+	}
+	return re, nil
+}
+
+// match is one hit, rendered as path:line: text.
+type match struct {
+	path string
+	line int
+	text string
+}
+
+func (m match) String() string {
+	t := strings.TrimRight(m.text, "\r\n")
+	t = strings.TrimLeft(t, " \t")
+	if len(t) > maxMatchLineLen {
+		t = t[:maxMatchLineLen] + "…"
+	}
+	return fmt.Sprintf("%s:%d: %s", m.path, m.line, t)
+}
+
+// dirArg resolves the optional dir argument to a walk root. Absent means the
+// whole workspace, which fs.FS spells ".".
+func (s *Source) dirArg(args map[string]any) (string, error) {
+	d, _ := args["dir"].(string)
+	if d == "" || d == "." || d == "/" {
+		return ".", nil
+	}
+	rel, err := s.rel(d)
+	if err != nil {
+		return "", err
+	}
+	return rel, nil
+}
+
+// limitArg reads an optional positive limit, falling back to a default. JSON
+// numbers decode as float64, so an integer argument arrives as one.
+func limitArg(args map[string]any, def int) int {
+	switch v := args["limit"].(type) {
+	case float64:
+		if int(v) > 0 {
+			return int(v)
+		}
+	case int:
+		if v > 0 {
+			return v
+		}
+	}
+	return def
+}
+
+func (s *Source) list(args map[string]any) *core.ToolResult {
+	dir, err := s.dirArg(args)
+	if err != nil {
+		return toolError(err.Error())
+	}
+	limit := limitArg(args, DefaultListLimit)
+
+	res, err := s.walk(walkOpts{dir: dir, exclude: s.exclude, limit: limit})
+	if err != nil {
+		return toolError(escapeMessage(dir, err))
+	}
+	if len(res.paths) == 0 {
+		return &core.ToolResult{
+			Content:           []core.Content{{Type: "text", Text: fmt.Sprintf("no files under %s", dir)}},
+			StructuredContent: map[string]any{"dir": dir, "paths": []string{}, "total": 0},
+		}
+	}
+
+	var b strings.Builder
+	b.WriteString(strings.Join(res.paths, "\n"))
+	writeOmissions(&b, res, len(res.paths), res.total, "file")
+
+	return &core.ToolResult{
+		Content: []core.Content{{Type: "text", Text: b.String()}},
+		StructuredContent: map[string]any{
+			"dir": dir, "paths": res.paths, "total": res.total, "truncated": res.truncated,
+		},
+	}
+}
+
+func (s *Source) search(args map[string]any) *core.ToolResult {
+	query, _ := args["query"].(string)
+	literal, _ := args["literal"].(bool)
+	re, err := compilePattern(query, literal)
+	if err != nil {
+		return toolError(err.Error())
+	}
+	dir, err := s.dirArg(args)
+	if err != nil {
+		return toolError(err.Error())
+	}
+	limit := limitArg(args, DefaultSearchLimit)
+
+	// Every file is a candidate, so the walk is unbounded and the limit is
+	// applied to matches instead.
+	walked, err := s.walk(walkOpts{dir: dir, exclude: s.exclude, limit: 1 << 30})
+	if err != nil {
+		return toolError(escapeMessage(dir, err))
+	}
+
+	var matches []match
+	var binary, unreadable, oversize int
+	truncated := false
+	total := 0
+
+	for _, p := range walked.paths {
+		info, err := fs.Stat(s.root.FS(), p)
+		if err != nil {
+			// A symlink pointing out of the root lands here, which is the
+			// point: it stays visible as a name and is never read through.
+			unreadable++
+			continue
+		}
+		if info.Size() > maxSearchFileSize {
+			oversize++
+			continue
+		}
+		content, err := fs.ReadFile(s.root.FS(), p)
+		if err != nil {
+			unreadable++
+			continue
+		}
+		if isBinary(content) {
+			binary++
+			continue
+		}
+		hits := searchFile(re, p, content, 1<<30)
+		total += len(hits)
+		for _, h := range hits {
+			if len(matches) >= limit {
+				truncated = true
+				continue
+			}
+			matches = append(matches, h)
+		}
+	}
+
+	if len(matches) == 0 {
+		msg := fmt.Sprintf("no matches for %q under %s", query, dir)
+		if n := binary + unreadable + oversize; n > 0 {
+			msg += fmt.Sprintf(" (%d file(s) were not searched: %d binary, %d oversize, %d unreadable)",
+				n, binary, oversize, unreadable)
+		}
+		return &core.ToolResult{
+			Content:           []core.Content{{Type: "text", Text: msg}},
+			StructuredContent: map[string]any{"query": query, "dir": dir, "matches": []string{}, "total": 0},
+		}
+	}
+
+	var b strings.Builder
+	for i, m := range matches {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		b.WriteString(m.String())
+	}
+	if truncated {
+		fmt.Fprintf(&b, "\n\nshowing %d of %d match(es); narrow the query or raise limit", len(matches), total)
+	}
+	writeSkipped(&b, walked, binary, oversize, unreadable)
+
+	out := make([]string, len(matches))
+	for i, m := range matches {
+		out[i] = m.String()
+	}
+	return &core.ToolResult{
+		Content: []core.Content{{Type: "text", Text: b.String()}},
+		StructuredContent: map[string]any{
+			"query": query, "dir": dir, "matches": out, "total": total, "truncated": truncated,
+		},
+	}
+}
+
+// writeOmissions appends what a listing left out.
+//
+// Silence here would be the bug: a capped list that does not say so reads as
+// the complete contents of the directory, and the caller concludes a file it
+// was looking for does not exist.
+func writeOmissions(b *strings.Builder, res walkResult, shown, total int, noun string) {
+	if res.truncated {
+		fmt.Fprintf(b, "\n\nshowing %d of %d %s(s); pass a narrower dir or raise limit", shown, total, noun)
+	}
+	if len(res.skippedDir) > 0 {
+		fmt.Fprintf(b, "\n%d director%s skipped: %s", len(res.skippedDir),
+			plural(len(res.skippedDir)), strings.Join(res.skippedDir, ", "))
+	}
+}
+
+// writeSkipped appends what a search declined to read.
+func writeSkipped(b *strings.Builder, walked walkResult, binary, oversize, unreadable int) {
+	if n := binary + oversize + unreadable; n > 0 {
+		fmt.Fprintf(b, "\n\n%d file(s) not searched: %d binary, %d over %d MiB, %d unreadable",
+			n, binary, oversize, maxSearchFileSize>>20, unreadable)
+	}
+	if len(walked.skippedDir) > 0 {
+		fmt.Fprintf(b, "\n%d director%s skipped: %s", len(walked.skippedDir),
+			plural(len(walked.skippedDir)), strings.Join(walked.skippedDir, ", "))
+	}
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return "y was"
+	}
+	return "ies were"
+}
+
+// searchFile scans one file's content for the pattern, appending up to the
+// remaining budget.
+func searchFile(re *regexp.Regexp, p string, content []byte, budget int) []match {
+	var out []match
+	for i, line := range strings.Split(string(content), "\n") {
+		if len(out) >= budget {
+			break
+		}
+		if re.MatchString(line) {
+			out = append(out, match{path: p, line: i + 1, text: line})
+		}
+	}
+	return out
+}

--- a/agent/ext/files/discover_test.go
+++ b/agent/ext/files/discover_test.go
@@ -1,0 +1,303 @@
+package files
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func newSourceWith(t *testing.T, cfg Config) (*Source, string) {
+	t.Helper()
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.Root = root
+	s, err := NewSource(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s, root
+}
+
+func TestListReturnsFilesRecursively(t *testing.T) {
+	s, root := newTestSource(t)
+	write(t, root, "a.txt", "one")
+	write(t, root, "sub/b.txt", "two")
+	write(t, root, "sub/deep/c.txt", "three")
+
+	text, isErr := call(t, s, "list_files", nil)
+	if isErr {
+		t.Fatalf("list_files failed: %s", text)
+	}
+	for _, want := range []string{"a.txt", "sub/b.txt", "sub/deep/c.txt"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("listing is missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestListScopedToDir(t *testing.T) {
+	s, root := newTestSource(t)
+	write(t, root, "top.txt", "x")
+	write(t, root, "sub/inner.txt", "y")
+
+	text, isErr := call(t, s, "list_files", map[string]any{"dir": "sub"})
+	if isErr {
+		t.Fatalf("list_files failed: %s", text)
+	}
+	if !strings.Contains(text, "sub/inner.txt") {
+		t.Errorf("scoped listing missing its own file:\n%s", text)
+	}
+	if strings.Contains(text, "top.txt") {
+		t.Errorf("scoped listing leaked a file outside dir:\n%s", text)
+	}
+}
+
+// TestListSaysWhatItLeftOut is the no-silent-caps rule. A capped listing that
+// does not admit it reads as the complete contents of the directory, and the
+// caller concludes a file it wanted is not there.
+func TestListSaysWhatItLeftOut(t *testing.T) {
+	s, root := newTestSource(t)
+	for i := range 10 {
+		write(t, root, fmt.Sprintf("f%02d.txt", i), "x")
+	}
+
+	text, isErr := call(t, s, "list_files", map[string]any{"limit": 3})
+	if isErr {
+		t.Fatalf("list_files failed: %s", text)
+	}
+	if !strings.Contains(text, "showing 3 of 10") {
+		t.Errorf("a truncated listing must say so:\n%s", text)
+	}
+}
+
+func TestListReportsExcludedDirectories(t *testing.T) {
+	s, root := newTestSource(t)
+	write(t, root, "keep.txt", "x")
+	write(t, root, "node_modules/dep/index.js", "noise")
+
+	text, isErr := call(t, s, "list_files", nil)
+	if isErr {
+		t.Fatalf("list_files failed: %s", text)
+	}
+	if strings.Contains(text, "index.js") {
+		t.Errorf("excluded directory was listed:\n%s", text)
+	}
+	if !strings.Contains(text, "node_modules") {
+		t.Errorf("an applied exclusion must be reported, not silent:\n%s", text)
+	}
+}
+
+// TestEmptyExcludeMeansExcludeNothing pins the nil-versus-empty distinction.
+// Collapsing them would make "list everything" unexpressible.
+func TestEmptyExcludeMeansExcludeNothing(t *testing.T) {
+	s, root := newSourceWith(t, Config{Exclude: []string{}})
+	write(t, root, "node_modules/dep/index.js", "noise")
+
+	text, isErr := call(t, s, "list_files", nil)
+	if isErr {
+		t.Fatalf("list_files failed: %s", text)
+	}
+	if !strings.Contains(text, "index.js") {
+		t.Errorf("an explicitly empty Exclude should exclude nothing:\n%s", text)
+	}
+}
+
+// TestWalkDoesNotDescendIntoASymlinkedDirectory is the confinement property on
+// the walk, which is a different code path from the open. A traversal that
+// followed links would both escape the root and be able to loop forever.
+func TestWalkDoesNotDescendIntoASymlinkedDirectory(t *testing.T) {
+	s, root := newTestSource(t)
+	outside, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	const sentinel = "OUTSIDE-FILE-SENTINEL"
+	if err := os.WriteFile(filepath.Join(outside, "secret.txt"), []byte(sentinel), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, "escape")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	write(t, root, "inside.txt", "fine")
+
+	text, isErr := call(t, s, "list_files", nil)
+	if isErr {
+		t.Fatalf("list_files failed: %s", text)
+	}
+	if strings.Contains(text, "secret.txt") {
+		t.Fatalf("walk descended into a symlinked directory:\n%s", text)
+	}
+	if !strings.Contains(text, "inside.txt") {
+		t.Errorf("walk should still list real files:\n%s", text)
+	}
+}
+
+func TestSearchFindsMatchesWithPathAndLine(t *testing.T) {
+	s, root := newTestSource(t)
+	write(t, root, "a.go", "package a\n\nfunc Target() {}\n")
+	write(t, root, "b.go", "package b\n")
+
+	text, isErr := call(t, s, "search_files", map[string]any{"query": "func Target"})
+	if isErr {
+		t.Fatalf("search_files failed: %s", text)
+	}
+	if !strings.Contains(text, "a.go:3:") {
+		t.Errorf("match should carry path and line number:\n%s", text)
+	}
+	if strings.Contains(text, "b.go") {
+		t.Errorf("non-matching file appeared:\n%s", text)
+	}
+}
+
+func TestSearchTreatsQueryAsRegex(t *testing.T) {
+	s, root := newTestSource(t)
+	write(t, root, "a.go", "func GetUser() {}\nfunc GetOrder() {}\nfunc Delete() {}\n")
+
+	text, isErr := call(t, s, "search_files", map[string]any{"query": `func Get\w+`})
+	if isErr {
+		t.Fatalf("search_files failed: %s", text)
+	}
+	if !strings.Contains(text, "GetUser") || !strings.Contains(text, "GetOrder") {
+		t.Errorf("regex should have matched both:\n%s", text)
+	}
+	if strings.Contains(text, "Delete") {
+		t.Errorf("regex matched something it should not:\n%s", text)
+	}
+}
+
+// TestSearchLiteralEscapesMetacharacters covers the escape hatch for the regex
+// default. Without it, text containing regex syntax is unsearchable except by
+// hand-escaping.
+func TestSearchLiteralEscapesMetacharacters(t *testing.T) {
+	s, root := newTestSource(t)
+	write(t, root, "a.go", "call foo(bar)\ncall foobar\n")
+
+	text, isErr := call(t, s, "search_files", map[string]any{"query": "foo(bar)", "literal": true})
+	if isErr {
+		t.Fatalf("search_files failed: %s", text)
+	}
+	if !strings.Contains(text, "a.go:1:") {
+		t.Errorf("literal search should match the parenthesised text:\n%s", text)
+	}
+	if strings.Contains(text, "a.go:2:") {
+		t.Errorf("literal search should not match foobar:\n%s", text)
+	}
+}
+
+// TestMalformedRegexIsRefusedNotEmpty is the failure the regex default makes
+// likely. Reporting a broken pattern as "no matches" sends the caller looking
+// for code that is sitting right there.
+func TestMalformedRegexIsRefusedNotEmpty(t *testing.T) {
+	s, root := newTestSource(t)
+	write(t, root, "a.go", "func Target() {}\n")
+
+	text, isErr := call(t, s, "search_files", map[string]any{"query": "func Target([a-z"})
+	if !isErr {
+		t.Fatalf("a malformed regex must be refused, got: %s", text)
+	}
+	if strings.Contains(text, "no matches") {
+		t.Errorf("a broken pattern must not read as zero results: %s", text)
+	}
+	if !strings.Contains(text, "literal:true") {
+		t.Errorf("refusal should name the way out: %s", text)
+	}
+}
+
+func TestSearchSaysWhatItLeftOut(t *testing.T) {
+	s, root := newTestSource(t)
+	var b strings.Builder
+	for range 20 {
+		b.WriteString("needle here\n")
+	}
+	write(t, root, "many.txt", b.String())
+
+	text, isErr := call(t, s, "search_files", map[string]any{"query": "needle", "limit": 5})
+	if isErr {
+		t.Fatalf("search_files failed: %s", text)
+	}
+	if !strings.Contains(text, "showing 5 of 20") {
+		t.Errorf("a truncated search must say so:\n%s", text)
+	}
+}
+
+func TestSearchSkipsAndCountsBinaryFiles(t *testing.T) {
+	s, root := newTestSource(t)
+	write(t, root, "text.txt", "needle\n")
+	if err := os.WriteFile(filepath.Join(root, "blob.bin"), []byte("needle\x00\x01\x02"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	text, isErr := call(t, s, "search_files", map[string]any{"query": "needle"})
+	if isErr {
+		t.Fatalf("search_files failed: %s", text)
+	}
+	if strings.Contains(text, "blob.bin") {
+		t.Errorf("binary file was searched:\n%s", text)
+	}
+	if !strings.Contains(text, "1 binary") {
+		t.Errorf("skipped binary files must be counted, not dropped silently:\n%s", text)
+	}
+}
+
+// TestSearchDoesNotReadThroughASymlink is the search-side half of the
+// confinement. The walk lists the link as a name, which is useful; reading its
+// target would not be.
+func TestSearchDoesNotReadThroughASymlink(t *testing.T) {
+	s, root := newTestSource(t)
+	outside, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	const sentinel = "NEEDLE-OUTSIDE-THE-ROOT"
+	secret := filepath.Join(outside, "secret.txt")
+	if err := os.WriteFile(secret, []byte(sentinel+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(secret, filepath.Join(root, "innocent.txt")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	text, isErr := call(t, s, "search_files", map[string]any{"query": "NEEDLE"})
+	if isErr && !strings.Contains(text, "no matches") {
+		t.Fatalf("search_files failed unexpectedly: %s", text)
+	}
+	if strings.Contains(text, sentinel) {
+		t.Fatalf("search read through a symlink out of the root:\n%s", text)
+	}
+}
+
+func TestSearchNoMatchesIsNotAnError(t *testing.T) {
+	s, root := newTestSource(t)
+	write(t, root, "a.go", "package a\n")
+
+	text, isErr := call(t, s, "search_files", map[string]any{"query": "definitelyNotPresent"})
+	if isErr {
+		t.Fatalf("an honest zero-result search is not an error: %s", text)
+	}
+	if !strings.Contains(text, "no matches") {
+		t.Errorf("should say there were no matches:\n%s", text)
+	}
+}
+
+func TestDiscoveryRefusesToEscapeTheRoot(t *testing.T) {
+	s, _ := newTestSource(t)
+	for _, tool := range []string{"list_files", "search_files"} {
+		t.Run(tool, func(t *testing.T) {
+			args := map[string]any{"dir": "../.."}
+			if tool == "search_files" {
+				args["query"] = "x"
+			}
+			text, isErr := call(t, s, tool, args)
+			if !isErr {
+				t.Fatalf("%s should refuse a dir outside the root, got:\n%s", tool, text)
+			}
+			if !strings.Contains(text, "outside the workspace root") {
+				t.Errorf("refusal should say why: %s", text)
+			}
+		})
+	}
+}

--- a/agent/ext/files/extension_test.go
+++ b/agent/ext/files/extension_test.go
@@ -23,8 +23,8 @@ func TestExtensionContributesToolsAndPrompt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(defs) != 2 {
-		t.Errorf("got %d tools, want 2", len(defs))
+	if len(defs) != 4 {
+		t.Errorf("got %d tools, want 4", len(defs))
 	}
 
 	sections := e.PromptSections()

--- a/agent/ext/files/tools.go
+++ b/agent/ext/files/tools.go
@@ -24,6 +24,14 @@ type Config struct {
 	// instruction into a write to an arbitrary path, so the confinement is
 	// the tool's, not a policy the caller can forget to add.
 	Root string
+
+	// Exclude names directories that list_files and search_files skip, by
+	// base name or by a path.Match pattern. Nil means DefaultExclude; an
+	// explicitly empty non-nil slice means exclude nothing.
+	//
+	// This is not .gitignore and deliberately does not read one. See
+	// DefaultExclude for why the two questions are different.
+	Exclude []string
 }
 
 // Source serves read_file and edit_file over agent.ToolSource.
@@ -35,6 +43,7 @@ type Config struct {
 type Source struct {
 	root     *os.Root
 	rootPath string
+	exclude  []string
 	defs     []core.ToolDef
 }
 
@@ -58,7 +67,13 @@ func NewSource(cfg Config) (*Source, error) {
 	if err != nil {
 		return nil, fmt.Errorf("files: open root %s: %w", cfg.Root, err)
 	}
-	return &Source{root: root, rootPath: abs, defs: toolDefs()}, nil
+	// Nil means "the caller did not choose", empty means "the caller chose
+	// nothing". Collapsing the two would make excluding nothing impossible.
+	exclude := cfg.Exclude
+	if exclude == nil {
+		exclude = DefaultExclude
+	}
+	return &Source{root: root, rootPath: abs, exclude: exclude, defs: toolDefs()}, nil
 }
 
 // Close releases the root directory handle. A long-lived host need not call
@@ -122,6 +137,52 @@ func toolDefs() []core.ToolDef {
 				"required": []string{"path", "expect_hash", "edits"},
 			},
 		},
+		{
+			Name:        "list_files",
+			Title:       "List files",
+			Description: "List files in the workspace, recursively. Use this to find what is there before reading or editing.",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"dir": map[string]any{
+						"type":        "string",
+						"description": "Directory to list, relative to the workspace root. Omit for the whole workspace.",
+					},
+					"limit": map[string]any{
+						"type":        "integer",
+						"description": fmt.Sprintf("Maximum paths to return. Default %d. The reply says how many were left out.", DefaultListLimit),
+					},
+				},
+			},
+		},
+		{
+			Name:  "search_files",
+			Title: "Search file contents",
+			Description: "Search the workspace for a regular expression, returning matching lines as path:line: text. " +
+				"The query is a regex (RE2 syntax): escape it, or pass literal:true, to search for text containing regex characters.",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"query": map[string]any{
+						"type":        "string",
+						"description": "Regular expression to match against each line.",
+					},
+					"literal": map[string]any{
+						"type":        "boolean",
+						"description": "Treat query as plain text rather than a regex. Use this when searching for something containing ( ) [ ] . * + ? | \\ or $.",
+					},
+					"dir": map[string]any{
+						"type":        "string",
+						"description": "Directory to search, relative to the workspace root. Omit for the whole workspace.",
+					},
+					"limit": map[string]any{
+						"type":        "integer",
+						"description": fmt.Sprintf("Maximum matches to return. Default %d. The reply says how many were left out.", DefaultSearchLimit),
+					},
+				},
+				"required": []string{"query"},
+			},
+		},
 	}
 }
 
@@ -146,6 +207,10 @@ func (s *Source) Call(ctx context.Context, name string, args map[string]any) (*c
 		return s.read(args), nil
 	case "edit_file":
 		return s.edit(args), nil
+	case "list_files":
+		return s.list(args), nil
+	case "search_files":
+		return s.search(args), nil
 	default:
 		return nil, fmt.Errorf("files: unknown tool %q", name)
 	}

--- a/agent/ext/files/tools_test.go
+++ b/agent/ext/files/tools_test.go
@@ -340,8 +340,23 @@ func TestToolsAreDeclared(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(defs) != 2 {
-		t.Fatalf("got %d tools, want 2", len(defs))
+	// Asserted by name rather than by count: a count says a tool went missing
+	// without saying which, and it has to be edited every time one is added,
+	// which is how it stops being read.
+	want := map[string]bool{"read_file": true, "edit_file": true, "list_files": true, "search_files": true}
+	got := map[string]bool{}
+	for _, d := range defs {
+		got[d.Name] = true
+	}
+	for name := range want {
+		if !got[name] {
+			t.Errorf("tool %q is not declared", name)
+		}
+	}
+	for name := range got {
+		if !want[name] {
+			t.Errorf("undeclared tool %q appeared", name)
+		}
 	}
 	for _, d := range defs {
 		if d.Name == "" || d.Description == "" || d.InputSchema == nil {


### PR DESCRIPTION
## What changes

Adds `list_files` and `search_files` to `agent/ext/files`. Both are read-only and both traverse through the `os.Root` handle the module already holds, so the confinement story needs no new mechanism.

First half of #1284. `write_file` follows in a second PR.

## ELI15

A library where you can read any book by name, and edit any book by name, but there is no catalogue. You can do anything to a book, provided somebody already told you it exists.

That was the state of this package after the edit primitive landed. `read_file` and `edit_file` both take a path, and nothing produced paths, so an agent could only act on files it had been handed by a human. This adds the catalogue and the index: one tool that lists what is there, one that searches inside it.

The interesting part is not the walking, it is what a search **refuses to pretend**. Two failures look identical if you are careless, and they need opposite reactions. If you search for something and there genuinely are no matches, the right conclusion is "that code is not here". If your search pattern was *malformed*, the tool also finds nothing, and if it reports that the same way you conclude "that code is not here" about code sitting right in front of you. So a broken pattern is refused by name and never returned as an empty result. The same instinct governs the size limits: a list that quietly stops at 500 entries reads as *the complete contents of the directory*, so it says how many it dropped. In both cases the tool's job is to avoid being confidently wrong, which is the same thing the anchored editor was for.

## Reviewer's guide

Read in this order:

1. [agent/ext/files/discover.go](https://github.com/panyam/mcpkit/pull/1285/files#diff-1c79f87ebf7cbe999bc3611b12799030001c06023cd15bbc9b47d6b04cf2c585) — the whole change. Start at `walk`, then `search`. The doc comments carry the reasoning.
2. [agent/ext/files/discover_test.go](https://github.com/panyam/mcpkit/pull/1285/files#diff-68df6ad960d58762d291ddeecdf09ed7d9f7e6b5097e2836b13c120c98ecc40d) — acceptance. `TestWalkDoesNotDescendIntoASymlinkedDirectory` and `TestMalformedRegexIsRefusedNotEmpty` are the two that carry the design.
3. [agent/ext/files/tools.go](https://github.com/panyam/mcpkit/pull/1285/files#diff-ff86ee545bb090c437a29539fd95f66946f3e9ff1bf41e8aa6885021b7f06037) — the two new `ToolDef`s, `Config.Exclude`, and dispatch.
4. [agent/ext/files/README.md](https://github.com/panyam/mcpkit/pull/1285/files#diff-af212df5cc4e7a94c5990499ff9f5ffb5af8c389419ffdb6e59d7b911592f01c) — the "not a context-window mechanism" and gitignore paragraphs.
5. [agent/ext/files/tools_test.go](https://github.com/panyam/mcpkit/pull/1285/files#diff-92ef90d1510d40b1bc2e0bb8a02d7f0ccc94c94f5263511e0ef3158145858708), `extension_test.go` — two assertion updates, discussed under red-before-green.

## How it works

```
walk(dir, exclude, limit):
    fs.WalkDir over root.FS()            # confinement: cannot leave the root,
                                         # symlinked dirs are NOT descended
    directory whose name matches exclude -> SkipDir, record it as skipped
    unreadable directory                 -> SkipDir, record it (do not abort the walk)
    file                                 -> count it; append while under limit,
                                            else mark truncated

list:   walk, print paths, then append what was left out

search: compile the query (RE2; QuoteMeta first when literal:true)
        a pattern that does not compile -> REFUSE, naming it
        walk (unbounded — every file is a candidate)
        per file:  Stat  -> unreadable? count and skip   # a symlink out of the
                                                          # root lands here
                   size  -> over 2 MiB? count and skip
                   read  -> NUL in first 8 KiB? count as binary and skip
                   match each line, append while under limit
        print path:line: text, then append what was left out
```

Two things a reviewer would otherwise reconstruct. **The limit is applied to matches, not to the walk**, because every file is a candidate and stopping the traversal early would silently bias results toward whatever sorts first. And **`fs.Stat` before `fs.ReadFile` is a real guard, not a formality**: a symlink pointing out of the root fails there, which is why it is counted as unreadable rather than read. That double guard matters for how the tests were verified, below.

## Decision log

- **The query is a regex by default.** Matches `rg`, `grep`, and comparable agent tooling, so it is what a reader and a model both expect. The cost is that `foo(bar)` is a capture group; mitigated by refusing uncompilable patterns by name and by offering `literal: true`. (I initially recommended literal-by-default on fail-safe grounds and was overruled; the mitigations are what make regex-by-default safe rather than merely conventional.)
- **A malformed pattern is a refusal, never zero matches.** The two are acted on in opposite ways, and conflating them sends the caller looking for code that is present.
- **No byte-level truncation here.** `agent.OffloadingSource` already stores oversized results out of band behind a `read_tool_result` stub. Adding a second mechanism would give two truncations disagreeing about the same output. The split is A6: result *count* semantics belong to the tool, context economics to the agent layer.
- **Everything dropped is reported** — the cap, skipped directories, binary and oversize files. A silent cap reads as a complete answer.
- **Excludes are a config list, not `.gitignore`.** Parsing gitignore costs a dependency, which A10 turns into a satellite module, and it answers the wrong question: it says what should not be *committed*. A `.env` is ignored and is sometimes exactly what is wanted; a vendored dependency is committed and is usually noise. Neither set contains the other.
- **Nil `Exclude` means the default, empty means exclude nothing.** Collapsing them would make "list everything" unexpressible.
- **A symlink stays visible in a listing.** Knowing it exists is useful; reading through it is what is refused. That is `fs.WalkDir` over `Root.FS()` doing both at once.
- **`TestToolsAreDeclared` now asserts tool names rather than a count.** A count says a tool went missing without saying which, and it needs editing every time one is added, which is how an assertion stops being read.

## Risk / blast radius

- **Affects:** `agent/ext/files` only. Purely additive at runtime: two new tools, one new optional `Config` field. No existing behaviour changes.
- **Tests covering this:** 15 new in `discover_test.go`, plus the existing suite. All under `-race`.
- **Be paranoid about:** `excluded()`. It matches on the **base name** as well as the full relative path, so a `Config.Exclude` entry of `build` skips every directory named `build` at any depth, not only a top-level one. That is what the default list wants and it is what a caller passing a narrow pattern might not expect.
- **Also worth pressure-testing:** the binary heuristic is a NUL sniff of the first 8 KiB, the same one grep uses and equally approximate — a UTF-16 file trips it, and a binary with no early NUL does not. And the 2 MiB size cut is a judgement call, not a derivation.
- **Not covered:** no `.gitignore`, no glob/name filter on `list_files` (only `dir` scoping), and no context lines around a match.

## Red before green

Eight mutations, each verified to have actually changed the file before its result was trusted.

| Mutation | Caught by |
|---|---|
| Exclusion dropped | `TestListReportsExcludedDirectories` |
| List truncation reported silently | `TestListSaysWhatItLeftOut` |
| Search truncation reported silently | `TestSearchSaysWhatItLeftOut` |
| Bad regex yields a match-nothing pattern instead of a refusal | `TestMalformedRegexIsRefusedNotEmpty` |
| `literal` flag ignored | `TestSearchLiteralEscapesMetacharacters` |
| Binary detection always false | `TestSearchSkipsAndCountsBinaryFiles` |
| Nil and empty `Exclude` collapsed | `TestEmptyExcludeMeansExcludeNothing` |
| `dir` argument skips containment | `TestDiscoveryRefusesToEscapeTheRoot` |

**Two notes on how this was verified, because both matter more than the table.**

*The read-path confinement is guarded twice.* Replacing only `fs.ReadFile` with a path-joined `os.ReadFile` changes nothing, because the `fs.Stat` above it already refuses a symlink pointing out of the root. `TestSearchDoesNotReadThroughASymlink` only fails when **both** are mutated together, which it does. That is defence in depth working, not a missing test, and it is the third time this session that a downstream guard has masked a mutation — the pattern is now written up in `agent/NOTES.md` § Testing.

*One harness result was wrong.* My mutation runner reported the binary-detection mutation as surviving. Running the same mutation by hand — with and without the `gofmt` step, three times — showed `TestSearchSkipsAndCountsBinaryFiles` failing on it exactly as intended, with the binary file appearing in the results. The table records the hand-verified outcome. I could not account for the harness's disagreement and did not want to keep spending on it, so: the test is confirmed to discriminate, and my tooling around it is less trustworthy than the tests are.

Assertion sites added: 45, across 15 new tests. **Two existing assertions were replaced**, both audited: `TestToolsAreDeclared`'s `len(defs) != 2` became a name-set check that also catches an unexpected tool appearing (strictly stronger), and `extension_test.go`'s count moved 2 → 4 (equal strength, new count). None weakened.

## Before / after

Captured from a throwaway harness over a small tree containing a Go file, a nested package, a `node_modules` directory, and a PNG that contains the search term.

```
$ list_files {}
  [ok] assets/logo.png
       main.go
       store/db.go
       1 directory was skipped: node_modules

$ search_files {"query": "func Get\\w+"}
  [ok] main.go:3: func GetUser() {}
       main.go:4: func GetOrder() {}
       store/db.go:3: func GetConn() {}

       1 file(s) not searched: 1 binary, 0 over 2 MiB, 0 unreadable
       1 directory was skipped: node_modules

$ search_files {"query": "GetUser("}
  [IsError] invalid regex "GetUser(": error parsing regexp: missing closing ):
            `GetUser(`; pass literal:true to search for it as plain text

$ search_files {"query": "GetUser(", "literal": true}
  [ok] main.go:3: func GetUser() {}
```

The PNG contains the string `GetUser` and is correctly not searched but **is** counted, so the caller can tell the difference between "not there" and "not looked at". The unterminated pattern is refused by name rather than returning the empty result set that would have read as "no such function".

```mermaid
flowchart LR
    subgraph after["after"]
        L[list_files] --> W["walk via root.FS()"]
        S[search_files] --> W
        W --> R[read_file]
        R --> E[edit_file]
        W -. "reports skips,<br/>caps, binaries" .-> U((agent))
    end
    subgraph before["before"]
        H[human supplies path] --> R1[read_file]
        R1 --> E1[edit_file]
        X["no way to discover<br/>anything"]:::gap
    end
    classDef gap fill:#fee,stroke:#c66,stroke-dasharray: 4 3
```

## Out of scope (deliberately deferred)

- **`write_file`** and the `EditPaths` → `PathArg` rename → the second PR on #1284.
- **Glob/name filtering on `list_files`.** Only `dir` scoping today; a `pattern` argument is the obvious next thing if listing proves noisy in practice.
- **Context lines around a search match.** `path:line: text` only, which is the token-cheap shape; `-A/-B` style context can follow if the model turns out to need it.
- **`.gitignore` awareness**, per the decision log. If it is ever wanted it belongs in a satellite module with the dependency.

