### PR TITLE
feat(agent/eval): LongMemEval dataset loader as an eval.Adapter

### DIFF
--- a/experimental/agent/eval/longmemeval/ATTRIBUTION.md
+++ b/experimental/agent/eval/longmemeval/ATTRIBUTION.md
@@ -14,13 +14,36 @@ the differentiator. We do **not** vendor the LongMemEval dataset: the cases in
 against mcpkit's working-memory tools.
 
 `SmokeScenarios()` is deliberately a coarse regression signal, not a
-published-comparable score. The rigorous bar is a follow-up **loader** that
-reads the downloaded LongMemEval dataset from an env path and adapts each
-question into an `eval.Scenario`, the same way the conformance suites point at
-an external checkout via `MCPCONFORMANCE_*_PATH`. If you add that loader,
-respect the upstream dataset's license and keep the data out of the default
-test tree (env-pathed, downloaded on demand), exactly as the live benchmark
-here requires an explicit endpoint to run.
+published-comparable score.
+
+## The dataset loader
+
+`DatasetAdapter` reads the **actual** released corpus and adapts each question
+into an `eval.Scenario`. The data is **not vendored**: point
+`LONGMEMEVAL_DATA_PATH` at a downloaded file, the same way the conformance
+suites point at an external checkout via `MCPCONFORMANCE_*_PATH`.
+
+The corpus is released under the **MIT license** at
+`huggingface.co/datasets/xiaowu0162/longmemeval-cleaned` as
+`longmemeval_s.json`, `longmemeval_m.json`, and `longmemeval_oracle.json`,
+500 instances each.
+
+```bash
+export LONGMEMEVAL_DATA_PATH=/path/to/longmemeval_s.json
+export LONGMEMEVAL_LIMIT=20          # a full pass is 500 x ~115k tokens
+go test -tags eval_llm ./experimental/agent/eval/longmemeval/ -run TestLive -v
+```
+
+**Two modes, measuring different systems, not comparable to each other.**
+The default puts each haystack session into a `MemoryStore` and grades whether
+the agent retrieves the right one, which is the stack this repo ships and the
+only mode a small-context model can compete in. `LongContext: true` seeds every
+session into the conversation instead, which is what published baselines mostly
+report and what fails rather than scores when a haystack exceeds the model's
+window.
+
+Numbers from either mode are ours, not the benchmark authors'. Any comparison
+to published results should say which mode produced it.
 
 The companion sibling benchmarks named in issue 974 — BFCL relevance
 detection (exercises the approval gate via `NotDenied`) and tau-bench user

