### PR TITLE
feat(agent/eval): adapter seam so external benchmarks are data, not harnesses

### DIFF
--- a/experimental/agent/NOTES.md
+++ b/experimental/agent/NOTES.md
@@ -987,6 +987,41 @@ A tool denial emits `EventToolDenied` with `Event.Reason`, is fed back as model-
 **the turn continues**. It is deliberately not an error, so `eval.NoError` ignores it and
 `eval.NotDenied` is the separate check.
 
+### The adapter seam (#1015)
+
+External suites are **data sources**, not harnesses. `Adapter.Load` yields `[]SuiteCase`, and
+adding LoCoMo / BFCL / tau-bench must not touch the Runner, the scorers, or `Suite`.
+
+Three things had to change for that, and each was forced by a real shape rather than anticipated:
+
+- **Scorers are per-case.** `Suite.Scorers` was one list applied to every case, which can only
+  express properties true of all of them ("did not error"), never the ground truth that makes a
+  benchmark a benchmark. The evidence was `longmemeval/live_test.go`, which hand-rolled its own
+  copy of `Suite.Run` because `Suite` could not take it. That file is now the harness call it
+  should always have been.
+- **`Scenario.History` seeds without running.** A memory benchmark supplies a long prior
+  conversation and asks one question about it. Replaying that as `Turns` would call the model once
+  per historical message and grade its own invented replies. History is data the agent is told it
+  had; Turns are turns the agent takes.
+- **`SuiteCase.Configure` returns a config rather than mutating one**, so a compaction case's
+  `Compactor` cannot leak into the next case. `TestSuiteCaseConfigureIsPerCase` observes the
+  handed-in config through `Configure` rather than through `Result`, because `Result.Case` carries
+  only the turn's name and input — asserting there compares two zero values and passes either way.
+
+**Ungradeable is a failure, not a pass.** `Suite.Run` already failed a case with no scorers. The
+subtler version bit immediately: the abstention smoke case is graded by a `Rubric`, and its only
+deterministic scorer is a `MustNot` that *any* answer satisfies. Reachable from the default build
+for the first time (the adapter is untagged; `live_test.go` never was), it passed against a stub
+answering "stub answer". So `appendRubric` now yields `eval.Ungradeable` without the `eval_llm`
+tag. A case graded only by checks that cannot fail is not graded.
+
+**Aggregation is single-axis on purpose.** `SuiteReport.Passed/Failed` counts whole cases, which
+is right for one-question-per-case and wrong for a suite reporting several independent rates — a
+security suite wants utility and attack-success counted separately, and one of them inverted.
+Deliberately not designed for now: per-scorer verdicts are kept with their names, so a
+per-dimension rollup is an addition over existing data rather than a re-plumb. #1060 is the one
+that will actually stress it, and reshaping is free while the agent track is unreleased.
+
 ---
 
 ## Testing

--- a/experimental/agent/eval/adapter.go
+++ b/experimental/agent/eval/adapter.go
@@ -1,0 +1,74 @@
+package eval
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/panyam/mcpkit/experimental/agent"
+)
+
+// Adapter turns an external benchmark into cases this harness can run.
+//
+// The harness is the constant and the suites vary: LongMemEval, LoCoMo, BFCL,
+// tau-bench and our own fixtures differ in where the tasks come from and how
+// they are graded, not in how a turn is executed or how a report is tallied.
+// An adapter is therefore a data source, and adding one must not touch the
+// Runner, the scorers, or Suite.
+//
+// # Conventions an adapter follows
+//
+//   - **Data lives outside the repo.** Benchmark corpora are large and
+//     separately licensed, so an adapter reads a path from the environment and
+//     skips cleanly when it is unset, mirroring the MCPCONFORMANCE_*_PATH
+//     convention in conformance/. Nothing is vendored.
+//   - **Adapters live in sibling packages.** agent/eval must not grow a
+//     dependency because one benchmark ships parquet or needs a tokenizer.
+//   - **Per-case ground truth goes in the case.** SuiteCase.Scorers is where a
+//     suite's expected answers live; the adapter maps its format onto them.
+//
+// An adapter that yields zero cases and a nil error means "this suite is not
+// configured here", which a caller reports as a skip rather than a pass.
+type Adapter interface {
+	// Name identifies the suite in reports and skip messages.
+	Name() string
+
+	// Load reads the suite and yields its cases. An error means the data was
+	// found but could not be read; zero cases with a nil error means the
+	// suite is not configured on this machine.
+	Load() ([]SuiteCase, error)
+}
+
+// SuitePath resolves a benchmark's data location from an environment
+// variable, and reports whether it is usable.
+//
+// Adapters call this instead of reading os.Getenv directly so the three
+// outcomes stay distinct: configured and present, not configured, and
+// configured but wrong. The third is the one worth an error — an operator who
+// set the variable meant to run the suite, and silently reporting "not
+// configured" for a typo would show up as a suite that mysteriously never
+// runs.
+func SuitePath(envVar string) (path string, ok bool, err error) {
+	p := os.Getenv(envVar)
+	if p == "" {
+		return "", false, nil
+	}
+	if _, statErr := os.Stat(p); statErr != nil {
+		return "", false, fmt.Errorf("eval: %s=%q: %w", envVar, p, statErr)
+	}
+	return p, true, nil
+}
+
+// LoadSuite builds a Suite from an adapter over a base config.
+//
+// It returns ok=false when the adapter is not configured, so a caller can
+// skip. Any other failure is an error.
+func LoadSuite(cfg agent.RunnerConfig, a Adapter) (suite Suite, ok bool, err error) {
+	cases, err := a.Load()
+	if err != nil {
+		return Suite{}, false, fmt.Errorf("eval: adapter %q: %w", a.Name(), err)
+	}
+	if len(cases) == 0 {
+		return Suite{}, false, nil
+	}
+	return Suite{Config: cfg, Cases: cases}, true, nil
+}

