### PR TITLE
feat(agent/ext/files): write_file, and EditPaths becomes PathArg

### DIFF
--- a/agent/ext/files/README.md
+++ b/agent/ext/files/README.md
@@ -87,39 +87,29 @@ against the original content rather than against the result of earlier edits.
 So listing order cannot change the outcome, and an edit cannot match text an
 earlier edit introduced.
 
-## Wiring it into a host
+## Creating and replacing whole files
 
-```go
-ext, _ := files.New(files.Config{Root: "/work/project"})
-app, _ := host.NewApp(cfg, out, in, host.WithExtension(ext))
+`edit_file` needs existing content to anchor against, so creating a file and
+replacing one outright are `write_file`'s job. It carries the same discipline,
+expressed through `expect_hash` rather than through a separate flag:
+
+| Call | Meaning |
+|---|---|
+| no `expect_hash` | create; **refused** if the path already exists |
+| `expect_hash` set | replace, only if the content still hashes to it |
+
+There is deliberately no way to spell "write this, whatever is there". A
+create-or-overwrite mode would reopen the hole `edit_file` exists to close, and
+it would be the mode a model reached for the moment anchoring felt awkward.
+
+```
+$ write_file {"path": "notes.md", "content": "..."}
+  [IsError] refusing notes.md: it already exists. Read it first and pass
+            expect_hash to replace it, or use edit_file to change part of it.
 ```
 
-The extension contributes the tools and a prompt section stating the rules the
-tools enforce. Those travel together on purpose: a model that has not been
-told anchors must be unique will keep sending single-word anchors and keep
-being refused, so shipping the tools alone would make the contract
-discoverable only by failing.
-
-## Undo, and why there is no Reverser here
-
-An edit is checkpointable through `agent/ext/checkpoint`, but this package
-contains no reversal code and does not import that one:
-
-```go
-cp, _ := checkpoint.New(checkpoint.Config{
-    Root:   ".mcpkit/checkpoints",
-    Writes: []checkpoint.WriteSpec{{Tool: "edit_file", Paths: files.EditPaths}},
-})
-app, _ := host.NewApp(cfg, out, in, host.WithExtension(ext, cp))
-```
-
-`checkpoint.WriteSpec` is a declaration keyed by tool name, supplied by the
-wiring, so the two features compose at the config layer with no import edge in
-either direction. `EditPaths` is a plain function rather than a `WriteSpec`
-precisely to keep it that way. The alternative, this package declaring its own
-`checkpoint.Reverser`, would stabilize checkpoint's API for this package's
-benefit with no design decision saying the two must interoperate, which is the
-coupling constraint C4 exists to prevent.
+Missing parent directories are created. Replacing a file keeps its mode, so
+editing a script does not disarm it.
 
 ## Finding things
 
@@ -171,8 +161,45 @@ Traversal uses the same root handle as everything else, so it cannot leave the
 workspace. A symlinked directory is listed as a name but never descended into,
 which also means a link cycle cannot hang a walk.
 
+## Wiring it into a host
+
+```go
+ext, _ := files.New(files.Config{Root: "/work/project"})
+app, _ := host.NewApp(cfg, out, in, host.WithExtension(ext))
+```
+
+The extension contributes the tools and a prompt section stating the rules the
+tools enforce. Those travel together on purpose: a model that has not been
+told anchors must be unique will keep sending single-word anchors and keep
+being refused, so shipping the tools alone would make the contract
+discoverable only by failing.
+
+## Undo, and why there is no Reverser here
+
+An edit is checkpointable through `agent/ext/checkpoint`, but this package
+contains no reversal code and does not import that one:
+
+```go
+cp, _ := checkpoint.New(checkpoint.Config{
+    Root:   ".mcpkit/checkpoints",
+    Writes: []checkpoint.WriteSpec{
+        {Tool: "edit_file", Paths: files.PathArg},
+        {Tool: "write_file", Paths: files.PathArg},
+    },
+})
+app, _ := host.NewApp(cfg, out, in, host.WithExtension(ext, cp))
+```
+
+`checkpoint.WriteSpec` is a declaration keyed by tool name, supplied by the
+wiring, so the two features compose at the config layer with no import edge in
+either direction. Every writing tool here names its target in the same `path` argument, so one
+`PathArg` serves them all. It is a plain function rather than a `WriteSpec`
+precisely to keep it that way. The alternative, this package declaring its own
+`checkpoint.Reverser`, would stabilize checkpoint's API for this package's
+benefit with no design decision saying the two must interoperate, which is the
+coupling constraint C4 exists to prevent.
+
 ## Status
 
-Anchored edit engine, four tools (`read_file`, `edit_file`, `list_files`,
-`search_files`), and the host extension. Not yet here: whole-file creation and
-`write_file`.
+Anchored edit engine, five tools (`read_file`, `edit_file`, `write_file`,
+`list_files`, `search_files`), and the host extension.

--- a/agent/ext/files/extension_test.go
+++ b/agent/ext/files/extension_test.go
@@ -23,8 +23,8 @@ func TestExtensionContributesToolsAndPrompt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(defs) != 4 {
-		t.Errorf("got %d tools, want 4", len(defs))
+	if len(defs) != 5 {
+		t.Errorf("got %d tools, want 5", len(defs))
 	}
 
 	sections := e.PromptSections()

--- a/agent/ext/files/tools.go
+++ b/agent/ext/files/tools.go
@@ -138,6 +138,32 @@ func toolDefs() []core.ToolDef {
 			},
 		},
 		{
+			Name:  "write_file",
+			Title: "Write a whole file",
+			Description: "Create a new file, or replace an existing one entirely. " +
+				"Omit expect_hash to create: the call is refused if the path already exists. " +
+				"To replace an existing file, pass expect_hash from the read_file that produced your view of it. " +
+				"Prefer edit_file for changing part of a file.",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"path": map[string]any{
+						"type":        "string",
+						"description": "Path to the file, relative to the workspace root.",
+					},
+					"content": map[string]any{
+						"type":        "string",
+						"description": "The complete new contents of the file.",
+					},
+					"expect_hash": map[string]any{
+						"type":        "string",
+						"description": "The hash read_file returned for the content being replaced. Omit only when creating a file that does not exist yet.",
+					},
+				},
+				"required": []string{"path", "content"},
+			},
+		},
+		{
 			Name:        "list_files",
 			Title:       "List files",
 			Description: "List files in the workspace, recursively. Use this to find what is there before reading or editing.",
@@ -207,6 +233,8 @@ func (s *Source) Call(ctx context.Context, name string, args map[string]any) (*c
 		return s.read(args), nil
 	case "edit_file":
 		return s.edit(args), nil
+	case "write_file":
+		return s.write(args), nil
 	case "list_files":
 		return s.list(args), nil
 	case "search_files":
@@ -282,6 +310,94 @@ func (s *Source) edit(args map[string]any) *core.ToolResult {
 			Text: fmt.Sprintf("edited %s, %d edit(s) applied\nhash: %s", path, len(hunks), hash),
 		}},
 		StructuredContent: map[string]any{"path": path, "hash": hash, "edits": len(hunks)},
+	}
+}
+
+// write replaces a file's entire contents, or creates it.
+//
+// The two cases are told apart by expect_hash rather than by a separate flag,
+// and the rule is that there is no way to spell "overwrite whatever is there".
+//
+//	no expect_hash  -> create; refused if the path exists
+//	expect_hash set -> replace, only if the content still hashes to it
+//
+// A create-or-overwrite mode would undo the whole module. edit_file exists to
+// stop a change landing on content nobody looked at, and a write_file that
+// clobbered on request would be the same hole with a different name, reachable
+// by a model that found the anchor matching awkward.
+func (s *Source) write(args map[string]any) *core.ToolResult {
+	path, ok := args["path"].(string)
+	if !ok || path == "" {
+		return toolError("write_file needs a path")
+	}
+	content, ok := args["content"].(string)
+	if !ok {
+		return toolError("write_file needs content (pass an empty string to write an empty file)")
+	}
+	expect, _ := args["expect_hash"].(string)
+
+	rel, err := s.rel(path)
+	if err != nil {
+		return toolError(err.Error())
+	}
+
+	info, statErr := s.root.Stat(rel)
+	switch {
+	case statErr == nil && !info.Mode().IsRegular():
+		return toolError(fmt.Sprintf("refusing %s: it is not a regular file", path))
+
+	case statErr == nil && expect == "":
+		return toolError(fmt.Sprintf(
+			"refusing %s: it already exists. Read it first and pass expect_hash to replace it, or use edit_file to change part of it.", path))
+
+	case statErr == nil:
+		b, err := s.root.ReadFile(rel)
+		if err != nil {
+			return toolError(escapeMessage(path, err))
+		}
+		if got := Hash(string(b)); got != expect {
+			return toolError(fmt.Sprintf(
+				"%s: %v: expected %s, found %s; re-read it before writing", path, ErrStale, expect, got))
+		}
+
+	case !errors.Is(statErr, os.ErrNotExist):
+		// A path that escapes the root lands here rather than in the create
+		// branch, so a refusal is never mistaken for "does not exist yet".
+		return toolError(escapeMessage(path, statErr))
+
+	case expect != "":
+		return toolError(fmt.Sprintf(
+			"refusing %s: expect_hash was given but the file does not exist. Omit it to create the file.", path))
+	}
+
+	mode := os.FileMode(0o644)
+	if info != nil {
+		mode = info.Mode().Perm()
+	}
+	// Creating a file in a directory that does not exist yet is an ordinary
+	// thing to want, and MkdirAll goes through the root so it cannot climb
+	// out. Only reached on the create path: replacing a file means its
+	// directory is already there.
+	if dir := filepath.Dir(rel); statErr != nil && dir != "." {
+		if err := s.root.MkdirAll(dir, 0o755); err != nil {
+			return toolError(escapeMessage(path, err))
+		}
+	}
+	if err := s.writeThroughRoot(rel, content, mode); err != nil {
+		return toolError(fmt.Sprintf("cannot write %s: %v", path, err))
+	}
+
+	verb := "created"
+	if statErr == nil {
+		verb = "replaced"
+	}
+	hash := Hash(content)
+	return &core.ToolResult{
+		Content: []core.Content{{
+			Type: "text",
+			Text: fmt.Sprintf("%s %s, %d byte(s)\nhash: %s", verb, path, len(content), hash),
+		}},
+		StructuredContent: map[string]any{"path": path, "hash": hash, "bytes": len(content), "created": statErr != nil},
 	}
 }
 
@@ -406,17 +522,19 @@ func toolError(msg string) *core.ToolResult {
 	}
 }
 
-// EditPaths reports the files an edit_file call is about to write, in the
-// shape a checkpoint WriteSpec wants:
+// PathArg reports the file a call is about to write, in the shape a
+// checkpoint WriteSpec wants. Every writing tool here names its target in the
+// same `path` argument, so one function serves them all:
 //
-//	checkpoint.WriteSpec{Tool: "edit_file", Paths: files.EditPaths}
+//	checkpoint.WriteSpec{Tool: "edit_file", Paths: files.PathArg}
+//	checkpoint.WriteSpec{Tool: "write_file", Paths: files.PathArg}
 //
 // It is a plain function rather than a WriteSpec so that this package does
 // not import the checkpoint package and checkpoint does not import this one.
 // The two features compose at the wiring layer, keyed by tool name, which is
 // what keeps either free to change without the other's API stabilizing around
 // it.
-func EditPaths(args map[string]any) []string {
+func PathArg(args map[string]any) []string {
 	p, ok := args["path"].(string)
 	if !ok || p == "" {
 		return nil

--- a/agent/ext/files/tools_test.go
+++ b/agent/ext/files/tools_test.go
@@ -37,6 +37,15 @@ func write(t *testing.T, dir, name, content string) string {
 	return p
 }
 
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
 func call(t *testing.T, s *Source, name string, args map[string]any) (string, bool) {
 	t.Helper()
 	res, err := s.Call(context.Background(), name, args)
@@ -343,7 +352,7 @@ func TestToolsAreDeclared(t *testing.T) {
 	// Asserted by name rather than by count: a count says a tool went missing
 	// without saying which, and it has to be edited every time one is added,
 	// which is how it stops being read.
-	want := map[string]bool{"read_file": true, "edit_file": true, "list_files": true, "search_files": true}
+	want := map[string]bool{"read_file": true, "edit_file": true, "list_files": true, "search_files": true, "write_file": true}
 	got := map[string]bool{}
 	for _, d := range defs {
 		got[d.Name] = true
@@ -366,10 +375,10 @@ func TestToolsAreDeclared(t *testing.T) {
 }
 
 func TestEditPathsFeedsACheckpointWriteSpec(t *testing.T) {
-	if got := EditPaths(map[string]any{"path": "notes.md"}); len(got) != 1 || got[0] != "notes.md" {
-		t.Errorf("EditPaths = %v, want [notes.md]", got)
+	if got := PathArg(map[string]any{"path": "notes.md"}); len(got) != 1 || got[0] != "notes.md" {
+		t.Errorf("PathArg = %v, want [notes.md]", got)
 	}
-	if got := EditPaths(map[string]any{}); got != nil {
-		t.Errorf("EditPaths with no path = %v, want nil", got)
+	if got := PathArg(map[string]any{}); got != nil {
+		t.Errorf("PathArg with no path = %v, want nil", got)
 	}
 }

--- a/agent/ext/files/write_test.go
+++ b/agent/ext/files/write_test.go
@@ -1,0 +1,273 @@
+package files
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWriteCreatesANewFile(t *testing.T) {
+	s, root := newTestSource(t)
+
+	text, isErr := call(t, s, "write_file", map[string]any{
+		"path": "new.txt", "content": "hello\n",
+	})
+	if isErr {
+		t.Fatalf("write_file failed: %s", text)
+	}
+	if got := readFile(t, filepath.Join(root, "new.txt")); got != "hello\n" {
+		t.Errorf("file = %q, want %q", got, "hello\n")
+	}
+	if !strings.Contains(text, Hash("hello\n")) {
+		t.Errorf("write_file should report the new hash:\n%s", text)
+	}
+	if !strings.Contains(text, "created") {
+		t.Errorf("reply should distinguish a create from a replace:\n%s", text)
+	}
+}
+
+// TestWriteRefusesAnExistingPathWithoutAHash is the whole discipline. Without
+// it, write_file is a way to clobber content nobody looked at, which is the
+// hole edit_file exists to close, reachable by a model that found anchoring
+// awkward.
+func TestWriteRefusesAnExistingPathWithoutAHash(t *testing.T) {
+	s, root := newTestSource(t)
+	p := write(t, root, "notes.md", "original\n")
+
+	text, isErr := call(t, s, "write_file", map[string]any{
+		"path": "notes.md", "content": "clobbered\n",
+	})
+	if !isErr {
+		t.Fatalf("write_file must refuse an existing path with no expect_hash, got: %s", text)
+	}
+	if got := readFile(t, p); got != "original\n" {
+		t.Errorf("file was modified despite the refusal: %q", got)
+	}
+	for _, want := range []string{"already exists", "expect_hash", "edit_file"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("refusal should mention %q so the caller can correct: %s", want, text)
+		}
+	}
+}
+
+func TestWriteReplacesWhenTheHashMatches(t *testing.T) {
+	s, root := newTestSource(t)
+	p := write(t, root, "notes.md", "original\n")
+
+	text, isErr := call(t, s, "write_file", map[string]any{
+		"path": "notes.md", "content": "replaced\n", "expect_hash": Hash("original\n"),
+	})
+	if isErr {
+		t.Fatalf("write_file failed: %s", text)
+	}
+	if got := readFile(t, p); got != "replaced\n" {
+		t.Errorf("file = %q, want %q", got, "replaced\n")
+	}
+	if !strings.Contains(text, "replaced") {
+		t.Errorf("reply should say it replaced rather than created:\n%s", text)
+	}
+}
+
+func TestWriteRefusesAStaleHash(t *testing.T) {
+	s, root := newTestSource(t)
+	p := write(t, root, "notes.md", "original\n")
+
+	text, isErr := call(t, s, "write_file", map[string]any{
+		"path": "notes.md", "content": "clobbered\n", "expect_hash": Hash("something else"),
+	})
+	if !isErr {
+		t.Fatalf("write_file must refuse a stale hash, got: %s", text)
+	}
+	if got := readFile(t, p); got != "original\n" {
+		t.Errorf("file was modified despite the refusal: %q", got)
+	}
+	if !strings.Contains(text, "re-read it") {
+		t.Errorf("refusal should say how to fix it: %s", text)
+	}
+}
+
+// TestWriteRefusesAHashForAFileThatDoesNotExist catches the caller who thinks
+// they are replacing something. Creating it instead would succeed while their
+// belief about the world was wrong, which is the failure mode in miniature.
+func TestWriteRefusesAHashForAFileThatDoesNotExist(t *testing.T) {
+	s, root := newTestSource(t)
+
+	text, isErr := call(t, s, "write_file", map[string]any{
+		"path": "ghost.txt", "content": "x", "expect_hash": Hash("anything"),
+	})
+	if !isErr {
+		t.Fatalf("write_file should refuse a hash for a missing file, got: %s", text)
+	}
+	if _, err := os.Stat(filepath.Join(root, "ghost.txt")); err == nil {
+		t.Error("the file should not have been created")
+	}
+}
+
+func TestWriteCreatesMissingParentDirectories(t *testing.T) {
+	s, root := newTestSource(t)
+
+	text, isErr := call(t, s, "write_file", map[string]any{
+		"path": "a/b/c/deep.txt", "content": "nested\n",
+	})
+	if isErr {
+		t.Fatalf("write_file failed: %s", text)
+	}
+	if got := readFile(t, filepath.Join(root, "a/b/c/deep.txt")); got != "nested\n" {
+		t.Errorf("file = %q", got)
+	}
+}
+
+func TestWriteRefusesToEscapeTheRoot(t *testing.T) {
+	s, _ := newTestSource(t)
+	text, isErr := call(t, s, "write_file", map[string]any{
+		"path": "../escaped.txt", "content": "x",
+	})
+	if !isErr {
+		t.Fatalf("write_file should refuse a path outside the root, got: %s", text)
+	}
+	if !strings.Contains(text, "outside the workspace root") {
+		t.Errorf("refusal should say why: %s", text)
+	}
+}
+
+// TestWriteRefusesToWriteThroughASymlink mirrors the edit_file guarantee. A
+// symlink is not a regular file, so replacing "it" would mean writing to
+// whatever it points at.
+func TestWriteRefusesToWriteThroughASymlink(t *testing.T) {
+	s, root := newTestSource(t)
+	outside, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(outside, "important.conf")
+	const original = "keep me\n"
+	if err := os.WriteFile(target, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(root, "innocent.txt")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	text, isErr := call(t, s, "write_file", map[string]any{
+		"path": "innocent.txt", "content": "CLOBBERED\n", "expect_hash": Hash(original),
+	})
+	if !isErr {
+		t.Fatalf("write_file should refuse to write through a symlink, got: %s", text)
+	}
+	if got := readFile(t, target); got != original {
+		t.Fatalf("wrote outside the workspace root: %q", got)
+	}
+}
+
+// TestWriteToADirectorySaysItIsNotAFile pins a message, not a safety property.
+// Without the check the write still fails, because os.Root refuses to rename
+// over a directory, but the caller is told the path "already exists" and is
+// invited to pass expect_hash, which can never work. A refusal that suggests
+// an impossible fix costs the model a turn to discover that.
+func TestWriteToADirectorySaysItIsNotAFile(t *testing.T) {
+	s, root := newTestSource(t)
+	if err := os.MkdirAll(filepath.Join(root, "somedir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	text, isErr := call(t, s, "write_file", map[string]any{
+		"path": "somedir", "content": "x",
+	})
+	if !isErr {
+		t.Fatalf("write_file should refuse a directory, got: %s", text)
+	}
+	if !strings.Contains(text, "not a regular file") {
+		t.Errorf("refusal should say what it found, not offer expect_hash: %s", text)
+	}
+}
+
+// TestSymlinkOutOfRootReadsAsAnEscapeNotACreate is the same kind of pin. The
+// path resolves lexically, so the escape is only discovered at Stat. Without
+// that branch the call falls through to the create path and the eventual
+// refusal comes from the write, phrased as though the file merely could not be
+// written rather than as a workspace-boundary refusal.
+func TestSymlinkOutOfRootReadsAsAnEscapeNotACreate(t *testing.T) {
+	s, root := newTestSource(t)
+	outside, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(outside, "important.conf")
+	if err := os.WriteFile(target, []byte("keep me\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(root, "innocent.txt")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	text, isErr := call(t, s, "write_file", map[string]any{
+		"path": "innocent.txt", "content": "CLOBBERED\n",
+	})
+	if !isErr {
+		t.Fatalf("write_file should refuse, got: %s", text)
+	}
+	if !strings.Contains(text, "outside the workspace root") {
+		t.Errorf("refusal should name the boundary, not read as a write failure: %s", text)
+	}
+	if got := readFile(t, target); got != "keep me\n" {
+		t.Fatalf("wrote outside the workspace root: %q", got)
+	}
+}
+
+func TestWriteAcceptsEmptyContent(t *testing.T) {
+	s, root := newTestSource(t)
+
+	if text, isErr := call(t, s, "write_file", map[string]any{
+		"path": "empty.txt", "content": "",
+	}); isErr {
+		t.Fatalf("an empty file is a legitimate thing to write: %s", text)
+	}
+	if got := readFile(t, filepath.Join(root, "empty.txt")); got != "" {
+		t.Errorf("file = %q, want empty", got)
+	}
+}
+
+func TestWriteNeedsContent(t *testing.T) {
+	s, _ := newTestSource(t)
+	text, isErr := call(t, s, "write_file", map[string]any{"path": "x.txt"})
+	if !isErr {
+		t.Fatalf("write_file should refuse a missing content argument, got: %s", text)
+	}
+}
+
+func TestWritePreservesModeOnReplace(t *testing.T) {
+	s, root := newTestSource(t)
+	p := write(t, root, "script.sh", "echo one\n")
+	if err := os.Chmod(p, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if text, isErr := call(t, s, "write_file", map[string]any{
+		"path": "script.sh", "content": "echo two\n", "expect_hash": Hash("echo one\n"),
+	}); isErr {
+		t.Fatalf("write_file failed: %s", text)
+	}
+	info, err := os.Stat(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o755 {
+		t.Errorf("mode = %v, want 0755; a replace should not disarm an executable", got)
+	}
+}
+
+// TestPathArgServesEveryWritingTool is why the rename happened: one function
+// feeds a checkpoint WriteSpec for both write tools, so neither package has to
+// import the other.
+func TestPathArgServesEveryWritingTool(t *testing.T) {
+	for _, args := range []map[string]any{
+		{"path": "notes.md", "content": "x"},
+		{"path": "notes.md", "expect_hash": "abc", "edits": []any{}},
+	} {
+		got := PathArg(args)
+		if len(got) != 1 || got[0] != "notes.md" {
+			t.Errorf("PathArg(%v) = %v, want [notes.md]", args, got)
+		}
+	}
+}


### PR DESCRIPTION
## What changes

Adds `write_file`, so creating a file and replacing one outright are expressible. Renames `EditPaths` to `PathArg`, since every writing tool now names its target in the same argument. Completes #1284, and with it the file toolset.

## ELI15

A hotel safe you set your own code on. To open it you enter the code you set. There is no override, no master code, no "just let me in" button — because the moment one exists, it is the thing everybody uses, and the safe is a box.

`edit_file` already worked this way: you say what text you expect to be there, and if the file changed underneath, the edit is refused. But `edit_file` can only change *part* of a file. It cannot create one, and it cannot replace one wholesale, because it has nothing to anchor to. So there was an obvious missing tool — and the obvious way to write it is `write_file(path, content)`, which overwrites whatever it finds.

That would have been the master code. Every protection in the module is about not landing a change on content nobody looked at, and a tool that overwrites on request is exactly that, reachable the moment anchoring feels fiddly. So `write_file` splits by whether you claim to know what is already there. Say nothing about the existing content and you are creating: if the path exists, you are refused. Claim its contents by hash and you are replacing: if the hash is stale, you are refused. **There is no third option**, and the absence is the feature.

## Reviewer's guide

Read in this order:

1. [agent/ext/files/tools.go](https://github.com/panyam/mcpkit/pull/1286/files#diff-ff86ee545bb090c437a29539fd95f66946f3e9ff1bf41e8aa6885021b7f06037) — the `write` method. The switch is the whole design; its doc comment says why there is no overwrite mode.
2. [agent/ext/files/write_test.go](https://github.com/panyam/mcpkit/pull/1286/files#diff-174e93be4796ff02ec2185c094d95c5717034c7d8d52e142d585278a2e953d65) — acceptance. `TestWriteRefusesAnExistingPathWithoutAHash` is the load-bearing one.
3. [agent/ext/files/README.md](https://github.com/panyam/mcpkit/pull/1286/files#diff-af212df5cc4e7a94c5990499ff9f5ffb5af8c389419ffdb6e59d7b911592f01c) — the new section, and the checkpoint wiring now showing both write tools.
4. [agent/ext/files/tools_test.go](https://github.com/panyam/mcpkit/pull/1286/files#diff-92ef90d1510d40b1bc2e0bb8a02d7f0ccc94c94f5263511e0ef3158145858708), `extension_test.go` — the rename and two tool-set updates.

## How it works

```
write(path, content, expect_hash?):
    rel  = rel(path)                       # readable refusal for obvious escapes
    info = root.Stat(rel)

    exists and not a regular file  -> refuse, naming what it found
    exists and no expect_hash      -> refuse: "already exists", point at edit_file
    exists                         -> read it; hash mismatch -> refuse as stale
    Stat failed, not "not exist"   -> refuse as a boundary escape
    missing but expect_hash given  -> refuse: you think you are replacing something

    create missing parent dirs (through the root)
    write temp -> fchmod -> rename, all through the root
    report created-vs-replaced, and the new hash