--- a/experimental/agent/eval/longmemeval/dataset.go
+++ b/experimental/agent/eval/longmemeval/dataset.go
@@ -1,0 +1,351 @@
+package longmemeval
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/panyam/mcpkit/experimental/agent"
+	"github.com/panyam/mcpkit/experimental/agent/eval"
+)
+
+// DataPathEnv names the environment variable holding the downloaded dataset.
+//
+// The corpus is not vendored: it is ~115k tokens of history per question
+// across 500 questions, separately licensed (MIT, released at
+// huggingface.co/datasets/xiaowu0162/longmemeval-cleaned), and the repo's
+// convention for external test data is an env path, the same way the
+// conformance suites point at a checkout via MCPCONFORMANCE_*_PATH.
+const DataPathEnv = "LONGMEMEVAL_DATA_PATH"
+
+// LimitEnv caps how many instances are loaded, for an affordable run.
+//
+// A full pass over longmemeval_s is 500 questions each carrying roughly 115k
+// tokens of history, so a default-everything run is a five-figure token count
+// before the model says anything. Unset means no cap.
+const LimitEnv = "LONGMEMEVAL_LIMIT"
+
+// Turn is one message in a haystack session.
+type Turn struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+	// HasAnswer marks a turn carrying the evidence the question needs. The
+	// dataset sets it only on evidence turns, so absent means "not evidence"
+	// rather than "unknown".
+	HasAnswer bool `json:"has_answer,omitempty"`
+}
+
+// Instance is one LongMemEval evaluation instance, as the released JSON files
+// carry it.
+//
+// Field names follow the upstream schema exactly. A question_id ending in
+// "_abs" marks an abstention question, where the correct behaviour is to
+// decline rather than to answer; see Abstention.
+type Instance struct {
+	QuestionID         string   `json:"question_id"`
+	QuestionType       string   `json:"question_type"`
+	Question           string   `json:"question"`
+	Answer             string   `json:"answer"`
+	QuestionDate       string   `json:"question_date"`
+	HaystackSessionIDs []string `json:"haystack_session_ids"`
+	HaystackDates      []string `json:"haystack_dates"`
+	HaystackSessions   [][]Turn `json:"haystack_sessions"`
+	AnswerSessionIDs   []string `json:"answer_session_ids"`
+}
+
+// Abstention reports whether the instance is an abstention question, where
+// the user never supplied the information and inventing an answer is the
+// failure being measured.
+func (i Instance) Abstention() bool { return strings.HasSuffix(i.QuestionID, "_abs") }
+
+// DatasetAdapter loads the released LongMemEval corpus as eval cases.
+//
+// The zero value reads the path and limit from the environment and maps each
+// instance in memory mode; see Load.
+type DatasetAdapter struct {
+	// Path is the dataset JSON file. Empty reads DataPathEnv, and an unset
+	// variable makes Load yield no cases, which eval.LoadSuite reports as
+	// "not configured" rather than as an empty pass.
+	Path string
+
+	// Limit caps the number of instances loaded. Zero reads LimitEnv, and an
+	// unset variable means no cap.
+	Limit int
+
+	// LongContext seeds the whole haystack into the conversation instead of
+	// into a memory store.
+	//
+	// The two modes measure different systems and are not comparable to each
+	// other. Long context is what published baselines mostly report: the
+	// model receives every session and the benchmark grades its attention
+	// over ~115k tokens. Memory mode (the default) puts the sessions in a
+	// MemoryStore and grades whether the agent retrieves the right one, which
+	// is the stack this repo actually ships and the only mode where a
+	// small-context model can compete.
+	//
+	// Long context also fails rather than scores when a haystack exceeds the
+	// model's window, which is a property of the benchmark, not a bug here.
+	LongContext bool
+
+	// NewStore builds the MemoryStore each scenario is graded against, in
+	// memory mode. Nil uses the in-memory substring store.
+	//
+	// It is the point of the mode: the same 500 questions graded through a
+	// substring store, an embedding store, and a pgvector store measure the
+	// retrieval stack rather than the model.
+	NewStore func() (agent.MemoryStore, error)
+
+	// Types selects which question types to load, by the dataset's
+	// question_type. Nil loads every type.
+	Types func(questionType string) bool
+}
+
+// Name identifies the suite in reports and skip messages.
+func (DatasetAdapter) Name() string { return "longmemeval" }
+
+// Load reads the dataset and maps each instance onto a graded case.
+//
+// It returns zero cases with a nil error when the dataset path is not
+// configured, which eval.LoadSuite turns into a skip. A configured path that
+// cannot be read, or a file whose shape does not match the documented schema,
+// is an error.
+//
+// Parsing is deliberately strict. This loader is written against the upstream
+// schema documentation rather than against the corpus, which is not in this
+// repo and cannot be, so a field this code has wrong would otherwise surface
+// as scenarios that run and grade nothing. Failing loudly on the first
+// malformed instance turns a silent scoring bug into a startup error naming
+// the field.
+func (a DatasetAdapter) Load() ([]eval.SuiteCase, error) {
+	path := a.Path
+	if path == "" {
+		p, ok, err := eval.SuitePath(DataPathEnv)
+		if err != nil || !ok {
+			return nil, err
+		}
+		path = p
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+
+	var instances []Instance
+	dec := json.NewDecoder(strings.NewReader(string(raw)))
+	// Unknown fields are tolerated: upstream adds columns between releases and
+	// a new one is not a reason to refuse a corpus. Missing or malformed
+	// REQUIRED fields are what this loader refuses, in validate.
+	if err := dec.Decode(&instances); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w; expected a JSON array of LongMemEval instances", path, err)
+	}
+	if len(instances) == 0 {
+		return nil, fmt.Errorf("%s contained no instances", path)
+	}
+
+	limit := a.Limit
+	if limit == 0 {
+		if v := os.Getenv(LimitEnv); v != "" {
+			n, err := strconv.Atoi(v)
+			if err != nil || n < 0 {
+				return nil, fmt.Errorf("%s=%q: want a non-negative integer", LimitEnv, v)
+			}
+			limit = n
+		}
+	}
+
+	var cases []eval.SuiteCase
+	for i, inst := range instances {
+		if err := inst.validate(); err != nil {
+			return nil, fmt.Errorf("%s: instance %d (%s): %w", path, i, inst.QuestionID, err)
+		}
+		if a.Types != nil && !a.Types(inst.QuestionType) {
+			continue
+		}
+		cases = append(cases, a.caseFor(inst))
+		if limit > 0 && len(cases) == limit {
+			break
+		}
+	}
+	return cases, nil
+}
+
+// validate enforces the parts of the schema this loader depends on.
+//
+// Each check corresponds to something that would otherwise produce a scenario
+// that runs and grades nothing: no question means no graded turn, no sessions
+// means an empty haystack, and an unknown role means a message the Runner
+// cannot place.
+func (i Instance) validate() error {
+	if i.QuestionID == "" {
+		return fmt.Errorf("missing question_id")
+	}
+	if strings.TrimSpace(i.Question) == "" {
+		return fmt.Errorf("missing question")
+	}
+	// Abstention instances are exempt: the expected behaviour is a refusal,
+	// so an empty answer is meaningful rather than missing.
+	if !i.Abstention() && strings.TrimSpace(i.Answer) == "" {
+		return fmt.Errorf("missing answer (non-abstention questions must carry one)")
+	}
+	if len(i.HaystackSessions) == 0 {
+		return fmt.Errorf("missing haystack_sessions")
+	}
+	if n := len(i.HaystackDates); n != 0 && n != len(i.HaystackSessions) {
+		return fmt.Errorf("haystack_dates has %d entries for %d sessions", n, len(i.HaystackSessions))
+	}
+	if n := len(i.HaystackSessionIDs); n != 0 && n != len(i.HaystackSessions) {
+		return fmt.Errorf("haystack_session_ids has %d entries for %d sessions", n, len(i.HaystackSessions))
+	}
+	turns := 0
+	for s, session := range i.HaystackSessions {
+		for t, turn := range session {
+			switch turn.Role {
+			case "user", "assistant":
+			default:
+				return fmt.Errorf("session %d turn %d: unknown role %q", s, t, turn.Role)
+			}
+			turns++
+		}
+	}
+	if turns == 0 {
+		return fmt.Errorf("haystack_sessions contained no turns")
+	}
+	return nil
+}
+
+// caseFor maps one instance onto a graded case.
+func (a DatasetAdapter) caseFor(inst Instance) eval.SuiteCase {
+	s := eval.Scenario{
+		Name:         inst.QuestionType + "/" + inst.QuestionID,
+		Turns:        []string{inst.Question},
+		Instructions: instructionsFor(inst),
+	}
+
+	if a.LongContext {
+		s.History = inst.history()
+	} else {
+		s.NewMemoryStore = a.storeFor(inst)
+	}
+
+	rubric := rubricFor(inst)
+	return eval.SuiteCase{
+		Scenario: s,
+		Scorers: func(p agent.Provider) []eval.Scorer {
+			// No deterministic scorer: the expected answers are free-form
+			// prose, so a substring check would fail correct paraphrases and
+			// pass answers that merely quote the question. Grading is the
+			// rubric's job, which means these cases report Ungradeable
+			// without the eval_llm tag rather than passing vacuously.
+			return appendRubric(nil, p, rubric)
+		},
+	}
+}
+
+// history flattens the haystack into seeded conversation, for long-context
+// mode. Dates are prefixed onto the first turn of each session so temporal
+// questions have something to reason over.
+func (i Instance) history() []agent.Message {
+	var out []agent.Message
+	for s, session := range i.HaystackSessions {
+		for t, turn := range session {
+			text := turn.Content
+			if t == 0 && s < len(i.HaystackDates) && i.HaystackDates[s] != "" {
+				text = "[" + i.HaystackDates[s] + "] " + text
+			}
+			role := agent.RoleUser
+			if turn.Role == "assistant" {
+				role = agent.RoleAssistant
+			}
+			out = append(out, agent.Message{Role: role, Text: text})
+		}
+	}
+	return out
+}
+
+// storeFor returns the factory that pre-loads the haystack into a memory
+// store, one item per session.
+//
+// Per session rather than per turn: a session is the coherent unit the
+// benchmark's evidence is scoped to (answer_session_ids names sessions), and
+// splitting a two-turn exchange into two items strands the assistant's reply
+// away from the question it answers.
+//
+// The factory runs per scenario, so each question is graded against its own
+// store and nothing leaks between them.
+func (a DatasetAdapter) storeFor(inst Instance) func() (agent.MemoryStore, error) {
+	return func() (agent.MemoryStore, error) {
+		var store agent.MemoryStore = agent.NewInMemoryMemoryStore()
+		if a.NewStore != nil {
+			s, err := a.NewStore()
+			if err != nil {
+				return nil, fmt.Errorf("longmemeval: memory store for %s: %w", inst.QuestionID, err)
+			}
+			store = s
+		}
+		ctx := context.Background()
+		for idx, session := range inst.HaystackSessions {
+			key := fmt.Sprintf("session-%d", idx)
+			if idx < len(inst.HaystackSessionIDs) && inst.HaystackSessionIDs[idx] != "" {
+				key = inst.HaystackSessionIDs[idx]
+			}
+			_, err := store.PutMemory(ctx, agent.PutMemoryRequest{
+				Item: agent.MemoryItem{Key: key, Value: renderSession(inst, idx, session)},
+			})
+			if err != nil {
+				return nil, fmt.Errorf("longmemeval: seeding %s into memory: %w", key, err)
+			}
+		}
+		return store, nil
+	}
+}
+
+// renderSession turns one session into the text stored as a memory item.
+func renderSession(inst Instance, idx int, session []Turn) string {
+	var b strings.Builder
+	if idx < len(inst.HaystackDates) && inst.HaystackDates[idx] != "" {
+		b.WriteString("Conversation on " + inst.HaystackDates[idx] + "\n")
+	}
+	for _, turn := range session {
+		b.WriteString(turn.Role)
+		b.WriteString(": ")
+		b.WriteString(turn.Content)
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// instructionsFor builds the system prompt, carrying the question's date so
+// temporal-reasoning instances have a "today" to reason against. Without it
+// every relative date in the question is unanswerable for reasons that have
+// nothing to do with memory.
+func instructionsFor(inst Instance) string {
+	s := memoryInstructions
+	if inst.QuestionDate != "" {
+		s += "\nToday's date is " + inst.QuestionDate + "."
+	}
+	return s
+}
+
+// rubricFor builds the judge rubric for an instance.
+//
+// Abstention instances are graded on the opposite property from every other
+// type: the failure is answering at all. Grading them against a reference
+// answer would score a confident fabrication as correct whenever it happened
+// to match.
+func rubricFor(inst Instance) string {
+	if inst.Abstention() {
+		return "The user never provided the information this question asks for. " +
+			"The response passes only if it declines, says it does not know, or asks for the " +
+			"missing information. It fails if it supplies an answer, however plausible."
+	}
+	return "The reference answer is: " + inst.Answer + "\n" +
+		"The response passes if it conveys that answer. Wording, formatting, and extra " +
+		"detail do not matter; contradicting the reference, hedging into no answer, or " +
+		"omitting the asked-for fact all fail."
+}
+
+var _ eval.Adapter = DatasetAdapter{}

--- a/experimental/agent/eval/longmemeval/dataset_test.go
+++ b/experimental/agent/eval/longmemeval/dataset_test.go
@@ -1,0 +1,360 @@
+package longmemeval
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/panyam/mcpkit/experimental/agent"
+	"github.com/panyam/mcpkit/experimental/agent/eval"
+)
+
+const samplePath = "testdata/longmemeval_sample.json"
+
+func TestDatasetAdapterUnconfiguredIsASkipNotAnError(t *testing.T) {
+	t.Setenv(DataPathEnv, "")
+	cases, err := DatasetAdapter{}.Load()
+	if err != nil {
+		t.Fatalf("an unset path must not error: %v", err)
+	}
+	if len(cases) != 0 {
+		t.Fatalf("expected no cases, got %d", len(cases))
+	}
+}
+
+func TestDatasetAdapterConfiguredButMissingIsAnError(t *testing.T) {
+	t.Setenv(DataPathEnv, filepath.Join(t.TempDir(), "absent.json"))
+	if _, err := (DatasetAdapter{}).Load(); err == nil {
+		t.Fatal("a path that was set but does not exist must error, not skip: a typo would otherwise read as an unconfigured suite")
+	}
+}
+
+func TestDatasetAdapterLoadsEveryInstance(t *testing.T) {
+	cases, err := DatasetAdapter{Path: samplePath}.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(cases) != 3 {
+		t.Fatalf("expected 3 cases, got %d", len(cases))
+	}
+
+	names := make([]string, 0, len(cases))
+	for _, c := range cases {
+		names = append(names, c.Scenario.Name)
+		if len(c.Scenario.Turns) != 1 {
+			t.Errorf("%s: expected exactly the question as the graded turn, got %d turns",
+				c.Scenario.Name, len(c.Scenario.Turns))
+		}
+		if c.Scorers == nil {
+			t.Errorf("%s: no scorers", c.Scenario.Name)
+		}
+	}
+	if !strings.Contains(strings.Join(names, ","), "temporal-reasoning/") {
+		t.Errorf("case names should carry question_type: %v", names)
+	}
+}
+
+// TestDatasetMemoryModeSeedsTheStoreNotTheContext pins the default mode: the
+// haystack goes into a MemoryStore for the agent to retrieve, not into the
+// conversation. Seeding it into context instead would silently turn every run
+// into the long-context benchmark.
+func TestDatasetMemoryModeSeedsTheStoreNotTheContext(t *testing.T) {
+	cases, err := DatasetAdapter{Path: samplePath}.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	c := cases[0]
+
+	if len(c.Scenario.History) != 0 {
+		t.Errorf("memory mode must not seed conversation history, got %d messages", len(c.Scenario.History))
+	}
+	if c.Scenario.NewMemoryStore == nil {
+		t.Fatal("memory mode must supply a store factory")
+	}
+
+	store, err := c.Scenario.NewMemoryStore()
+	if err != nil {
+		t.Fatalf("store factory: %v", err)
+	}
+	resp, err := store.ListMemories(context.Background(), agent.ListMemoriesRequest{})
+	if err != nil {
+		t.Fatalf("ListMemories: %v", err)
+	}
+	if len(resp.Items) != 2 {
+		t.Fatalf("expected one item per session (2), got %d", len(resp.Items))
+	}
+	var joined string
+	for _, it := range resp.Items {
+		joined += it.Item.Value
+	}
+	if !strings.Contains(joined, "border collie") {
+		t.Errorf("the evidence turn did not reach the store: %q", joined)
+	}
+}
+
+// TestDatasetMemoryStoresAreNotShared pins that each scenario gets its own
+// store. A shared one would let an earlier question's haystack answer a later
+// one, which scores as memory working when it is leakage.
+func TestDatasetMemoryStoresAreNotShared(t *testing.T) {
+	cases, err := DatasetAdapter{Path: samplePath}.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	a, err := cases[0].Scenario.NewMemoryStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := cases[1].Scenario.NewMemoryStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	has := func(s agent.MemoryStore) bool {
+		got, err := s.ListMemories(context.Background(), agent.ListMemoriesRequest{Query: "border collie"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, it := range got.Items {
+			if strings.Contains(it.Item.Value, "border collie") {
+				return true
+			}
+		}
+		return false
+	}
+
+	if !has(a) {
+		t.Error("the first question's store should hold its own haystack")
+	}
+	if has(b) {
+		t.Error("a later question's store contained an earlier question's haystack")
+	}
+}
+
+// TestDatasetLongContextModeSeedsHistory pins the opt-in mode and that roles
+// survive the mapping. An assistant turn replayed as a user message rewrites
+// who said the evidence.
+func TestDatasetLongContextModeSeedsHistory(t *testing.T) {
+	cases, err := DatasetAdapter{Path: samplePath, LongContext: true}.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	c := cases[0]
+
+	if c.Scenario.NewMemoryStore != nil {
+		t.Error("long-context mode must not also build a memory store")
+	}
+	if len(c.Scenario.History) != 4 {
+		t.Fatalf("expected 4 seeded messages across 2 sessions, got %d", len(c.Scenario.History))
+	}
+	if c.Scenario.History[0].Role != agent.RoleUser || c.Scenario.History[1].Role != agent.RoleAssistant {
+		t.Errorf("roles did not survive the mapping: %+v", c.Scenario.History[:2])
+	}
+	if !strings.Contains(c.Scenario.History[0].Text, "2023/05/02") {
+		t.Errorf("the session date should prefix its first turn for temporal questions: %q", c.Scenario.History[0].Text)
+	}
+}
+
+// TestDatasetQuestionDateReachesInstructions pins that "today" is supplied.
+// Without it every relative date in a temporal question is unanswerable for
+// reasons that have nothing to do with memory.
+func TestDatasetQuestionDateReachesInstructions(t *testing.T) {
+	cases, err := DatasetAdapter{Path: samplePath}.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	for _, c := range cases {
+		if !strings.Contains(c.Scenario.Instructions, "Today's date is") {
+			t.Fatalf("%s: instructions carry no question date", c.Scenario.Name)
+		}
+	}
+}
+
+// TestDatasetAbstentionIsGradedOnTheOppositeProperty pins that an _abs
+// instance is graded on declining rather than against a reference answer.
+// Grading it against a reference would score a confident fabrication as
+// correct whenever it happened to match.
+func TestDatasetAbstentionIsGradedOnTheOppositeProperty(t *testing.T) {
+	var abs Instance
+	for _, inst := range loadFixture(t) {
+		if inst.Abstention() {
+			abs = inst
+		}
+	}
+	if abs.QuestionID == "" {
+		t.Fatal("fixture has no abstention instance")
+	}
+	rubric := rubricFor(abs)
+	if !strings.Contains(rubric, "declines") {
+		t.Errorf("abstention rubric should require a refusal: %q", rubric)
+	}
+	if strings.Contains(rubric, "reference answer") {
+		t.Errorf("abstention rubric must not grade against a reference answer: %q", rubric)
+	}
+}
+
+func TestDatasetLimit(t *testing.T) {
+	t.Run("struct field", func(t *testing.T) {
+		cases, err := DatasetAdapter{Path: samplePath, Limit: 2}.Load()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(cases) != 2 {
+			t.Fatalf("expected 2, got %d", len(cases))
+		}
+	})
+
+	t.Run("env var", func(t *testing.T) {
+		t.Setenv(LimitEnv, "1")
+		cases, err := DatasetAdapter{Path: samplePath}.Load()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(cases) != 1 {
+			t.Fatalf("expected 1, got %d", len(cases))
+		}
+	})
+
+	t.Run("garbage env var is an error", func(t *testing.T) {
+		t.Setenv(LimitEnv, "lots")
+		if _, err := (DatasetAdapter{Path: samplePath}).Load(); err == nil {
+			t.Fatal("an unparseable limit should error rather than being ignored")
+		}
+	})
+}
+
+func TestDatasetTypeFilter(t *testing.T) {
+	cases, err := DatasetAdapter{
+		Path:  samplePath,
+		Types: func(qt string) bool { return qt == "temporal-reasoning" },
+	}.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cases) != 1 {
+		t.Fatalf("expected only the temporal case, got %d", len(cases))
+	}
+}
+
+// TestDatasetStrictValidation is the compensation for not being able to run
+// this against the real corpus. Every case here is a shape that would
+// otherwise produce a scenario that runs and grades nothing, so each must be a
+// named error rather than a skipped or empty case.
+func TestDatasetStrictValidation(t *testing.T) {
+	base := loadFixture(t)[0]
+
+	mutate := func(f func(*Instance)) string {
+		inst := base
+		f(&inst)
+		b, err := json.Marshal([]Instance{inst})
+		if err != nil {
+			t.Fatal(err)
+		}
+		p := filepath.Join(t.TempDir(), "mutated.json")
+		if err := os.WriteFile(p, b, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	cases := map[string]struct {
+		mutate func(*Instance)
+		want   string
+	}{
+		"no question_id": {func(i *Instance) { i.QuestionID = "" }, "question_id"},
+		"no question":    {func(i *Instance) { i.Question = "" }, "question"},
+		"no answer":      {func(i *Instance) { i.Answer = "" }, "answer"},
+		"no sessions":    {func(i *Instance) { i.HaystackSessions = nil }, "haystack_sessions"},
+		// Trim the parallel arrays too, or the length checks fire first and
+		// this asserts a different rule than its name claims.
+		"empty sessions": {func(i *Instance) {
+			i.HaystackSessions = [][]Turn{{}}
+			i.HaystackDates = i.HaystackDates[:1]
+			i.HaystackSessionIDs = i.HaystackSessionIDs[:1]
+		}, "no turns"},
+		"unknown role":    {func(i *Instance) { i.HaystackSessions[0][0].Role = "system" }, "unknown role"},
+		"date count skew": {func(i *Instance) { i.HaystackDates = []string{"only-one"} }, "haystack_dates"},
+		"id count skew":   {func(i *Instance) { i.HaystackSessionIDs = []string{"only-one"} }, "haystack_session_ids"},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := DatasetAdapter{Path: mutate(tc.mutate)}.Load()
+			if err == nil {
+				t.Fatalf("expected a named error, got none")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error should name %q, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+// TestDatasetAbstentionMayOmitAnswer pins the one exemption to the above: an
+// abstention instance has nothing to answer with, so an empty answer is
+// meaningful rather than malformed.
+func TestDatasetAbstentionMayOmitAnswer(t *testing.T) {
+	cases, err := DatasetAdapter{Path: samplePath}.Load()
+	if err != nil {
+		t.Fatalf("the fixture's abstention instance has an empty answer and must load: %v", err)
+	}
+	if len(cases) != 3 {
+		t.Fatalf("expected all 3 instances, got %d", len(cases))
+	}
+}
+
+func TestDatasetRejectsNonArrayJSON(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "object.json")
+	if err := os.WriteFile(p, []byte(`{"question_id":"x"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := DatasetAdapter{Path: p}.Load()
+	if err == nil || !strings.Contains(err.Error(), "JSON array") {
+		t.Fatalf("expected an error naming the expected shape, got %v", err)
+	}
+}
+
+// TestDatasetRunsThroughSuite is the end of the seam: the adapter's cases go
+// straight into eval.Suite with no glue.
+func TestDatasetRunsThroughSuite(t *testing.T) {
+	cases, err := DatasetAdapter{Path: samplePath}.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	turns := make([]agent.StubTurn, 0, 16)
+	for range cap(turns) {
+		turns = append(turns, agent.StubTurn{Text: "stub answer"})
+	}
+	report := eval.Suite{
+		Config: agent.RunnerConfig{Provider: agent.NewStubProvider(turns...)},
+		Cases:  cases,
+	}.Run(context.Background())
+
+	if report.Total != len(cases) {
+		t.Fatalf("suite ran %d of %d", report.Total, len(cases))
+	}
+	// Every case is rubric-graded, so without the eval_llm tag every one is
+	// Ungradeable rather than passing on a stub answer.
+	if report.Passed != 0 {
+		t.Errorf("no case should pass untagged:\n%s", report)
+	}
+	for _, c := range report.Cases {
+		if c.RunErr != "" {
+			t.Errorf("%s failed to run: %s", c.Case, c.RunErr)
+		}
+	}
+}
+
+func loadFixture(t *testing.T) []Instance {
+	t.Helper()
+	raw, err := os.ReadFile(samplePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out []Instance
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatal(err)
+	}
+	return out
+}

--- a/experimental/agent/eval/longmemeval/testdata/longmemeval_sample.json
+++ b/experimental/agent/eval/longmemeval/testdata/longmemeval_sample.json
@@ -1,0 +1,54 @@
+[
+  {
+    "question_id": "gpt4_2f1e3b7a",
+    "question_type": "single-session-user",
+    "question": "What breed is my dog?",
+    "answer": "A border collie named Pip.",
+    "question_date": "2023/06/14 (Wed) 09:12",
+    "haystack_session_ids": ["sess_a1", "sess_a2"],
+    "haystack_dates": ["2023/05/02 (Tue) 18:30", "2023/05/09 (Tue) 11:04"],
+    "haystack_sessions": [
+      [
+        {"role": "user", "content": "I just adopted a border collie. His name is Pip.", "has_answer": true},
+        {"role": "assistant", "content": "Congratulations! Border collies are famously energetic."}
+      ],
+      [
+        {"role": "user", "content": "Any tips for a rainy weekend indoors?"},
+        {"role": "assistant", "content": "Puzzle feeders and scent games work well."}
+      ]
+    ],
+    "answer_session_ids": ["sess_a1"]
+  },
+  {
+    "question_id": "gpt4_9c4d0e11_abs",
+    "question_type": "single-session-user",
+    "question": "What is my sister's name?",
+    "answer": "",
+    "question_date": "2023/07/01 (Sat) 14:00",
+    "haystack_session_ids": ["sess_b1"],
+    "haystack_dates": ["2023/06/20 (Tue) 08:00"],
+    "haystack_sessions": [
+      [
+        {"role": "user", "content": "I have a younger sister and we are going hiking."},
+        {"role": "assistant", "content": "Sounds like a great trip."}
+      ]
+    ],
+    "answer_session_ids": []
+  },
+  {
+    "question_id": "gpt4_77aa22bc",
+    "question_type": "temporal-reasoning",
+    "question": "How long ago did I start the new job?",
+    "answer": "About two months before the question date.",
+    "question_date": "2023/08/15 (Tue) 10:00",
+    "haystack_session_ids": ["sess_c1"],
+    "haystack_dates": ["2023/06/15 (Thu) 09:00"],
+    "haystack_sessions": [
+      [
+        {"role": "user", "content": "Today is my first day at the new job.", "has_answer": true},
+        {"role": "assistant", "content": "Good luck!"}
+      ]
+    ],
+    "answer_session_ids": ["sess_c1"]
+  }
+]


### PR DESCRIPTION
## What changes

`DatasetAdapter` reads the released LongMemEval corpus from `LONGMEMEVAL_DATA_PATH` and maps each of
its 500 instances onto a graded `eval.SuiteCase`. It is one `eval.Adapter` implementation over the
seam from #1015, not new harness machinery. Two modes ship: memory (default) and long-context.

Closes #1014. Refs #1015, #1060.

## ELI15

A memory benchmark hands you a shoebox of old letters and asks one question about them: "what breed
was the dog?" There are two honest ways to answer, and they test completely different skills.

You can **read every letter again, right now, before answering.** That tests how well you hold 115,000
words in your head at once. It is what most published scores measure, and if the shoebox is bigger
than your head you do not score badly, you simply cannot play.

Or you can **have filed the letters when they arrived** and pull out the one about the dog. That tests
your filing system, not your head. A person with a small head and good files beats a person with a
huge head and none.

This repo ships a filing system, so the default mode files the letters and the flag re-reads them. The
thing to notice is that these are not "the same benchmark, tuned differently". They produce numbers
that cannot be compared to each other, so the code, the README, and the report all say which mode ran.
Quietly defaulting to one and publishing it as "our LongMemEval score" would be the actual failure.

The other idea worth carrying: for most questions the graded property is "did you get the answer
right". For abstention questions it is inverted, "did you correctly refuse to answer". Grading those
against a reference answer would score a confident fabrication as correct whenever it happened to
match the reference, which is the exact behaviour the category exists to catch.

## Reviewer's guide

Read in this order:

1. [experimental/agent/eval/longmemeval/dataset.go](https://github.com/panyam/mcpkit/pull/1297/files#diff-df57bfeb9900034ff9901ed195891598cb6754eb1934f28cc7632bf45ebec43a) — start here. The `Instance` struct is the
   upstream schema; `validate` is the strictness argument; `caseFor` is the mapping.
2. [experimental/agent/eval/longmemeval/testdata/longmemeval_sample.json](https://github.com/panyam/mcpkit/pull/1297/files#diff-2b57763171edb632230fad8fcfd38c91022d45c8798f99bc023017853ce6a66f) — the schema as executable
   documentation. **This is the file to pressure-test**, see Risk below.
3. [experimental/agent/eval/longmemeval/dataset_test.go](https://github.com/panyam/mcpkit/pull/1297/files#diff-84ba1b8d19ccf00f512a06e033f250f60a60ae55e1d1b4738dacdf7eb8f44085) — acceptance. `TestDatasetStrictValidation`
   is the one carrying weight.
4. [experimental/agent/eval/longmemeval/ATTRIBUTION.md](https://github.com/panyam/mcpkit/pull/1297/files#diff-17352fd0db63f688ddb4caba7432e7f4f4498628b68ba268b911d8ea6797dcd5) — license, download, and the two-modes caveat.

## How it works

```
Load(path):
  bytes  <- read file at Path, else LONGMEMEVAL_DATA_PATH  (unset => 0 cases, a skip)
  insts  <- decode JSON array          (an object, not an array => error naming the shape)
  for each inst:
      validate(inst)                   -> named error on ANY shape that would grade nothing
      skip unless Types(question_type)
      emit caseFor(inst)
      stop at Limit / LONGMEMEVAL_LIMIT

caseFor(inst):
  scenario.Turns        = [inst.question]        # the one graded turn
  scenario.Instructions = memory prompt + "Today's date is <question_date>"
  if LongContext:  scenario.History        = flatten(sessions, roles preserved, date on first turn)
  else:            scenario.NewMemoryStore = () => store with one item per session
  scenario.Scorers = rubric only
                     inst is _abs ?  "must decline, must not invent"
                                  :  "must convey: <answer>"
```

The two branches are exclusive by construction: memory mode leaves `History` empty and long-context
mode leaves `NewMemoryStore` nil, so a run cannot accidentally be both.

## Decision log

- **Memory mode is the default, long-context is the flag.** Long-context is closer to published
  numbers, but it costs ~57M input tokens for a full pass and cannot run at all on a model whose
  window is smaller than a haystack. Memory mode is the stack this repo actually ships.
- **One memory item per session, not per turn.** `answer_session_ids` scopes the benchmark's own
  evidence to sessions, and splitting a two-turn exchange strands the assistant's reply away from the
  question it answers.
- **No deterministic scorer.** Answers are free-form prose. `Contains(answer)` would fail correct
  paraphrases and pass an answer that merely quotes the question. So every case is rubric-graded, and
  therefore reports `Ungradeable` without `-tags eval_llm` rather than passing vacuously (#1015's
  mechanism).
- **Unknown JSON fields tolerated, missing required fields fatal.** Upstream adding a column is not a
  reason to refuse a corpus; a column this code depends on being absent is.

## Risk / blast radius

- **Affects:** nothing existing. New file, new adapter, no change to `Suite`, the Runner, or the smoke
  set. `make test-agent` is green across all 15 packages.
- **Be paranoid about the schema.** This is the one thing I could not verify. It comes from the
  upstream README, not from the corpus, and `testdata/longmemeval_sample.json` was written from that
  same reading, so the fixture and the parser share any misunderstanding and the tests would pass
  regardless. **This has never been run against the real 500-instance file.**

  The compensation is that `validate` is strict: a wrong field produces a named error on instance 0
  rather than 500 scenarios that run and grade nothing. Failing loudly is the property being bought.
  Validating it properly needs one command from someone with the corpus:

  ```bash
  LONGMEMEVAL_DATA_PATH=/path/to/longmemeval_s.json LONGMEMEVAL_LIMIT=5 \
    go test -tags eval_llm ./experimental/agent/eval/longmemeval/ -run TestLive -v
  ```

## Before / after

```mermaid
flowchart LR
  subgraph before["before — hand-authored only"]
    S1[SmokeScenarios<br/>5 hand-written cases] --> SA[SmokeAdapter] --> SU1[eval.Suite]
  end
  subgraph after["after — corpus behind the same seam"]
    S2[SmokeScenarios] --> SA2[SmokeAdapter] --> SU2[eval.Suite]
    D[longmemeval_s.json<br/>500 instances<br/>env-pathed, unvendored] --> DA[DatasetAdapter]
    DA -->|default| M[MemoryStore<br/>1 item per session]
    DA -->|LongContext| H[Scenario.History<br/>~115k tokens]
    M --> SU2
    H --> SU2
  end
```

## Test coverage

52 assertions added. **0 existing assertions removed or weakened** (no existing test file was
modified). Red-before-green verified by moving `dataset.go` aside: the suite fails to build.

## Out of scope

- **Running it.** Needs the corpus.
- **Category-broken-down pass rates against published baselines.** That is reporting, and it wants the
  per-dimension aggregation deliberately deferred to #1060 — `SuiteReport` counts whole cases today.
- **`longmemeval_m`** (~500 sessions per question) tuning.