--- a/experimental/agent/eval/adapter_test.go
+++ b/experimental/agent/eval/adapter_test.go
@@ -1,0 +1,281 @@
+package eval
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/panyam/mcpkit/experimental/agent"
+)
+
+// TestSuitePerCaseScorers covers the thing the old Suite could not express:
+// two cases in one suite, each graded against its own expected answer.
+//
+// Under the previous shape (one Scorers list for the whole suite) the only way
+// to write this was a scorer that passed for both answers, which grades
+// nothing. That limitation is why longmemeval hand-rolled its own loop.
+func TestSuitePerCaseScorers(t *testing.T) {
+	suite := Suite{
+		Config: agent.RunnerConfig{
+			Provider: agent.NewStubProvider(
+				agent.StubTurn{Text: "paris"},
+				agent.StubTurn{Text: "rome"},
+			),
+		},
+		Cases: []SuiteCase{
+			Single(Case{Name: "france", Input: "capital of france"}, ExactMatch("paris")),
+			Single(Case{Name: "italy", Input: "capital of italy"}, ExactMatch("rome")),
+		},
+	}
+
+	report := suite.Run(context.Background())
+	if report.Passed != 2 || report.Failed != 0 {
+		t.Fatalf("both cases should pass against their own ground truth: %s", report)
+	}
+}
+
+// TestSuitePerCaseScorersCatchTheWrongAnswer is the negative half: the same
+// two cases with the answers swapped must both fail, proving each case's
+// scorers really are bound to that case rather than being satisfied by any
+// case's answer.
+func TestSuitePerCaseScorersCatchTheWrongAnswer(t *testing.T) {
+	suite := Suite{
+		Config: agent.RunnerConfig{
+			Provider: agent.NewStubProvider(
+				agent.StubTurn{Text: "rome"},
+				agent.StubTurn{Text: "paris"},
+			),
+		},
+		Cases: []SuiteCase{
+			Single(Case{Name: "france", Input: "capital of france"}, ExactMatch("paris")),
+			Single(Case{Name: "italy", Input: "capital of italy"}, ExactMatch("rome")),
+		},
+	}
+
+	report := suite.Run(context.Background())
+	if report.Failed != 2 {
+		t.Fatalf("swapped answers should fail both cases: %s", report)
+	}
+}
+
+// TestSuiteCaseConfigureIsPerCase pins that a case's config change does not
+// leak into the next case. Configure returns a config rather than mutating
+// one for exactly this reason.
+func TestSuiteCaseConfigureIsPerCase(t *testing.T) {
+	// The second case observes the config it is handed. If the first case's
+	// override leaked, it arrives here as 7 instead of the suite's 3.
+	//
+	// Observing it through Configure is deliberate: Result.Case carries only
+	// the turn's name and input, so asserting on the Result would compare two
+	// zero values and pass whether or not the leak existed.
+	var handed int
+	suite := Suite{
+		Config: agent.RunnerConfig{
+			Provider: agent.NewStubProvider(agent.StubTurn{Text: "a"}, agent.StubTurn{Text: "b"}),
+			MaxSteps: 3,
+		},
+		Cases: []SuiteCase{
+			{
+				Scenario: Scenario{Name: "with-override", Turns: []string{"hi"}},
+				Scorers:  func(agent.Provider) []Scorer { return []Scorer{NoError()} },
+				Configure: func(cfg agent.RunnerConfig) (agent.RunnerConfig, error) {
+					cfg.MaxSteps = 7
+					return cfg, nil
+				},
+			},
+			{
+				Scenario: Scenario{Name: "observes", Turns: []string{"hi"}},
+				Scorers:  func(agent.Provider) []Scorer { return []Scorer{NoError()} },
+				Configure: func(cfg agent.RunnerConfig) (agent.RunnerConfig, error) {
+					handed = cfg.MaxSteps
+					return cfg, nil
+				},
+			},
+		},
+	}
+
+	report := suite.Run(context.Background())
+	if report.Failed != 0 {
+		t.Fatalf("both cases should pass: %s", report)
+	}
+	if handed != 3 {
+		t.Fatalf("the first case's override leaked into the second: MaxSteps = %d, want the suite's 3", handed)
+	}
+}
+
+// TestSuiteCaseConfigureErrorIsPerCase pins that a Configure failure fails
+// only its own case and the suite keeps going.
+func TestSuiteCaseConfigureErrorIsPerCase(t *testing.T) {
+	suite := Suite{
+		Config: agent.RunnerConfig{Provider: agent.NewStubProvider(agent.StubTurn{Text: "ok"})},
+		Cases: []SuiteCase{
+			{
+				Scenario:  Scenario{Name: "broken", Turns: []string{"hi"}},
+				Scorers:   func(agent.Provider) []Scorer { return []Scorer{NoError()} },
+				Configure: func(agent.RunnerConfig) (agent.RunnerConfig, error) { return agent.RunnerConfig{}, errors.New("boom") },
+			},
+			Single(Case{Name: "fine", Input: "hi"}, NoError()),
+		},
+	}
+
+	report := suite.Run(context.Background())
+	if report.Total != 2 || report.Passed != 1 || report.Failed != 1 {
+		t.Fatalf("one case should fail on configure, the other run: %s", report)
+	}
+	if got := report.Cases[0].RunErr; !strings.Contains(got, "boom") {
+		t.Errorf("first case should carry the configure error, got %q", got)
+	}
+}
+
+// TestSuiteCaseWithNoTurnsIsReported pins that a scenario with seeded History
+// and no Turns is reported as that case's failure rather than panicking the
+// whole suite. Final panics on an empty slice, and forgetting the question
+// while populating the history is a plausible adapter bug.
+func TestSuiteCaseWithNoTurnsIsReported(t *testing.T) {
+	suite := Suite{
+		Config: agent.RunnerConfig{Provider: agent.NewStubProvider(agent.StubTurn{Text: "ok"})},
+		Cases: []SuiteCase{{
+			Scenario: Scenario{
+				Name:    "history-only",
+				History: []agent.Message{{Role: agent.RoleUser, Text: "prior"}},
+			},
+			Scorers: func(agent.Provider) []Scorer { return []Scorer{NoError()} },
+		}},
+	}
+
+	report := suite.Run(context.Background())
+	if report.Failed != 1 {
+		t.Fatalf("a turnless case should fail: %s", report)
+	}
+	if got := report.Cases[0].RunErr; !strings.Contains(got, "no turns") {
+		t.Errorf("expected a 'ran no turns' error, got %q", got)
+	}
+}
+
+// TestScenarioHistoryIsSeededNotRun pins the distinction the History field
+// exists for: seeded messages reach the model as context, without the model
+// being called to produce them.
+func TestScenarioHistoryIsSeededNotRun(t *testing.T) {
+	stub := agent.NewStubProvider(agent.StubTurn{Text: "answer"})
+	s := Scenario{
+		Name: "seeded",
+		History: []agent.Message{
+			{Role: agent.RoleUser, Text: "my cat is called Mango"},
+			{Role: agent.RoleAssistant, Text: "noted"},
+		},
+		Turns: []string{"what is my cat called?"},
+	}
+
+	results, err := RunScenario(context.Background(), agent.RunnerConfig{Provider: stub}, s)
+	if err != nil {
+		t.Fatalf("RunScenario: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("two history messages must not become turns; got %d results", len(results))
+	}
+
+	reqs := stub.Requests()
+	if len(reqs) != 1 {
+		t.Fatalf("the model should be called once, for the single turn; got %d calls", len(reqs))
+	}
+	var texts []string
+	for _, m := range reqs[0].Messages {
+		texts = append(texts, m.Text)
+	}
+	joined := strings.Join(texts, "|")
+	if !strings.Contains(joined, "Mango") {
+		t.Errorf("seeded history did not reach the model: %q", joined)
+	}
+}
+
+// TestScenarioHistoryIsNotAliased pins that running a Scenario twice does not
+// accumulate the first run's turns into the caller's History slice. A suite
+// that grades one scenario across several memory backends does exactly that.
+func TestScenarioHistoryIsNotAliased(t *testing.T) {
+	s := Scenario{
+		Name:    "reused",
+		History: []agent.Message{{Role: agent.RoleUser, Text: "seed"}},
+		Turns:   []string{"go"},
+	}
+	for i := 0; i < 2; i++ {
+		stub := agent.NewStubProvider(agent.StubTurn{Text: "ok"})
+		if _, err := RunScenario(context.Background(), agent.RunnerConfig{Provider: stub}, s); err != nil {
+			t.Fatalf("run %d: %v", i, err)
+		}
+	}
+	if len(s.History) != 1 {
+		t.Fatalf("the scenario's History grew across runs: %+v", s.History)
+	}
+}
+
+// TestSuitePath covers the three outcomes an adapter has to tell apart:
+// configured and present, not configured, and configured but wrong.
+func TestSuitePath(t *testing.T) {
+	const env = "MCPKIT_TEST_SUITE_PATH"
+
+	t.Run("unset is not an error", func(t *testing.T) {
+		t.Setenv(env, "")
+		path, ok, err := SuitePath(env)
+		if err != nil || ok || path != "" {
+			t.Fatalf("got (%q, %v, %v)", path, ok, err)
+		}
+	})
+
+	t.Run("present resolves", func(t *testing.T) {
+		f := filepath.Join(t.TempDir(), "suite.json")
+		if err := os.WriteFile(f, []byte("{}"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv(env, f)
+		path, ok, err := SuitePath(env)
+		if err != nil || !ok || path != f {
+			t.Fatalf("got (%q, %v, %v)", path, ok, err)
+		}
+	})
+
+	t.Run("set but missing is an error, not a skip", func(t *testing.T) {
+		t.Setenv(env, filepath.Join(t.TempDir(), "nope.json"))
+		_, ok, err := SuitePath(env)
+		if err == nil {
+			t.Fatal("a typo'd path must be an error; reporting it as unconfigured hides a suite that never runs")
+		}
+		if ok {
+			t.Fatal("ok should be false on error")
+		}
+	})
+}
+
+// stubAdapter is a minimal Adapter for LoadSuite's contract.
+type stubAdapter struct {
+	name  string
+	cases []SuiteCase
+	err   error
+}
+
+func (a stubAdapter) Name() string               { return a.name }
+func (a stubAdapter) Load() ([]SuiteCase, error) { return a.cases, a.err }
+
+// TestLoadSuite pins that an unconfigured adapter is a skip rather than an
+// empty pass, and that a load failure is an error.
+func TestLoadSuite(t *testing.T) {
+	cfg := agent.RunnerConfig{Provider: agent.NewStubProvider()}
+
+	if _, ok, err := LoadSuite(cfg, stubAdapter{name: "empty"}); ok || err != nil {
+		t.Fatalf("no cases should report not-configured: ok=%v err=%v", ok, err)
+	}
+
+	if _, _, err := LoadSuite(cfg, stubAdapter{name: "bad", err: errors.New("corrupt")}); err == nil {
+		t.Fatal("a load failure must surface as an error")
+	}
+
+	suite, ok, err := LoadSuite(cfg, stubAdapter{
+		name:  "one",
+		cases: []SuiteCase{Single(Case{Name: "c"}, NoError())},
+	})
+	if err != nil || !ok || len(suite.Cases) != 1 {
+		t.Fatalf("got (%d cases, %v, %v)", len(suite.Cases), ok, err)
+	}
+}

--- a/experimental/agent/eval/eval_test.go
+++ b/experimental/agent/eval/eval_test.go
@@ -235,13 +235,9 @@ func TestSuiteAggregate(t *testing.T) {
 			),
 			Tools: src,
 		},
-		Cases: []Case{
-			{Name: "A-uses-tool", Input: "get x"},
-			{Name: "B-wrong-answer", Input: "guess"},
-		},
-		Scorers: []Scorer{
-			ExactMatch("value-for-x"),
-			NoError(),
+		Cases: []SuiteCase{
+			Single(Case{Name: "A-uses-tool", Input: "get x"}, ExactMatch("value-for-x"), NoError()),
+			Single(Case{Name: "B-wrong-answer", Input: "guess"}, ExactMatch("value-for-x"), NoError()),
 		},
 	}
 
@@ -279,9 +275,11 @@ func TestSuiteRecordsHarnessErrorPerCase(t *testing.T) {
 	// No provider -> every case fails to build; the suite records RunErr and
 	// keeps going rather than aborting.
 	suite := Suite{
-		Config:  agent.RunnerConfig{},
-		Cases:   []Case{{Name: "a"}, {Name: "b"}},
-		Scorers: []Scorer{NoError()},
+		Config: agent.RunnerConfig{},
+		Cases: []SuiteCase{
+			Single(Case{Name: "a"}, NoError()),
+			Single(Case{Name: "b"}, NoError()),
+		},
 	}
 	report := suite.Run(context.Background())
 	if report.Failed != 2 || report.Passed != 0 {

--- a/experimental/agent/eval/longmemeval/adapter_test.go
+++ b/experimental/agent/eval/longmemeval/adapter_test.go
@@ -1,0 +1,94 @@
+package longmemeval
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/panyam/mcpkit/experimental/agent"
+	"github.com/panyam/mcpkit/experimental/agent/eval"
+)
+
+// TestSmokeAdapterYieldsEveryCase pins that the adapter maps the whole smoke
+// set onto the harness, and that each case carries its own scorers. Under the
+// previous suite shape neither was expressible, which is why this package ran
+// its own loop.
+func TestSmokeAdapterYieldsEveryCase(t *testing.T) {
+	cases, err := SmokeAdapter{}.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(cases) != len(SmokeScenarios()) {
+		t.Fatalf("adapter dropped cases: %d of %d", len(cases), len(SmokeScenarios()))
+	}
+	for _, c := range cases {
+		if c.Scorers == nil {
+			t.Fatalf("case %q has no scorers; a case nothing grades passes forever", c.Scenario.Name)
+		}
+		if len(c.Scorers(nil)) == 0 {
+			// Without the eval_llm tag a rubric-only case has no deterministic
+			// scorers, which would silently pass. Every smoke case is expected
+			// to carry at least one substring check for that reason.
+			t.Errorf("case %q yields no scorers without a provider", c.Scenario.Name)
+		}
+	}
+}
+
+// TestSmokeAdapterNamesCarryCategory pins that the report groups by category
+// without the harness knowing what a category is.
+func TestSmokeAdapterNamesCarryCategory(t *testing.T) {
+	cases, err := SmokeAdapter{}.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	for _, c := range cases {
+		if !strings.Contains(c.Scenario.Name, "/") {
+			t.Errorf("case name %q should be <category>/<name>", c.Scenario.Name)
+		}
+	}
+}
+
+// TestSmokeAdapterRunsThroughSuite is the end of the seam: an adapter's cases
+// go straight into eval.Suite with no per-suite glue. It runs against a stub
+// provider, so it asserts the plumbing rather than memory quality (that is
+// what the live, tagged benchmark is for).
+func TestSmokeAdapterRunsThroughSuite(t *testing.T) {
+	cases, err := SmokeAdapter{}.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	// Over-provision the script. A compaction case runs under a
+	// SummarizingCompactor, which calls the provider itself to summarize the
+	// head, so the number of provider calls is not the number of turns.
+	total := 0
+	for _, c := range cases {
+		total += len(c.Scenario.Turns)
+	}
+	turns := make([]agent.StubTurn, 0, total*4+20)
+	for i := 0; i < cap(turns); i++ {
+		turns = append(turns, agent.StubTurn{Text: "stub answer"})
+	}
+
+	suite := eval.Suite{
+		Config: agent.RunnerConfig{Provider: agent.NewStubProvider(turns...)},
+		Cases:  cases,
+	}
+	report := suite.Run(context.Background())
+
+	if report.Total != len(cases) {
+		t.Fatalf("suite ran %d of %d cases", report.Total, len(cases))
+	}
+	// No case may pass on a stub answer. This is the assertion that caught the
+	// abstention case passing vacuously: its only deterministic scorer is a
+	// MustNot that any answer satisfies, so without the rubric it graded
+	// nothing. appendRubric now marks such a case ungradeable instead.
+	if report.Passed != 0 {
+		t.Errorf("a stub answer should satisfy no case's ground truth, got %d passes:\n%s", report.Passed, report)
+	}
+	for _, c := range report.Cases {
+		if c.RunErr != "" {
+			t.Errorf("case %q failed to run: %s", c.Case, c.RunErr)
+		}
+	}
+}

--- a/experimental/agent/eval/longmemeval/cases.go
+++ b/experimental/agent/eval/longmemeval/cases.go
@@ -172,3 +172,69 @@ func (c MemCase) Deterministic() []eval.Scorer {
 	}
 	return out
 }
+
+// SuiteCase adapts a MemCase onto the harness's graded unit.
+//
+// It is the whole of what an adapter does: map this suite's shape (a
+// category, a rubric, substring requirements, an optional compaction
+// strategy) onto a Scenario plus the scorers that grade it. The Runner, the
+// scorers, and the report are untouched.
+//
+// The name carries the category so a report groups readably without the
+// harness needing to know what a category is.
+func (c MemCase) SuiteCase() eval.SuiteCase {
+	s := c.Scenario
+	s.Name = string(c.Category) + "/" + s.Name
+
+	sc := eval.SuiteCase{Scenario: s}
+
+	sc.Scorers = func(p agent.Provider) []eval.Scorer {
+		// The judge needs a model, which is why Scorers takes the provider
+		// rather than being a plain slice: a rubric cannot be built until the
+		// suite's provider is known. appendRubric is a no-op without the
+		// eval_llm build tag, where eval.Judge does not exist.
+		return appendRubric(c.Deterministic(), p, c.Rubric)
+	}
+
+	if c.NewCompactor != nil {
+		// A compaction case is about the harness, not the model: it proves a
+		// fact survives the compaction boundary, so it has to run under a
+		// Compactor. Building it needs the provider (a SummarizingCompactor
+		// summarizes with a model), which is why Configure receives the
+		// config rather than being a static override.
+		sc.Configure = func(cfg agent.RunnerConfig) (agent.RunnerConfig, error) {
+			compactor, err := c.NewCompactor(cfg.Provider)
+			if err != nil {
+				return cfg, err
+			}
+			cfg.Compactor = compactor
+			return cfg, nil
+		}
+	}
+
+	return sc
+}
+
+// SmokeAdapter yields the in-repo smoke set as an eval.Adapter.
+//
+// It needs no external data, so unlike a real corpus adapter it is always
+// configured. It exists to prove the seam with something that runs today; the
+// LongMemEval corpus loader (issue 1014) is the same interface over
+// LONGMEMEVAL_DATA_PATH and slots in beside it without touching the harness.
+type SmokeAdapter struct{}
+
+// Name identifies the suite in reports.
+func (SmokeAdapter) Name() string { return "longmemeval-smoke" }
+
+// Load yields the smoke set. It never returns zero cases, because the data is
+// compiled in.
+func (SmokeAdapter) Load() ([]eval.SuiteCase, error) {
+	cases := SmokeScenarios()
+	out := make([]eval.SuiteCase, 0, len(cases))
+	for _, c := range cases {
+		out = append(out, c.SuiteCase())
+	}
+	return out, nil
+}
+
+var _ eval.Adapter = SmokeAdapter{}

--- a/experimental/agent/eval/longmemeval/live_test.go
+++ b/experimental/agent/eval/longmemeval/live_test.go
@@ -41,47 +41,24 @@ func liveProvider(t *testing.T) agent.Provider {
 
 func TestLiveLongMemEval(t *testing.T) {
 	provider := liveProvider(t)
-	ctx := context.Background()
 
-	var passed, total int
-	for _, c := range SmokeScenarios() {
-		cfg := agent.RunnerConfig{Provider: provider}
-		if c.NewCompactor != nil {
-			// The case supplies the compaction strategy (a Compactor that
-			// decides per turn whether to compact) — issue 939's
-			// SummarizingCompactor graded by issue 974's harness.
-			compactor, err := c.NewCompactor(provider)
-			if err != nil {
-				t.Fatalf("%s: build compactor: %v", c.Scenario.Name, err)
-			}
-			cfg.Compactor = compactor
-		}
-		results, err := eval.RunScenario(ctx, cfg, c.Scenario)
-		if err != nil {
-			t.Fatalf("%s: harness error: %v", c.Scenario.Name, err)
-		}
-		final := eval.Final(results)
-
-		casePass := true
-		for _, s := range c.Deterministic() {
-			if sc := s.Score(final); !sc.Pass {
-				casePass = false
-				t.Logf("[%s] %s FAIL: %s", c.Category, c.Scenario.Name, sc.Detail)
-			}
-		}
-		if c.Rubric != "" {
-			if sc := eval.Judge(provider, c.Rubric).Score(final); !sc.Pass {
-				casePass = false
-				t.Logf("[%s] %s JUDGE FAIL (%.2f): %s", c.Category, c.Scenario.Name, sc.Value, sc.Detail)
-			}
-		}
-
-		total++
-		if casePass {
-			passed++
-			t.Logf("[%s] %s PASS", c.Category, c.Scenario.Name)
-		}
+	// The whole benchmark is now Suite.Run over an adapter. What used to live
+	// here was a hand-rolled copy of that loop -- run each case, apply its
+	// scorers, tally -- written because Suite could not express per-case
+	// scorers or multi-turn scenarios. That duplication was the evidence the
+	// adapter seam was missing (issue 1015).
+	suite, ok, err := eval.LoadSuite(agent.RunnerConfig{Provider: provider}, SmokeAdapter{})
+	if err != nil {
+		t.Fatalf("load suite: %v", err)
 	}
-	// Report, do not gate — the benchmark's job is to surface the pass rate.
-	t.Logf("LongMemEval-derived pass rate: %d/%d", passed, total)
+	if !ok {
+		t.Skip("longmemeval-smoke yielded no cases")
+	}
+
+	report := suite.Run(context.Background())
+
+	// Report, do not gate -- the benchmark's job is to surface the pass rate,
+	// since memory quality is statistical.
+	t.Logf("\n%s", report)
+	t.Logf("LongMemEval-derived pass rate: %d/%d", report.Passed, report.Total)
 }

--- a/experimental/agent/eval/longmemeval/rubric.go
+++ b/experimental/agent/eval/longmemeval/rubric.go
@@ -1,0 +1,30 @@
+//go:build !eval_llm
+
+package longmemeval
+
+import (
+	"github.com/panyam/mcpkit/experimental/agent"
+	"github.com/panyam/mcpkit/experimental/agent/eval"
+)
+
+// appendRubric marks a rubric case as ungraded in the default build.
+//
+// eval.Judge needs a live model and lives behind the eval_llm tag, so the
+// rubric cannot be evaluated here. Returning the deterministic scorers alone
+// would be worse than it looks: for a case whose real grade IS the rubric, the
+// remaining scorers can be satisfied by any answer at all. The abstention case
+// is exactly that shape — its only deterministic check is that one unrelated
+// token is absent, so a model replying with nonsense scores as having
+// correctly abstained.
+//
+// Suite.Run already treats a case with no scorers as a failure, on the
+// reasoning that a case nothing grades passes forever. This is the same
+// reasoning one step in: a case graded only by checks that cannot fail is not
+// graded either. So it fails, legibly, naming the tag that would grade it.
+func appendRubric(scorers []eval.Scorer, _ agent.Provider, rubric string) []eval.Scorer {
+	if rubric == "" {
+		return scorers
+	}
+	return append(scorers, eval.Ungradeable("Rubric",
+		"this case is graded by an LLM rubric; run with -tags eval_llm and a live provider"))
+}

--- a/experimental/agent/eval/longmemeval/rubric_llm.go
+++ b/experimental/agent/eval/longmemeval/rubric_llm.go
@@ -1,0 +1,17 @@
+//go:build eval_llm
+
+package longmemeval
+
+import (
+	"github.com/panyam/mcpkit/experimental/agent"
+	"github.com/panyam/mcpkit/experimental/agent/eval"
+)
+
+// appendRubric adds the LLM-as-judge scorer for a case that has a rubric, for
+// the fuzzy categories where a substring check cannot express the grade.
+func appendRubric(scorers []eval.Scorer, p agent.Provider, rubric string) []eval.Scorer {
+	if rubric == "" || p == nil {
+		return scorers
+	}
+	return append(scorers, eval.Judge(p, rubric))
+}

--- a/experimental/agent/eval/scenario.go
+++ b/experimental/agent/eval/scenario.go
@@ -21,6 +21,18 @@ type Scenario struct {
 	// Name identifies the scenario in a report. Should be unique in a Suite.
 	Name string
 
+	// History seeds the conversation before the first turn runs. It is data,
+	// not turns: nothing in it is executed, and the model is never called to
+	// produce it.
+	//
+	// This is what an external suite needs and Turns cannot express. A
+	// memory benchmark supplies a long prior conversation and then asks one
+	// question about it; replaying that conversation as Turns would call the
+	// model once per historical message and would grade the model's own
+	// invented replies rather than the dataset's. The distinction is
+	// "conversation the agent is told it had" versus "turns the agent takes".
+	History []agent.Message
+
 	// Turns are the user inputs, oldest first. Each runs as one agent turn
 	// against the accumulated history; the final turn's Result is the graded
 	// one.
@@ -107,7 +119,10 @@ func RunScenario(ctx context.Context, cfg agent.RunnerConfig, s Scenario) ([]Res
 		return nil, fmt.Errorf("eval: build runner for scenario %q: %w", s.Name, err)
 	}
 
-	var history []agent.Message
+	// Copied rather than aliased: the loop appends to history, and a Scenario
+	// is a value a caller may run more than once (across memory backends, for
+	// instance) or share across a suite.
+	history := append([]agent.Message(nil), s.History...)
 	results := make([]Result, 0, len(s.Turns))
 	for i, input := range s.Turns {
 		history = append(history, agent.Message{Role: agent.RoleUser, Text: input})

--- a/experimental/agent/eval/scorer.go
+++ b/experimental/agent/eval/scorer.go
@@ -165,3 +165,16 @@ func NotDenied() Scorer {
 		return boolScore("NotDenied", true, "no tool calls were denied")
 	})
 }
+
+// Ungradeable returns a Scorer that always fails, naming why the grade could
+// not be computed here.
+//
+// It exists so "we could not grade this" is reported as a failure rather than
+// as a pass. The alternative shapes are both worse: dropping the scorer leaves
+// the case graded by whatever remains, which for a rubric-graded case can be
+// nothing that discriminates; and skipping the case hides it from the totals.
+func Ungradeable(name, reason string) Scorer {
+	return scorerFunc(func(Result) Score {
+		return Score{Name: name, Pass: false, Value: 0, Detail: reason}
+	})
+}

--- a/experimental/agent/eval/suite.go
+++ b/experimental/agent/eval/suite.go
@@ -8,19 +8,68 @@ import (
 	"github.com/panyam/mcpkit/experimental/agent"
 )
 
-// Suite runs each Case against every Scorer and folds the verdicts into a
-// SuiteReport. Config is the base RunnerConfig; each Case may override its
-// tool surface, instructions, or step cap on top of it.
+// SuiteCase is one graded unit: a scenario to run and the scorers that grade
+// it.
+//
+// Scorers are per-case rather than per-suite because that is what an external
+// benchmark is. Every question in a memory benchmark has its own expected
+// answer, so a single scorer list shared across the suite can only express
+// properties that hold for every case ("did not error", "called a tool"),
+// never the ground truth that makes a benchmark a benchmark. The previous
+// shape had exactly that limitation, and longmemeval worked around it by
+// hand-rolling its own runner loop.
+type SuiteCase struct {
+	// Scenario is the conversation to run. Its Name identifies the case in
+	// the report.
+	Scenario Scenario
+
+	// Scorers builds this case's graders. It takes the provider because a
+	// rubric scorer (Judge) needs a model to grade with, and the suite owns
+	// the provider; a case that only uses deterministic scorers ignores the
+	// argument.
+	//
+	// A case with no scorers fails, on the same reasoning as before: a case
+	// nothing grades is a case that silently passes forever.
+	Scorers func(agent.Provider) []Scorer
+
+	// Configure adapts the suite's base RunnerConfig for this case. Nil uses
+	// the base unchanged.
+	//
+	// It exists because some cases are about the harness rather than the
+	// model: a compaction case has to run under a Compactor, which needs the
+	// provider to build. Returning a config rather than mutating one keeps
+	// each case's changes from leaking into the next.
+	Configure func(agent.RunnerConfig) (agent.RunnerConfig, error)
+}
+
+// Single wraps a single-turn Case with a fixed scorer list, for the
+// table-driven style that does not need per-case ground truth.
+//
+// It exists so the common shape stays one line after Suite moved to
+// scenarios. There is one graded unit, not two: this builds the same
+// SuiteCase an adapter yields.
+func Single(c Case, scorers ...Scorer) SuiteCase {
+	return SuiteCase{
+		Scenario: Scenario{
+			Name:         c.Name,
+			History:      c.History,
+			Turns:        []string{c.Input},
+			Tools:        c.Tools,
+			Instructions: c.Instructions,
+			MaxSteps:     c.MaxSteps,
+		},
+		Scorers: func(agent.Provider) []Scorer { return scorers },
+	}
+}
+
+// Suite is a set of graded cases sharing a base config.
 type Suite struct {
 	// Config is the base RunnerConfig shared by every case (Provider is
-	// required). Per-case overrides in Case are layered on a copy.
+	// required). Each case's Configure is layered on a copy.
 	Config agent.RunnerConfig
 
-	// Cases is the set of inputs to evaluate.
-	Cases []Case
-
-	// Scorers is the set of graders applied to every case's Result.
-	Scorers []Scorer
+	// Cases is the set of graded units to evaluate.
+	Cases []SuiteCase
 }
 
 // CaseReport is one case's outcome: the per-scorer verdicts and whether the
@@ -29,12 +78,21 @@ type CaseReport struct {
 	Case   string  `json:"case"`
 	Scores []Score `json:"scores"`
 	Pass   bool    `json:"pass"`
-	// RunErr is set when the harness could not build the runner for this
-	// case (an invalid config); when set, no scorers ran and Pass is false.
+	// RunErr is set when the harness could not run this case (an invalid
+	// config, a case with no turns); when set, no scorers ran and Pass is
+	// false.
 	RunErr string `json:"runErr,omitempty"`
 }
 
 // SuiteReport is the aggregate: one CaseReport per case plus pass/fail counts.
+//
+// Passed and Failed count whole cases, where a case passes only if every one
+// of its scorers passed. That is the right aggregate for a benchmark asking
+// one question per case, and the wrong one for a benchmark reporting several
+// independent rates — a security suite wants utility and attack-success
+// counted separately, and one of them inverted. Per-scorer verdicts are kept
+// on each CaseReport with their names, so a per-dimension rollup is a pure
+// addition over data already here rather than a re-plumb. See issue 1060.
 type SuiteReport struct {
 	Cases  []CaseReport `json:"cases"`
 	Passed int          `json:"passed"`
@@ -45,33 +103,60 @@ type SuiteReport struct {
 // Pass reports whether every case passed.
 func (r SuiteReport) Pass() bool { return r.Failed == 0 }
 
-// Run evaluates every case against every scorer and returns the report. It
-// does not stop on a failing case; a per-case harness failure (bad config) is
-// recorded in that case's RunErr and the suite continues. Ctx cancellation
-// surfaces per case via the Runner (recorded in scores through NoError, or in
-// RunErr for a build failure) rather than aborting the whole suite.
+// Run evaluates every case against its own scorers and returns the report. It
+// does not stop on a failing case; a per-case harness failure is recorded in
+// that case's RunErr and the suite continues. Ctx cancellation surfaces per
+// case via the Runner (recorded in scores through NoError, or in RunErr for a
+// build failure) rather than aborting the whole suite.
 func (s Suite) Run(ctx context.Context) SuiteReport {
 	report := SuiteReport{Total: len(s.Cases)}
-	for _, c := range s.Cases {
-		cr := CaseReport{Case: c.Name, Pass: true}
+	for _, sc := range s.Cases {
+		cr := CaseReport{Case: sc.Scenario.Name, Pass: true}
 
-		res, err := Run(ctx, s.Config, c)
-		if err != nil {
-			cr.RunErr = err.Error()
+		fail := func(format string, args ...any) {
+			cr.RunErr = fmt.Sprintf(format, args...)
 			cr.Pass = false
 			report.Cases = append(report.Cases, cr)
 			report.Failed++
-			continue
 		}
 
-		for _, sc := range s.Scorers {
-			verdict := sc.Score(res)
+		cfg := s.Config
+		if sc.Configure != nil {
+			adapted, err := sc.Configure(cfg)
+			if err != nil {
+				fail("configure: %v", err)
+				continue
+			}
+			cfg = adapted
+		}
+
+		results, err := RunScenario(ctx, cfg, sc.Scenario)
+		if err != nil {
+			fail("%v", err)
+			continue
+		}
+		// Final panics on an empty slice, and a case whose Scenario has no
+		// Turns produces one. That is a plausible adapter bug (History
+		// populated, the question forgotten), so it is reported as this
+		// case's failure rather than taking the suite down.
+		if len(results) == 0 {
+			fail("scenario %q ran no turns", sc.Scenario.Name)
+			continue
+		}
+		final := Final(results)
+
+		var scorers []Scorer
+		if sc.Scorers != nil {
+			scorers = sc.Scorers(s.Config.Provider)
+		}
+		for _, scorer := range scorers {
+			verdict := scorer.Score(final)
 			cr.Scores = append(cr.Scores, verdict)
 			if !verdict.Pass {
 				cr.Pass = false
 			}
 		}
-		if len(s.Scorers) == 0 {
+		if len(scorers) == 0 {
 			cr.Pass = false
 		}
 


### PR DESCRIPTION
Makes an external benchmark a **data source** rather than a harness. `Adapter.Load` yields
`[]SuiteCase`; adding LoCoMo / BFCL / tau-bench must not touch the Runner, the scorers, or `Suite`.

Closes #1015. Refs #1014 (the LongMemEval corpus loader slots in behind this), #1060, #1052.

## The evidence was already in the tree

`longmemeval/live_test.go` hand-rolled its own copy of `Suite.Run`: loop cases, run each, apply
scorers, tally pass/fail. It existed because `Suite` could not take what `MemCase` needed. It is now
the harness call it should always have been, 40 lines shorter.

## What `Suite` could not do

| Before | What an external suite needs |
|---|---|
| `Scorers []Scorer`, one list for all cases | Per-case ground truth. A shared list can only express properties true of every case ("did not error"), never the answers that make a benchmark a benchmark. |
| `Cases []Case`, single-turn | Multi-turn scenarios |
| One shared `Config` | Per-case config: a compaction case must run under a `Compactor`, which needs the provider to build |

`SuiteCase.Scorers` takes the provider because a rubric scorer needs a model to grade with, and the
suite owns the provider.

## `Scenario.History`: seeded, not run

A memory benchmark supplies a long prior conversation and asks one question about it. Replaying that
as `Turns` would call the model once per historical message and grade its own invented replies rather
than the dataset's. History is conversation the agent is *told* it had; Turns are turns the agent
*takes*. It is copied rather than aliased, so a scenario graded across several memory backends does
not accumulate turns into the caller's slice.

## One mechanism, not two

`Suite` unifies on `[]SuiteCase` rather than growing a parallel scenario path, with `Single()` for the
table-driven shape. `Suite` had exactly one consumer in the whole tree, so reshaping cost one test
file, and after #1290 the agent track is unreleased so breaking it is free.

## A bug my own test caught

The abstention smoke case is graded by a `Rubric`; its only deterministic scorer is a `MustNot` that
**any** answer satisfies. Under `eval_llm` the judge covers it. But the adapter is untagged and
`live_test.go` never was, so this reached the default build for the first time here, where it passed
against a stub answering `"stub answer"`.

`Suite.Run` already failed a case with no scorers, on the reasoning that a case nothing grades passes
forever. This is the same reasoning one step in: a case graded only by checks that cannot fail is not
graded. `appendRubric` now yields the new `eval.Ungradeable` without the tag, so the case fails
legibly and names the tag that would grade it.

## Aggregation stays single-axis, deliberately

`SuiteReport.Passed/Failed` counts whole cases. That is right for one-question-per-case and wrong for
a suite reporting several independent rates: a security suite wants utility and attack-success
counted separately, with one of them inverted.

Not designed for now, per the call made before starting. Per-scorer verdicts keep their names on each
`CaseReport`, so a per-dimension rollup is an addition over data already there rather than a re-plumb.
#1060 is what will actually stress it, and reshaping is free while the track is unreleased. The
reasoning is recorded on `SuiteReport` and in `agent/NOTES.md`.

## Reviewer's guide

- `eval/adapter.go` is the new contract. `SuitePath` keeps three outcomes distinct: configured and
  present, not configured, and configured-but-wrong. The third is an error, because an operator who
  set the variable meant to run the suite and a typo would otherwise show up as a suite that
  mysteriously never runs.
- `eval/suite.go` is the reshape. `String()` is untouched.
- `longmemeval/cases.go` gains `SuiteCase()` and `SmokeAdapter` — the whole of what an adapter does.
- `rubric.go` / `rubric_llm.go` split the judge by build tag, mirroring how `judge.go` already is.

## Verification

```
make test-agent                    # 15 packages, all ok
go vet -tags eval_llm ./...        # the tagged build still compiles
make vet                           # clean
scripts/verify-submodule-deps.sh   # PASS
scripts/check-no-binaries.sh       # clean
```

`TestSuiteCaseConfigureIsPerCase` observes the handed-in config through `Configure` rather than
through `Result`, because `Result.Case` carries only the turn's name and input, so asserting there
would compare two zero values and pass either way. **Verified by mutation**: hoisting `cfg` out of the
loop in `Suite.Run` makes it fail with `MaxSteps = 7, want the suite's 3`.

`gofmt -l` flags `eval_test.go`, `judge.go`, and `scenario_test.go`. All three are already unformatted
on `main`; left alone rather than adding noise to this diff.