```

The ordering of that switch is the design. Each arm removes one way of being wrong about the file, and the fall-through at the end is the only path that writes.

## Decision log

- **No create-or-overwrite mode.** `expect_hash`'s presence distinguishes create from replace, so there is no argument combination that clobbers unseen content. A flag would have been the escape hatch that made the rest decorative.
- **A hash for a file that does not exist is refused**, not treated as a create. The caller believed they were replacing something and was wrong; succeeding anyway hides that.
- **Missing parent directories are created.** Through the root, so `MkdirAll` cannot climb out. Refusing would make `write_file` useless for the common case of adding a file to a new package.
- **Mode is preserved on replace**, via the existing `fchmod`-on-descriptor path, so rewriting a script does not disarm it.
- **`EditPaths` → `PathArg`.** One function now feeds a `checkpoint.WriteSpec` for both `edit_file` and `write_file`, and the old name says `edit`. The module postdates v0.5.1 and has no tag, so the rename is free today and a breaking change after 1.0.
- **Two guards are message quality, not safety, and are documented as such.** See below — this is the part I would most want a second opinion on.

## Risk / blast radius

- **Affects:** `agent/ext/files` only. `write_file` is new; the rename touches one exported symbol with no external consumers (no release tag).
- **Tests covering this:** 14 new in `write_test.go`, plus the existing suite. All under `-race`.
- **Be paranoid about:** the switch ordering in `write`. Its arms are mutually exclusive today, but a future arm inserted in the wrong place could let a case reach the write path. The tests cover each arm, not the ordering as such.
- **Also:** `write_file` replacing a file is not atomic with respect to a concurrent reader in the sense of content versioning — the hash check and the rename are separate operations, so a write landing between them would be lost rather than refused. The window is far narrower than the read-decide-write gap this module exists for, and closing it would need file locking that nothing else here uses.

## Red before green

Six mutations, each verified to have changed the file before its result was trusted.

| Mutation | Caught by |
|---|---|
| Existing path allowed with no hash | `TestWriteRefusesAnExistingPathWithoutAHash` |
| Stale hash accepted | `TestWriteRefusesAStaleHash` |
| Hash for a missing file accepted | `TestWriteRefusesAHashForAFileThatDoesNotExist` |
| Mode not preserved on replace | `TestWritePreservesModeOnReplace` |
| Non-regular target allowed | `TestWriteToADirectorySaysItIsNotAFile` |
| Escape not distinguished from missing | `TestSymlinkOutOfRootReadsAsAnEscapeNotACreate` |

**The last two initially survived, and diagnosing them is the useful part.** Both guards sit in front of `os.Root`, which refuses either way — writing to a directory fails at the rename, and a symlink out of the root fails at the open. So removing them changed no safety property and no test noticed.

What they change is **what the model is told**. Without the non-regular check, writing to a directory is reported as *"already exists, pass expect_hash to replace it"* — advice that can never work, costing a turn to discover. Without the escape branch, a symlink pointing out of the workspace reads as a generic write failure rather than a boundary refusal. Those messages are contract here, because the model acts on them, so the two new tests pin the wording rather than the outcome. That is the fourth time this session a downstream guard has masked a mutation; the pattern is in `agent/NOTES.md` § Testing.

Assertion sites added: 39, across 14 new tests. Existing assertions changed: 4, all audited and none weakened — two tool-count updates (4 → 5 and a new entry in the expected-name set) and two message strings following the rename.

## Before / after

There is no "before" for a tool that did not exist. Captured from a throwaway harness against a temp workspace containing `notes.md`:

```
$ write_file {"path":"new/deep.txt","content":"hello\n"}
  [ok] created new/deep.txt, 6 byte(s)
       hash: 5891b5b522d5

