### PR TITLE
feat(agent/host): pluggable approval prompt rendering, with the first consumer

### DIFF
--- a/agent/ext/files/README.md
+++ b/agent/ext/files/README.md
@@ -174,6 +174,33 @@ told anchors must be unique will keep sending single-word anchors and keep
 being refused, so shipping the tools alone would make the contract
 discoverable only by failing.
 
+## What the approval prompt shows
+
+When a write is gated, the host asks before it runs. Its default rendering is a
+call's JSON trimmed to 200 characters, which for an edit truncates the one
+thing you are being asked to judge:
+
+```
+Allow tool call "edit_file" with {"path":"main.go","expect_hash":"dcf19a8dce4a"…
+```
+
+This extension renders its own writes instead, so the question is about the
+change rather than the arguments:
+
+```
+Apply 2 change(s) to main.go?
+
+  - func Old() {}
+  + func New() {}
+
+  - return nil
+  + return fmt.Errorf("not implemented")
+```
+
+A whole-file write shows a capped preview and says whether it creates or
+replaces, since those differ by whether anything is destroyed. Everything this
+package does not own falls through to the host default untouched.
+
 ## Undo, and why there is no Reverser here
 
 An edit is checkpointable through `agent/ext/checkpoint`, but this package

--- a/agent/ext/files/approval_test.go
+++ b/agent/ext/files/approval_test.go
@@ -1,0 +1,168 @@
+package files
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/panyam/mcpkit/agent"
+	"github.com/panyam/mcpkit/core"
+)
+
+func renderCall(name, args string) (string, bool) {
+	return renderEditApproval(context.Background(), agent.ToolCallInfo{
+		Call: agent.ToolCall{Name: name, Args: core.NewRawJSON([]byte(args))},
+	})
+}
+
+// TestEditApprovalShowsTheDiff is the reason the seam exists. The default host
+// prompt would render this call's JSON trimmed to 200 characters, which cuts
+// off the change the user is being asked to approve.
+func TestEditApprovalShowsTheDiff(t *testing.T) {
+	got, ok := renderCall("edit_file", `{
+		"path": "main.go",
+		"expect_hash": "abc123",
+		"edits": [{"old": "func Old() {}", "new": "func New() {}"}]
+	}`)
+	if !ok {
+		t.Fatalf("edit_file should be claimed, got %q", got)
+	}
+	for _, want := range []string{"main.go", "1 change", "- func Old() {}", "+ func New() {}"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("prompt is missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "expect_hash") {
+		t.Errorf("the hash is bookkeeping, not something to review:\n%s", got)
+	}
+}
+
+func TestEditApprovalCountsEveryHunk(t *testing.T) {
+	got, ok := renderCall("edit_file", `{
+		"path": "main.go",
+		"edits": [
+			{"old": "one", "new": "ONE"},
+			{"old": "two", "new": "TWO"}
+		]
+	}`)
+	if !ok {
+		t.Fatal("edit_file should be claimed")
+	}
+	if !strings.Contains(got, "2 change(s)") {
+		t.Errorf("prompt should count the hunks:\n%s", got)
+	}
+	for _, want := range []string{"- one", "+ ONE", "- two", "+ TWO"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("prompt is missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// TestDeletionRendersWithNoAddedLines keeps an empty `new` from printing a
+// bare "+" that reads like an added blank line rather than a deletion.
+func TestDeletionRendersWithNoAddedLines(t *testing.T) {
+	got, ok := renderCall("edit_file", `{"path":"a.go","edits":[{"old":"gone","new":""}]}`)
+	if !ok {
+		t.Fatal("edit_file should be claimed")
+	}
+	if !strings.Contains(got, "- gone") {
+		t.Errorf("prompt should show the removed line:\n%s", got)
+	}
+	if strings.Contains(got, "+") {
+		t.Errorf("a deletion should add no lines:\n%s", got)
+	}
+}
+
+func TestWriteApprovalDistinguishesCreateFromReplace(t *testing.T) {
+	create, ok := renderCall("write_file", `{"path":"new.go","content":"package main\n"}`)
+	if !ok {
+		t.Fatal("write_file should be claimed")
+	}
+	if !strings.Contains(create, "Create new.go") {
+		t.Errorf("a create should say so:\n%s", create)
+	}
+
+	replace, ok := renderCall("write_file", `{"path":"old.go","content":"package main\n","expect_hash":"abc"}`)
+	if !ok {
+		t.Fatal("write_file should be claimed")
+	}
+	if !strings.Contains(replace, "Replace old.go") {
+		t.Errorf("a replace should say so, since it destroys content:\n%s", replace)
+	}
+}
+
+// TestWriteApprovalCapsItsOwnPreview is the renderer exercising the freedom
+// the seam gives it. The default's 200-character trim is wrong for a diff, but
+// unbounded output is wrong for a whole-file write, so the renderer picks.
+func TestWriteApprovalCapsItsOwnPreview(t *testing.T) {
+	var body strings.Builder
+	for i := range 200 {
+		body.WriteString("line ")
+		body.WriteByte(byte('0' + i%10))
+		body.WriteString("\n")
+	}
+	got, ok := renderCall("write_file", `{"path":"big.go","content":`+jsonQuote(body.String())+`}`)
+	if !ok {
+		t.Fatal("write_file should be claimed")
+	}
+	if !strings.Contains(got, "more line(s)") {
+		t.Errorf("a long write should be capped and say so:\n%s", got[:min(400, len(got))])
+	}
+	if n := strings.Count(got, "\n"); n > 60 {
+		t.Errorf("preview is %d lines, want it bounded", n)
+	}
+}
+
+// TestUnknownToolsAreDeclined keeps the default covering everything this
+// package does not own. Claiming broadly would silently replace the prompt for
+// tools whose arguments this renderer knows nothing about.
+func TestUnknownToolsAreDeclined(t *testing.T) {
+	for _, name := range []string{"read_file", "list_files", "search_files", "some_other_tool"} {
+		if got, ok := renderCall(name, `{"path":"a.go"}`); ok {
+			t.Errorf("%s should not be claimed, got %q", name, got)
+		}
+	}
+}
+
+// TestMalformedArgumentsDecline is where the generic rendering is the honest
+// one: it shows the raw text rather than a summary built from a guess.
+func TestMalformedArgumentsDecline(t *testing.T) {
+	cases := map[string]string{
+		"not json":      `{"path": `,
+		"no path":       `{"edits":[{"old":"a","new":"b"}]}`,
+		"no edits":      `{"path":"a.go"}`,
+		"empty edits":   `{"path":"a.go","edits":[]}`,
+		"bad edit item": `{"path":"a.go","edits":["nope"]}`,
+		"no content":    `{"path":"a.go"}`,
+	}
+	for name, args := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got, ok := renderCall("edit_file", args); ok {
+				t.Errorf("should have declined, got %q", got)
+			}
+		})
+	}
+}
+
+// TestRendererIsRegistered pins the wiring, since a renderer that is never
+// collected is a diff nobody sees.
+func TestRendererIsRegistered(t *testing.T) {
+	e, err := New(Config{Root: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rs := e.ApprovalRenderers()
+	if len(rs) != 1 {
+		t.Fatalf("got %d renderers, want 1", len(rs))
+	}
+	got, ok := rs[0](context.Background(), agent.ToolCallInfo{
+		Call: agent.ToolCall{Name: "edit_file", Args: core.NewRawJSON([]byte(`{"path":"a.go","edits":[{"old":"x","new":"y"}]}`))},
+	})
+	if !ok || !strings.Contains(got, "a.go") {
+		t.Errorf("registered renderer did not render: %q", got)
+	}
+}
+
+func jsonQuote(s string) string {
+	return `"` + strings.ReplaceAll(strings.ReplaceAll(s, `"`, `\"`), "\n", `\n`) + `"`
+}

--- a/agent/ext/files/extension.go
+++ b/agent/ext/files/extension.go
@@ -2,6 +2,9 @@ package files
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
 
 	"github.com/panyam/mcpkit/agent"
 	"github.com/panyam/mcpkit/agent/host"
@@ -52,6 +55,94 @@ the file and is matched byte for byte, including indentation. If it appears more
 than once the edit is refused rather than applied to a guess: add surrounding
 lines until it is unique. All edits in one call apply together or none do.`
 	})}
+}
+
+// ApprovalRenderers shows an edit as the change it makes, rather than as its
+// arguments.
+//
+// The default host prompt renders a call's JSON trimmed to 200 characters. For
+// most tools that is right: the arguments are an opaque payload and the
+// question is really "do you trust this tool with roughly this". For an edit
+// the arguments ARE the change, and 200 characters of JSON truncates the one
+// thing the user is being asked to judge, so they end up approving a diff they
+// could not read.
+func (e *Extension) ApprovalRenderers() []host.ApprovalRenderer {
+	return []host.ApprovalRenderer{renderEditApproval}
+}
+
+// renderEditApproval claims edit_file and write_file, and declines everything
+// else so the default still covers tools this package does not own.
+func renderEditApproval(_ context.Context, info agent.ToolCallInfo) (string, bool) {
+	args := map[string]any{}
+	if raw := info.Call.Args.Raw(); len(raw) > 0 {
+		if err := json.Unmarshal(raw, &args); err != nil {
+			// Unparseable arguments are exactly when the generic rendering is
+			// the honest one: it shows the raw text rather than a summary
+			// built from a guess.
+			return "", false
+		}
+	}
+	path, _ := args["path"].(string)
+	if path == "" {
+		return "", false
+	}
+
+	switch info.Call.Name {
+	case "edit_file":
+		hunks, err := parseHunks(args["edits"])
+		if err != nil || len(hunks) == 0 {
+			return "", false
+		}
+		var b strings.Builder
+		fmt.Fprintf(&b, "Apply %d change(s) to %s?\n", len(hunks), path)
+		for _, h := range hunks {
+			b.WriteString("\n")
+			writeDiff(&b, h.Old, h.New)
+		}
+		return b.String(), true
+
+	case "write_file":
+		content, ok := args["content"].(string)
+		if !ok {
+			return "", false
+		}
+		verb := "Create"
+		if _, replacing := args["expect_hash"].(string); replacing {
+			verb = "Replace"
+		}
+		return fmt.Sprintf("%s %s (%d bytes, %d lines)?\n\n%s",
+			verb, path, len(content), strings.Count(content, "\n")+1, indent(preview(content))), true
+	}
+	return "", false
+}
+
+// writeDiff renders one hunk as removed and added lines.
+func writeDiff(b *strings.Builder, old, nw string) {
+	for _, line := range strings.Split(strings.TrimRight(old, "\n"), "\n") {
+		fmt.Fprintf(b, "  - %s\n", line)
+	}
+	if nw == "" {
+		return
+	}
+	for _, line := range strings.Split(strings.TrimRight(nw, "\n"), "\n") {
+		fmt.Fprintf(b, "  + %s\n", line)
+	}
+}
+
+// preview caps a whole-file write at a readable length. This is the renderer
+// deciding its own truncation, which is the point of the seam: the cap that
+// suits an opaque payload is not the cap that suits a diff.
+func preview(s string) string {
+	const maxLines = 40
+	lines := strings.Split(s, "\n")
+	if len(lines) <= maxLines {
+		return s
+	}
+	return strings.Join(lines[:maxLines], "\n") + fmt.Sprintf("\n… %d more line(s)", len(lines)-maxLines)
+}
+
+func indent(s string) string {
+	return "  " + strings.ReplaceAll(s, "\n", "\n  ")
 }
 
 var _ host.Extension = (*Extension)(nil)

--- a/agent/host/README.md
+++ b/agent/host/README.md
@@ -51,6 +51,45 @@ stay out of the lean `agent/` module.
   nothing; persistence failures degrade to a rendered warning, never a turn
   failure.
 
+## Approval prompts
+
+The question a user is asked before a gated tool call runs is rendered by the
+host, and by default reads:
+
+```
+Allow tool call "edit_file" with {"path":"main.go","edits":[{"old":"func Old…?
+```
+
+That is right for a tool whose arguments are an opaque payload, and wrong for
+one whose arguments *are* the thing being reviewed. The default trims them to
+200 characters, so a real edit is unreviewable by construction and the user is
+answering a question they cannot evaluate.
+
+An extension supplies its own rendering for the tools it owns:
+
+```go
+func (e *Extension) ApprovalRenderers() []host.ApprovalRenderer {
+    return []host.ApprovalRenderer{func(ctx context.Context, info agent.ToolCallInfo) (string, bool) {
+        if info.Call.Name != "edit_file" {
+            return "", false          // not mine — next renderer, then the default
+        }
+        return renderDiff(info), true
+    }}
+}
+```
+
+Renderers are consulted in registration order and the first claim wins; the
+built-in format is the fallback, so a renderer only has to handle what it
+knows. Truncation becomes the renderer's decision, which is the point.
+
+`agent/ext/files` is the worked example: it renders an edit as a diff and a
+whole-file write as a capped preview.
+
+Two properties worth knowing. The `info` carries the call **as it will
+execute**, after every middleware has rewritten the arguments, so what the user
+approves is what runs. And a renderer that returns an empty string is treated
+as having declined, because an empty prompt asks the user to confirm nothing.
+
 ## Skills trust model
 
 Skills are data, not code (`ext/skills` is enforced no-exec), so the risk a

--- a/agent/host/app.go
+++ b/agent/host/app.go
@@ -117,6 +117,10 @@ type App struct {
 	// so per-turn lifecycle (TurnStart) can reach them.
 	extensions []Extension
 
+	// approvalRenderers are collected from the extensions in registration
+	// order and consulted before the built-in prompt format.
+	approvalRenderers []ApprovalRenderer
+
 	// toolOrigins records what each source id IS, so spotlight provenance is
 	// derived from where a tool came from rather than restated in config.
 	// Recorded where sources are added, because that is the only place the
@@ -334,7 +338,7 @@ func NewApp(cfg *Config, out io.Writer, in io.Reader, opts ...AppOption) (*App, 
 	// The approval "ask" prompt rides the same FIFO seam as elicitation, so a
 	// gated tool call never stacks a dialog against a concurrent elicitation.
 	ask := func(ctx context.Context, info agent.ToolCallInfo) (bool, error) {
-		return coord.Confirm(ctx, approvalPrompt(info))
+		return coord.Confirm(ctx, app.renderApproval(ctx, info))
 	}
 	app.approval = cfg.Approval.buildApproval(ask)
 

--- a/agent/host/approvalrender_test.go
+++ b/agent/host/approvalrender_test.go
@@ -1,0 +1,189 @@
+package host
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/panyam/mcpkit/agent"
+	"github.com/panyam/mcpkit/core"
+)
+
+func callInfo(name, args string) agent.ToolCallInfo {
+	return agent.ToolCallInfo{
+		Call: agent.ToolCall{Name: name, Args: core.NewRawJSON([]byte(args))},
+	}
+}
+
+// rendererExt is a minimal extension that contributes nothing but renderers,
+// which is also the shape a caller uses when they want a renderer without a
+// tool of their own.
+type rendererExt struct {
+	BaseExtension
+	name      string
+	renderers []ApprovalRenderer
+}
+
+func (e rendererExt) Name() string                          { return e.name }
+func (e rendererExt) ApprovalRenderers() []ApprovalRenderer { return e.renderers }
+
+// appWith runs the real applyExtensions rather than assigning renderers
+// directly, so these tests cover the collection wiring too and not just
+// renderApproval in isolation.
+func appWith(t *testing.T, exts ...Extension) *App {
+	t.Helper()
+	a := &App{
+		promptBuilder: &SystemPromptBuilder{},
+		commands:      NewCommandRegistry(),
+	}
+	if _, err := a.applyExtensions(exts); err != nil {
+		t.Fatal(err)
+	}
+	return a
+}
+
+func TestRendererTextReachesTheAsk(t *testing.T) {
+	a := appWith(t, rendererExt{name: "x", renderers: []ApprovalRenderer{
+		func(context.Context, agent.ToolCallInfo) (string, bool) { return "Apply 2 changes to main.go?", true },
+	}})
+
+	got := a.renderApproval(context.Background(), callInfo("edit_file", `{"path":"main.go"}`))
+	if got != "Apply 2 changes to main.go?" {
+		t.Errorf("renderApproval() = %q, want the renderer's text", got)
+	}
+}
+
+// TestDecliningFallsBackToTheDefault is what lets a renderer claim a subset
+// without reproducing the generic format for everything else.
+func TestDecliningFallsBackToTheDefault(t *testing.T) {
+	a := appWith(t, rendererExt{name: "x", renderers: []ApprovalRenderer{
+		func(context.Context, agent.ToolCallInfo) (string, bool) { return "", false },
+	}})
+
+	got := a.renderApproval(context.Background(), callInfo("other_tool", `{"a":1}`))
+	if !strings.Contains(got, "Allow tool call") {
+		t.Errorf("a declined call should get the built-in format, got %q", got)
+	}
+}
+
+// TestEmptyTextCountsAsDeclining guards a renderer that claims a call and then
+// produces nothing. Passing that through would ask the user to confirm a blank
+// question, which they can only answer by guessing.
+func TestEmptyTextCountsAsDeclining(t *testing.T) {
+	a := appWith(t, rendererExt{name: "x", renderers: []ApprovalRenderer{
+		func(context.Context, agent.ToolCallInfo) (string, bool) { return "", true },
+	}})
+
+	got := a.renderApproval(context.Background(), callInfo("edit_file", `{"path":"main.go"}`))
+	if !strings.Contains(got, "Allow tool call") {
+		t.Errorf("an empty render should fall back, got %q", got)
+	}
+}
+
+func TestFirstClaimWins(t *testing.T) {
+	a := appWith(t,
+		rendererExt{name: "first", renderers: []ApprovalRenderer{
+			func(context.Context, agent.ToolCallInfo) (string, bool) { return "first", true },
+		}},
+		rendererExt{name: "second", renderers: []ApprovalRenderer{
+			func(context.Context, agent.ToolCallInfo) (string, bool) { return "second", true },
+		}},
+	)
+
+	if got := a.renderApproval(context.Background(), callInfo("edit_file", `{}`)); got != "first" {
+		t.Errorf("renderApproval() = %q, want the first registered renderer", got)
+	}
+}
+
+// TestRendererSeesPostMiddlewareArguments is the security property this seam
+// has to preserve. A user approves what they were shown, so what they are
+// shown must be the call that runs, not the one the model proposed. If a
+// middleware rewrote the arguments and the prompt rendered the original, the
+// approval would be for a call that never executes.
+func TestRendererSeesPostMiddlewareArguments(t *testing.T) {
+	var seen string
+	a := appWith(t, rendererExt{name: "x", renderers: []ApprovalRenderer{
+		func(_ context.Context, info agent.ToolCallInfo) (string, bool) {
+			seen = string(info.Call.Args.Raw())
+			return "rendered", true
+		},
+	}})
+
+	// ToolCallInfo.Call.Args is documented as the arguments "as rewritten by
+	// any earlier middleware rather than as the model produced them", so the
+	// rewritten value is what a renderer must receive.
+	rewritten := `{"path":"REWRITTEN.md"}`
+	a.renderApproval(context.Background(), callInfo("edit_file", rewritten))
+
+	if seen != rewritten {
+		t.Fatalf("renderer saw %q, want the post-middleware arguments %q", seen, rewritten)
+	}
+}
+
+func TestNoRenderersLeavesTheDefaultUntouched(t *testing.T) {
+	a := appWith(t)
+	info := callInfo("edit_file", `{"path":"main.go"}`)
+
+	if got, want := a.renderApproval(context.Background(), info), approvalPrompt(info); got != want {
+		t.Errorf("with no renderers the prompt must be unchanged:\n got %q\nwant %q", got, want)
+	}
+}
+
+// TestDefaultStillTrimsLargeArguments keeps the fallback's own behaviour. The
+// trim is right for an unknown tool whose arguments are an opaque blob; what
+// the seam changes is that it is no longer imposed on tools that know better.
+func TestDefaultStillTrimsLargeArguments(t *testing.T) {
+	a := appWith(t)
+	big := `{"blob":"` + strings.Repeat("x", 500) + `"}`
+
+	got := a.renderApproval(context.Background(), callInfo("unknown_tool", big))
+	if !strings.Contains(got, "…") {
+		t.Errorf("the default should still trim a large payload:\n%s", got)
+	}
+	if len(got) > 300 {
+		t.Errorf("trimmed prompt is %d chars, want it bounded", len(got))
+	}
+}
+
+// TestCustomRendererIsNotTrimmed is the other half: a renderer that decided a
+// long prompt is correct gets it through intact. A diff trimmed to 200
+// characters is unreviewable, which is the whole reason for the seam.
+func TestCustomRendererIsNotTrimmed(t *testing.T) {
+	long := "Apply 1 change:\n" + strings.Repeat("  - a line of context\n", 60)
+	a := appWith(t, rendererExt{name: "x", renderers: []ApprovalRenderer{
+		func(context.Context, agent.ToolCallInfo) (string, bool) { return long, true },
+	}})
+
+	if got := a.renderApproval(context.Background(), callInfo("edit_file", `{}`)); got != long {
+		t.Errorf("a renderer's text must not be trimmed: got %d chars, want %d", len(got), len(long))
+	}
+}
+
+func TestNilRendererIsSkipped(t *testing.T) {
+	a := appWith(t, rendererExt{name: "x", renderers: []ApprovalRenderer{
+		nil,
+		func(context.Context, agent.ToolCallInfo) (string, bool) { return "second", true },
+	}})
+
+	if got := a.renderApproval(context.Background(), callInfo("edit_file", `{}`)); got != "second" {
+		t.Errorf("a nil renderer should be skipped, got %q", got)
+	}
+}
+
+func TestRendererReceivesTheContext(t *testing.T) {
+	type key struct{}
+	ctx := context.WithValue(context.Background(), key{}, "carried")
+
+	var seen any
+	a := appWith(t, rendererExt{name: "x", renderers: []ApprovalRenderer{
+		func(c context.Context, _ agent.ToolCallInfo) (string, bool) {
+			seen = c.Value(key{})
+			return "ok", true
+		},
+	}})
+
+	a.renderApproval(ctx, callInfo("edit_file", `{}`))
+	if seen != "carried" {
+		t.Errorf("renderer got %v, want the caller's context", seen)
+	}
+}

--- a/agent/host/config.go
+++ b/agent/host/config.go
@@ -443,8 +443,15 @@ func parseProvenance(s string) agent.Provenance {
 	}
 }
 
-// approvalPrompt renders the yes/no question shown when a tool call needs
-// approval. The args are trimmed so a large payload does not flood the prompt.
+// approvalPrompt is the fallback rendering, used for any call no registered
+// ApprovalRenderer claimed.
+//
+// The args are trimmed so a large payload does not flood the prompt. That trim
+// lives HERE and not in the calling path on purpose: it is the right default
+// for an unknown tool, whose arguments are an opaque blob, and the wrong one
+// for a tool whose arguments are the thing being reviewed. Applying it to
+// everything is what made an edit unreviewable, so a renderer that claims a
+// call decides its own truncation.
 func approvalPrompt(info agent.ToolCallInfo) string {
 	args := strings.TrimSpace(string(info.Call.Args.Raw()))
 	if len(args) > 200 {

--- a/agent/host/extension.go
+++ b/agent/host/extension.go
@@ -15,14 +15,21 @@ import (
 // plus the harness behaviour around them had nowhere to put it. That absence
 // is why App accumulated a feature per field instead of a registry per seam.
 //
-// Nothing here is a new mechanism. ToolSource, ToolMiddleware, PromptSection,
-// Command, and ContextStage all already exist and are all already wired. An
-// Extension's only job is to let one package contribute across all five as a
-// unit, because a feature is not five independent contributions — it is one
-// thing with five facets that have to agree. Memory's recall tool and its
-// pre-turn producer share a store; a checkpoint middleware and its /undo
-// command share a snapshot directory. Registering those separately would put
-// the coherence in the caller's head and leave their ordering unstated.
+// Most of this is not a new mechanism. ToolSource, ToolMiddleware,
+// PromptSection, Command, and ContextStage all already existed and were
+// already wired. An Extension's job is to let one package contribute across
+// them as a unit, because a feature is not a handful of independent
+// contributions — it is one thing with several facets that have to agree.
+// Memory's recall tool and its pre-turn producer share a store; a checkpoint
+// middleware and its /undo command share a snapshot directory; a file tool and
+// the way its approval reads describe the same operation. Registering those
+// separately would put the coherence in the caller's head and leave their
+// ordering unstated.
+//
+// Two seams were added because building real extensions found the contract
+// short: TurnStart, which checkpoint needed and no contribution seam could
+// express, and ApprovalRenderers, which the coding surface needed because the
+// ask text was the one part of the approval ladder a caller could not reach.
 //
 // Every method except Name is optional: return nil for the seams you do not
 // use. Embed BaseExtension to no-op all of them and override only what you
@@ -87,6 +94,21 @@ type Extension interface {
 	// it joining the session's history.
 	ContextStages() []ContextStage
 
+	// ApprovalRenderers supply the question a user is asked before a gated
+	// tool call runs, for the tools this extension owns.
+	//
+	// The ask text was the one part of the approval ladder a caller could not
+	// influence: mode, per-tool rules, remembering, and the ask transport are
+	// all configurable, while the wording was fixed. That is fine until a
+	// tool's arguments ARE the thing being reviewed. For an edit, the default
+	// renders a JSON blob trimmed to 200 characters, which makes a real change
+	// unreviewable by construction, so the user is answering a question they
+	// cannot actually evaluate.
+	//
+	// Consulted in registration order; the first renderer to claim a call
+	// wins, and the built-in format is the fallback. See ApprovalRenderer.
+	ApprovalRenderers() []ApprovalRenderer
+
 	// TurnStart runs once at the top of every turn, before any context stage
 	// and before history is touched, so a failure leaves nothing half-done.
 	// An error aborts the turn.
@@ -115,18 +137,67 @@ type Extension interface {
 //	func (c coding) Tools() (agent.ToolSource, error) { return c.src, nil }
 type BaseExtension struct{}
 
-func (BaseExtension) Tools() (agent.ToolSource, error)   { return nil, nil }
-func (BaseExtension) Middleware() []agent.ToolMiddleware { return nil }
-func (BaseExtension) PromptSections() []PromptSection    { return nil }
-func (BaseExtension) Commands() []*Command               { return nil }
-func (BaseExtension) ContextStages() []ContextStage      { return nil }
-func (BaseExtension) TurnStart(context.Context) error    { return nil }
+func (BaseExtension) Tools() (agent.ToolSource, error)      { return nil, nil }
+func (BaseExtension) Middleware() []agent.ToolMiddleware    { return nil }
+func (BaseExtension) PromptSections() []PromptSection       { return nil }
+func (BaseExtension) Commands() []*Command                  { return nil }
+func (BaseExtension) ContextStages() []ContextStage         { return nil }
+func (BaseExtension) ApprovalRenderers() []ApprovalRenderer { return nil }
+func (BaseExtension) TurnStart(context.Context) error       { return nil }
+
+// ApprovalRenderer turns a pending tool call into the question a user is
+// asked about it, or declines to.
+//
+// The bool is "this call is mine". False means the next renderer gets a look
+// and the built-in format is the fallback, so a renderer can claim a subset of
+// its own tools, or claim conditionally, without having to reproduce the
+// default for everything else. There is no error return on purpose: a
+// renderer that cannot do its job returns false and the user still gets asked,
+// which is the only useful behaviour at an approval prompt.
+//
+// The info carries the call as it WILL execute, arguments included, after
+// every middleware has rewritten them (#1248). That property is what makes the
+// prompt honest — the user approves the call that runs, not the one the model
+// proposed — and it is pinned by a test rather than left as a comment.
+//
+// Truncation is the renderer's business. The default trims arguments so a
+// large payload cannot flood the prompt; a renderer showing a diff wants the
+// opposite and is trusted to decide.
+//
+// The context is the turn's. It is here so a renderer can read state it needs
+// to render honestly — showing what a whole-file write would replace means
+// reading the file that is there now — rather than being restricted to what
+// the arguments happen to carry.
+type ApprovalRenderer func(context.Context, agent.ToolCallInfo) (string, bool)
 
 // WithExtension registers extensions with the App, applied in the order
 // given. Repeated calls accumulate rather than replace, so a caller can build
 // the list across several options.
 func WithExtension(exts ...Extension) AppOption {
 	return func(o *appOptions) { o.extensions = append(o.extensions, exts...) }
+}
+
+// renderApproval produces the question to ask about a pending call, giving
+// each registered renderer a look before falling back to the built-in format.
+//
+// First claim wins, in registration order, matching how middleware is ordered
+// rather than how Commands collide. Commands can refuse a duplicate because a
+// name is known at registration; a renderer decides per call, so two claiming
+// the same one cannot be detected until it happens, and failing a turn at that
+// point would be worse than picking the first.
+//
+// A renderer that returns an empty string is treated as having declined,
+// because an empty approval prompt asks the user to confirm nothing.
+func (a *App) renderApproval(ctx context.Context, info agent.ToolCallInfo) string {
+	for _, r := range a.approvalRenderers {
+		if r == nil {
+			continue
+		}
+		if text, ok := r(ctx, info); ok && text != "" {
+			return text
+		}
+	}
+	return approvalPrompt(info)
 }
 
 // startExtensionTurns runs every extension's TurnStart, in registration
@@ -183,6 +254,7 @@ func (a *App) applyExtensions(exts []Extension) ([]agent.ToolMiddleware, error) 
 		mw = append(mw, ext.Middleware()...)
 		a.promptBuilder.Sections = append(a.promptBuilder.Sections, ext.PromptSections()...)
 		a.context.transient = append(a.context.transient, ext.ContextStages()...)
+		a.approvalRenderers = append(a.approvalRenderers, ext.ApprovalRenderers()...)
 
 		for _, cmd := range ext.Commands() {
 			// Register overwrites silently, which is the wrong behaviour for


### PR DESCRIPTION
## What changes

`host.Extension` gains `ApprovalRenderers`, so an extension supplies the question a user is asked before its own tools run. The built-in format stays as the fallback. `agent/ext/files` ships as the first consumer, rendering an edit as a diff.

Closes #1253, and unblocks the diff-level review child of #1252.

## ELI15

Contracts get signed at the bottom of the last page. That is fine when the pages are a phone contract nobody reads either way, and it is not fine when the pages are the terms of your mortgage. The signature means the same thing in both cases; what differs is whether you could actually evaluate the thing you agreed to.

An agent asks permission before it runs a tool that changes something. The question was always rendered the same way: the tool's name, plus its arguments as raw JSON, cut off at 200 characters. For most tools that is honest — the arguments are an opaque payload, and what you are really deciding is whether you trust this tool to run at all.

But for an *edit*, the arguments **are** the change. Truncating them to 200 characters removes the one thing being reviewed, so the user is asked to approve a diff they cannot see, and the only available answer is a guess. The gate still functions in the sense that it stops and asks. It has stopped doing the thing it was for.

So the tool that owns an operation now gets to say how the question reads. An edit renders as a diff. A whole-file write says whether it creates or replaces, and shows a capped preview. Everything else falls through to the old format, which was never the problem.

## Reviewer's guide

Read in this order:

1. [agent/host/extension.go](https://github.com/panyam/mcpkit/pull/1287/files#diff-985592cc5a0e6e0c3b925b74b96eee4d2eccfb9049a8dbc9638c2a995e705e89) — the `ApprovalRenderer` type and `renderApproval`. The doc comments carry the contract; the resolution loop is eight lines.
2. [agent/host/approvalrender_test.go](https://github.com/panyam/mcpkit/pull/1287/files#diff-7c5a6429e99e0737d38bb3204a9b2ea59c84d2339b3aa68248e782311eae0a8b) — acceptance. `TestRendererSeesPostMiddlewareArguments` is the security one.
3. [agent/ext/files/extension.go](https://github.com/panyam/mcpkit/pull/1287/files#diff-4c7e7e625dda43bc04cf42499483f0e9d2397893754f19c6541609e9363237e6) — the first consumer, from `ApprovalRenderers` down.
4. [agent/ext/files/approval_test.go](https://github.com/panyam/mcpkit/pull/1287/files#diff-99898b7a085fd659c5e6a0799587c168cf80380ac7138685430b59252b8f4da2) — what the rendering actually promises.
5. [agent/host/app.go](https://github.com/panyam/mcpkit/pull/1287/files#diff-89fb8e04b6e1e9d5f7f76958490ef158dee40e2cae92d87c04b408d893c84361), `config.go` — wiring: one struct field, one call site, one doc comment on the now-fallback.
6. Both `README.md`s.

## How it works

```
ask(ctx, info):                       # the gate's existing entry point
    prompt = renderApproval(ctx, info)
    return coordinator.Confirm(ctx, prompt)     # unchanged FIFO seam

renderApproval(ctx, info):
    for each renderer, in registration order:
        skip nil
        text, claimed = renderer(ctx, info)
        if claimed and text != "":
            return text                        # first claim wins
    return approvalPrompt(info)                # built-in, still trims to 200
```

Two things a reviewer would otherwise pause on. **The FIFO ordering is untouched** — the approval ask rides the same queue as elicitation so a gated call never stacks a dialog against a concurrent elicitation, and this PR changes only what string goes in, not when. And **an empty claim is treated as a decline**, because a renderer that claims a call and produces nothing would otherwise ask the user to confirm a blank question.

## Decision log

- **An `Extension` seam, not an `AppOption`.** Every other contribution works this way, and the contract's premise is that a feature's facets travel together — a tool and how its approval reads describe the same operation. "One mechanism over two" is a live #1240 principle. If a bare renderer with no extension turns out to be wanted, adding the option later is *additive* and therefore still legal post-1.0; removing a redundant one would not be.
- **The seam ships with a consumer.** `ContextStages` is the one existing `Extension` seam nothing implements, and that is precisely how `TurnStart`'s absence went unnoticed until checkpoint needed it. Adding a second unexercised seam to the same interface would repeat the mistake in the same file. `files` costs no new import — it already depends on `agent/host`.
- **The renderer takes a `context.Context` that nothing here uses.** The deliberate call, not an oversight. A renderer showing what a whole-file write would *replace* must read the file that is there now. #1240 freezes the whole `agent/host` Config, so adding a parameter later is a breaking change while adding it now is free. Counter-argument, stated fairly: it is speculative generality in a repo that prefers shrinking surface, and if you would rather drop it, now is the moment.
- **First claim wins, in registration order.** Matches middleware ordering. `Command` collides loudly instead, but it can: a command name is known at registration, while a renderer decides per call, so two claiming the same one is undetectable until it happens and failing a turn at that point is worse than picking one.
- **No `error` return.** A renderer that cannot do its job returns `false` and the user still gets asked, which is the only useful behaviour at an approval prompt.
- **The 200-character trim stays in the fallback only**, per the issue's acceptance criteria. It is the right default for an unknown tool and the thing that made an edit unreviewable when applied to everything.

## Risk / blast radius

- **Affects:** `agent/host` and `agent/ext/files`. `Extension` gains a method, which is source-compatible for existing implementers because `BaseExtension` no-ops it and both in-tree extensions embed it.
- **Behaviour with no renderer registered is byte-identical**, pinned by `TestNoRenderersLeavesTheDefaultUntouched`.
- **Tests covering this:** 18 new (10 host, 8 files), all under `-race`. No existing test file was modified.
- **Be paranoid about:** a renderer is now trusted to describe a call the user is about to authorise, and nothing verifies that its text matches the arguments. A renderer that lied — or omitted the destructive part of a call — would produce an informed-looking approval for something else. That is inherent to letting the tool describe itself and is why the seam is extension-scoped rather than, say, model-supplied, but it is worth naming.
- **Also:** `renderApproval` runs on the turn's context inside the gate. A renderer that blocks (the `ctx` exists partly to permit I/O) delays the prompt. Nothing enforces a deadline.

## Red before green

Nine mutations, each verified to have changed the file before its result was trusted.

| Mutation | Caught by |
|---|---|
| Renderers never consulted | 6 tests incl. `TestRendererTextReachesTheAsk` |
| Renderers never collected from extensions | same 6 |
| Empty claimed text accepted | `TestEmptyTextCountsAsDeclining` |
| Last claim wins instead of first | `TestFirstClaimWins` |
| Nil renderer not skipped | `TestNilRendererIsSkipped` |
| `files` renderer claims every tool | `TestUnknownToolsAreDeclined` |
| Deletion prints a bare `+` line | `TestDeletionRendersWithNoAddedLines` |
| Write preview never caps | `TestWriteApprovalCapsItsOwnPreview` |
| Create/replace distinction dropped | `TestWriteApprovalDistinguishesCreateFromReplace` |

One mutation (last-claim-wins) initially failed to compile and was redone as a genuine ordering reversal before its result was recorded — the harness reports build failures separately for exactly this reason.

Assertion sites added: 33, across 18 new tests. Removed or weakened: **0** — no existing test file is touched by this PR.

## Before / after

Real output, same `edit_file` call rendered both ways:

```
BEFORE (host default)
Allow tool call "edit_file" with {"path":"main.go","expect_hash":"dcf19a8dce4a","edits":[{"old":"func Old() {}","new":"func New() {}"},{"old":"return nil","new":"return fmt.Errorf(\"not implemented\")"}]}?

AFTER (files renderer)
Apply 2 change(s) to main.go?

  - func Old() {}
  + func New() {}

  - return nil
  + return fmt.Errorf("not implemented")
```

And a whole-file write, which says which of the two things it is doing because only one of them destroys anything:

```
Replace cfg.yaml (10 bytes, 3 lines)?

  a: 1
  b: 2
```

```mermaid
flowchart TD
    G["approval gate needs a yes/no"] --> R{"any renderer<br/>claim this call?"}
    R -->|"files claims edit_file"| D["render the diff<br/>(its own truncation)"]
    R -->|"declined / none registered"| F["built-in format<br/>(args trimmed to 200)"]
    D --> C["Confirm on the existing FIFO seam"]
    F --> C
    C --> U(("user"))
```

## Out of scope (deliberately deferred)

- **Diff-level approval of individual hunks.** This makes the *question* legible; approving hunk 2 while rejecting hunk 1 is the #1252 child this unblocks, and it needs the edit engine to support partial application.
- **A `WithApprovalRenderer` AppOption** for a host-owned tool with no extension. Additive later, so deferring it costs nothing.
- **Rendering for the meta-tools** the host owns. Same reason.
- **A deadline around renderer execution**, noted under Risk.