$ write_file {"path":"notes.md","content":"..."}          # exists, no hash
  [IsError] refusing notes.md: it already exists. Read it first and pass
            expect_hash to replace it, or use edit_file to change part of it.

$ write_file {"path":"notes.md", expect_hash: <stale>}
  [IsError] notes.md: file changed since it was read: expected 000000000000,
            found 25718360e05d; re-read it before writing

$ write_file {"path":"notes.md", expect_hash: <correct>}
  [ok] replaced notes.md, 9 byte(s)
       hash: e2208f01e42b
```

Note the create reports `created` and the replace reports `replaced`, so a caller who thought it was doing one and did the other can tell.

```mermaid
stateDiagram-v2
    [*] --> Stat: write_file(path, content, expect_hash?)
    Stat --> Refuse: not a regular file
    Stat --> Refuse: exists, no expect_hash
    Stat --> CheckHash: exists, expect_hash given
    Stat --> Refuse: escapes the workspace
    Stat --> Refuse: missing, but expect_hash given
    Stat --> Create: missing, no expect_hash
    CheckHash --> Refuse: hash is stale
    CheckHash --> Replace: hash matches
    Create --> [*]: created
    Replace --> [*]: replaced
    Refuse --> [*]: IsError, says what to do next
```

## Out of scope (deliberately deferred)

- **Deleting files.** No `delete_file`; `edit_file` can empty one and `/undo` restores. Worth its own decision, since deletion is the one file operation where the checkpoint's absent-path handling is load-bearing.
- **Appending.** Expressible as `edit_file` anchored to the tail, or a read-then-write. A dedicated `append_file` would need its own staleness story.
- **Glob filtering on `list_files`** and **context lines on `search_files`**, both noted in #1285.

